### PR TITLE
Fix gemm profiler cache/dummy profiling

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,9 @@
+## Disable profilers
+
+When you need fast iteration or using unsupported platform.
+
+```python
+import os
+os.environ["DISABLE_PROFILER_CODEGEN"] = "1"
+os.environ["CI_FLAG"] = "CIRCLECI"
+```

--- a/src/honey/compiler/ops/gemm_universal/gemm_common.py
+++ b/src/honey/compiler/ops/gemm_universal/gemm_common.py
@@ -426,9 +426,9 @@ class gemm(Operator):
         relevant attributes with the cached result and return False.
         """
         # We are forced to use the cache, so we skip building profilers.
-        if environ.force_profiler_cache():
-            return False
         target = backend.target.Target.current()
+        if environ.force_profiler_cache() or target.use_dummy_profiling_results():
+            return False
 
         build_profiler = True
         # Now, let's query if all of our workloads have cache entries. If that


### PR DESCRIPTION
We can use dummy profiling when you need fast iteration or using unsupported platform. Mainly useful for testing graph or workspace related things, for example I used this when tracking #15 