### PR TITLE
Fix excessive workspace blob - Disable `fuse_single_source_parallel_gemms`

### DIFF
--- a/src/honey/compiler/transform/memory_planning.py
+++ b/src/honey/compiler/transform/memory_planning.py
@@ -129,27 +129,6 @@ def _make_tensor_usage_records(sorted_ops: List[Operator]) -> List[TensorUsageRe
     for name in tensor_views:
         del tensor_records[name]
 
-    # remove duplicates
-    # Cast causes unneeded extra tensor records
-    last_dst_ops = StableSet()
-    last_op_name = ""
-    for key, record in list(tensor_records.items()):
-        if isinstance(record.tensor.dst_ops(), set):
-            if (
-                StableSet(list(record.tensor.dst_ops())) == last_dst_ops
-                and "cast" in last_op_name
-            ):
-                tensor_records.pop(key)
-            else:
-                last_dst_ops = StableSet(list(record.tensor.dst_ops()))
-                last_op_name = record.tensor._attrs["name"]
-        else:
-            if record.tensor.dst_ops() == last_dst_ops and "cast" in last_op_name:
-                tensor_records.pop(key)
-            else:
-                last_dst_ops = record.tensor.dst_ops()
-                last_op_name = record.tensor._attrs["name"]
-
     # sanity checks
     # make sure we have valid indices and sizes
     records = tensor_records.values()

--- a/src/honey/compiler/transform/optimize_graph.py
+++ b/src/honey/compiler/transform/optimize_graph.py
@@ -107,7 +107,8 @@ def optimize_graph(
         fuse_expand_bmm,
         transform_odd_alignment,
         fuse_conv_elementwise,
-        fuse_single_source_parallel_gemms,
+        # TODO: investigate - Disabled as causes blob to blow up
+        # fuse_single_source_parallel_gemms,
         fuse_mm_elementwise,
         fuse_mm_reshape_permute,
         # make sure we run move_view_op_before_concat before transform_memory_ops


### PR DESCRIPTION
Important fix. In some models workspace was excessive, for example, T5 workspace was ~6GB, with `fuse_single_source_parallel_gemms` disabled it is ~170MB!!

`fuse_single_source_parallel_gemms` was fusing gemms and in turn concatenating weights - which uses an excessively large workspace.