### PR TITLE
Update gelu_new and finalize T5EncoderModel

### DIFF
--- a/csrc/include/dinoml/device.h
+++ b/csrc/include/dinoml/device.h
@@ -18,10 +18,12 @@ namespace dinoml {
 #ifdef DINOML_CUDA
 using bfloat16 = __nv_bfloat16;
 using DeviceStream = cudaStream_t;
+#define LDG(x) __ldg(x)
 #endif
 #ifdef DINOML_HIP
 using bfloat16 = hip_bfloat16;
 using DeviceStream = hipStream_t;
+#define LDG(x) *(x)
 #endif
 
 inline uint64_t make_seed() {

--- a/csrc/include/ops/activations.h
+++ b/csrc/include/ops/activations.h
@@ -1,0 +1,43 @@
+#pragma once
+#include <math.h>
+#include <algorithm>
+#include <cstdint>
+
+#include "dinoml/device.h"
+
+namespace dinoml {
+
+template <typename T>
+__device__ __forceinline__ T gelu_new(const T& x) {
+  const float x3 = (float)(x * x * x);
+  const T t = (T)tanhf((T)(0.79788456f * (float)(x + (T)(0.044715f * x3))));
+  return ((T)0.5) * x * (((T)1.0) + t);
+}
+
+template <typename T>
+__global__ void gelu_new_kernel(
+    T* __restrict__ out,
+    const T* __restrict__ in,
+    const int last_dim) {
+  const int64_t block_idx = blockIdx.x;
+  for (int64_t idx = threadIdx.x; idx < last_dim; idx += blockDim.x) {
+    const T x = LDG(&in[block_idx * last_dim + idx]);
+    out[block_idx * last_dim + idx] = gelu_new<T>(x);
+  }
+}
+
+} // namespace dinoml
+
+template <typename T>
+void invoke_gelu_new(
+    void* out,
+    const void* in,
+    int64_t n,
+    int last_dim,
+    dinoml::DeviceStream stream) {
+  int64_t blocks = n / last_dim;
+  int64_t threads = std::min(last_dim, 1024);
+
+  dinoml::gelu_new_kernel<T><<<blocks, threads, 0, stream>>>(
+      static_cast<T*>(out), static_cast<const T*>(in), last_dim);
+}

--- a/src/dinoml/backend/cuda/tensor/gelu_new.py
+++ b/src/dinoml/backend/cuda/tensor/gelu_new.py
@@ -8,177 +8,49 @@ import jinja2
 from dinoml.compiler.base import IntImm, IntVar
 
 
-CUDA_HEADER_FILES = """
-#include <cuda_fp16.h>
-#include <cuda_runtime.h>
-#include <cuda_bf16.h>
-
-using bfloat16 = __nv_bfloat16;
-using bfloat162 = __nv_bfloat162;
-"""
-
-
-KERNEL_TEMPLATE = jinja2.Template(
+SRC_TEMPLATE = jinja2.Template(
     """
-#include <stdint.h>
+#include <dinoml/device.h>
+#include <ops/activations.h>
 
-template <typename T>
-__device__ __forceinline__ float to_float(T v) { return (float)v; }
-
-template <>
-__device__ __forceinline__ float to_float<half>(half v) {
-    return __half2float(v);
-}
-
-template <>
-__device__ __forceinline__ float to_float<bfloat16>(bfloat16 v) {
-    return __bfloat162float(v);
-}
-
-template <typename T>
-__device__ __forceinline__ T from_float(float v);
-
-template <>
-__device__ __forceinline__ float from_float<float>(float v) { return v; }
-
-template <>
-__device__ __forceinline__ half from_float<half>(float v) {
-    return __float2half(v);
-}
-
-template <>
-__device__ __forceinline__ bfloat16 from_float<bfloat16>(float v) {
-    return __float2bfloat16(v);
-}
-
-__device__ __forceinline__ float gelu_new(float x) {
-    const float kAlpha = 0.7978845608028654f; // sqrt(2/pi)
-    const float kBeta  = 0.044715f;
-    float x3 = x * x * x;
-    return 0.5f * x * (1.0f + tanhf(kAlpha * (x + kBeta * x3)));
-}
-
-template <typename T>
-__global__ void GeluNewKernel(
-    T* __restrict__ out,
-    const T* __restrict__ in,
-    int64_t n)
-{
-    int64_t idx = (int64_t)blockIdx.x * blockDim.x + threadIdx.x;
-    if (idx >= n) return;
-
-    float x = to_float<T>(in[idx]);
-    out[idx] = from_float<T>(gelu_new(x));
-}
-
-__global__ void GeluNewKernelHalf2(
-    half* __restrict__ out,
-    const half* __restrict__ in,
-    int64_t n)
-{
-    int64_t idx = (int64_t)blockIdx.x * blockDim.x + threadIdx.x;
-    int64_t i = idx * 2;
-    if (i + 1 >= n) return;
-
-    half2 x2 = reinterpret_cast<const half2*>(in)[idx];
-    float2 xf = __half22float2(x2);
-
-    xf.x = gelu_new(xf.x);
-    xf.y = gelu_new(xf.y);
-
-    reinterpret_cast<half2*>(out)[idx] =
-        __floats2half2_rn(xf.x, xf.y);
-}
-
-__global__ void GeluNewKernelBf162(
-    bfloat16* __restrict__ out,
-    const bfloat16* __restrict__ in,
-    int64_t n)
-{
-    int64_t idx = (int64_t)blockIdx.x * blockDim.x + threadIdx.x;
-    int64_t i = idx * 2;
-    if (i + 1 >= n) return;
-
-    bfloat162 x2 = reinterpret_cast<const bfloat162*>(in)[idx];
-
-    float x0 = __bfloat162float(x2.x);
-    float x1 = __bfloat162float(x2.y);
-
-    x0 = gelu_new(x0);
-    x1 = gelu_new(x1);
-
-    reinterpret_cast<bfloat162*>(out)[idx] =
-        bfloat162{__float2bfloat16(x0), __float2bfloat16(x1)};
-}
-
-template <typename T>
-void invoke_gelu_new(
-    T* out,
-    const T* in,
+void {{function_name}}(
+    void* out,
+    const void* in,
     int64_t n,
-    {{prefix}}Stream_t stream)
-{
-    if (n <= 0) return;
-
-    int threads = 256;
-
-    if constexpr (std::is_same<T, half>::value) {
-        int64_t n2 = n >> 1;
-        int blocks = (int)((n2 + threads - 1) / threads);
-        GeluNewKernelHalf2<<<blocks, threads, 0, stream>>>(out, in, n);
-    } else if constexpr (std::is_same<T, bfloat16>::value) {
-        int64_t n2 = n >> 1;
-        int blocks = (int)((n2 + threads - 1) / threads);
-        GeluNewKernelBf162<<<blocks, threads, 0, stream>>>(out, in, n);
-    } else {
-        int blocks = (int)((n + threads - 1) / threads);
-        GeluNewKernel<T><<<blocks, threads, 0, stream>>>(out, in, n);
-    }
+    int last_dim,
+    dinoml::DeviceStream stream
+) {
+    invoke_gelu_new<{{elem_output_type}}>(
+        out,
+        in,
+        n,
+        last_dim,
+        stream
+    );
 }
 """
 )
 
-
-FUNC_DECL = jinja2.Template(
-    r"""
-    {{func_signature}};
-"""
-)
-
-FUNC_SIGNATURE = jinja2.Template(
+FUNC_DECL_TEMPLATE = jinja2.Template(
     """
-void {{func_name}}(void* output,
-                   const void* input,
-                   int64_t numel,
-                   {{prefix}}Stream_t stream)
-"""
-)
-
-FUNC_TEMPLATE = jinja2.Template(
-    """
-{{header_files}}
-
-namespace {
-
-{{kernel}}
-
-}  // namespace
-
-{{func_signature}}
-{
-    invoke_gelu_new<{{elem_type}}>(
-        static_cast<{{elem_type}}*>(output),
-        static_cast<const {{elem_type}}*>(input),
-        numel,
-        stream);
-}
+void {{func_name}}(
+    void*,
+    const void*,
+    int64_t,
+    int,
+    dinoml::DeviceStream
+);
 """
 )
 
 FUNC_CALL_TEMPLATE = jinja2.Template(
     """
 {{indent}}{{func_name}}(
-{{indent}}   {{output}}, {{input}}, {{numel}}, stream
+{{indent}}    {{output}},
+{{indent}}    {{input}},
+{{indent}}    {{numel}},
+{{indent}}    {{last_dim}},
+{{indent}}    stream
 {{indent}});
 """
 )
@@ -212,40 +84,32 @@ def gen_function_call(func_attrs: Dict[str, Any], indent="  ") -> str:
         output=y._attrs["name"],
         input=x._attrs["name"],
         numel=numel,
+        last_dim=x._attrs["shape"][-1]._attrs["name"],
         indent=indent,
     )
 
 
-def gen_function(func_attrs: Dict[str, Any], header_files: str, backend_spec) -> str:
-    y = func_attrs["outputs"][0]
-    elem_type = backend_spec.dtype_to_backend_type(y._attrs["dtype"])
-
-    return FUNC_TEMPLATE.render(
-        header_files=header_files,
-        elem_type=elem_type,
-        kernel=KERNEL_TEMPLATE.render(
-            elem_type=elem_type,
-            prefix=backend_spec.prefix,
-        ),
-        func_signature=FUNC_SIGNATURE.render(
-            func_name=func_attrs["name"],
-            prefix=backend_spec.prefix,
-        ),
+def gen_function(func_attrs, template_path):
+    func_name = func_attrs["name"]
+    backend_spec = CUDASpec()
+    input_type = backend_spec.dtype_to_backend_type(
+        func_attrs["outputs"][0]._attrs["dtype"]
+    )
+    return SRC_TEMPLATE.render(
+        function_name=func_name,
+        elem_output_type=input_type,
     )
 
 
 def gen_function_decl(func_attrs: Dict[str, Any], backend_spec) -> str:
-    return FUNC_DECL.render(
-        func_signature=FUNC_SIGNATURE.render(
-            func_name=func_attrs["name"],
-            prefix=backend_spec.prefix,
-        ).strip()
+    return FUNC_DECL_TEMPLATE.render(
+        func_name=func_attrs["name"],
     )
 
 
 @registry.reg("cuda.gelu_new.gen_function")
 def cuda_gelu_new_gen_function(func_attrs):
-    return gen_function(func_attrs, CUDA_HEADER_FILES, CUDASpec())
+    return gen_function(func_attrs, CUDASpec())
 
 
 @registry.reg("cuda.gelu_new.func_decl")

--- a/src/dinoml/modeling/transformers/t5/modeling_t5.py
+++ b/src/dinoml/modeling/transformers/t5/modeling_t5.py
@@ -196,10 +196,7 @@ class T5Attention(nn.Module):
             ops.softmax()(ops.cast()(scores, "float32"), dim=-1), scores.dtype()
         )
         attn_w3 = ops.reshape()(attn_weights, [BH, S, S])
-        context3 = ops.bmm_rrr()(attn_w3, v3)
-
-        attn_output = ops.reshape()(context3, [batch_size, self.n_heads, S, D])
-        attn_output = ops.transpose()(attn_output, 1, 2)
+        attn_output = ops.bmm_rrr_permute((self.n_heads,))(attn_w3, v3)
         attn_output = ops.reshape()(attn_output, [batch_size, -1, self.inner_dim])
         attn_output = self.o(attn_output)
 

--- a/tests/unittest/ops/test_gelu_new.py
+++ b/tests/unittest/ops/test_gelu_new.py
@@ -1,0 +1,45 @@
+import torch
+import torch.nn
+import math
+
+
+from dinoml.compiler import compile_model, ops
+from dinoml.frontend import IntImm, IntVar, Tensor, nn
+from dinoml.testing import detect_target
+from dinoml.testing.benchmark_dinoml import benchmark_module
+from dinoml.testing.benchmark_pt import benchmark_torch_function
+
+
+def gelu_new(input: torch.Tensor) -> torch.Tensor:
+    return (
+        0.5
+        * input
+        * (
+            1.0
+            + torch.tanh(
+                math.sqrt(2.0 / math.pi) * (input + 0.044715 * torch.pow(input, 3.0))
+            )
+        )
+    )
+
+
+torch.manual_seed(0)
+
+x_pt = torch.randn([1, 512, 4096]).to("cuda", torch.bfloat16)
+y_pt = gelu_new(x_pt.clone())
+
+x = Tensor([1, 512, 4096], name="x", is_input=True, dtype="bfloat16")
+y = ops.gelu_new()(x)
+y._attrs["name"] = "y"
+y._attrs["is_output"] = True
+
+module = compile_model(y, detect_target(), "./tmp", "gelu_new")
+
+out = module.run_with_tensors({"x": x_pt}, {"y": torch.empty_like(y_pt)})["y"]
+
+torch.testing.assert_close(out, y_pt, rtol=1e-5, atol=1e-5)
+
+benchmark_module(module, count=100)
+
+pt_mean = benchmark_torch_function(100, gelu_new, x_pt)
+print(pt_mean)


### PR DESCRIPTION
This version of gelu_new better matches PyTorch

```
DinoML Mean: 0.020 ms, Std: 0.000 ms
PyTorch: 0.0832 ms
```

For T5EncoderModel/T5Attention we use `bmm_rrr_permute` over separate `bmm_rrr`->`reshape`->`transpose`, this eliminates the warning about dynamic gemm alignment.

```
max diff: 0.078125
mean diff: 0.00128936767578125

PyTorch
tensor([[[-0.2266,  0.0708, -0.1094,  ...,  0.0457,  0.1279,  0.0713],
         [ 0.0586, -0.1206, -0.1387,  ..., -0.0588,  0.0854, -0.1426],
         [ 0.1680,  0.0903, -0.0057,  ..., -0.0864, -0.0908,  0.2178],
         ...,
         [-0.0835, -0.0791,  0.1689,  ..., -0.1943,  0.0371, -0.0376],
         [ 0.2910,  0.0205,  0.0850,  ..., -0.2168, -0.1387,  0.1533],
         [-0.0354, -0.2559, -0.0234,  ...,  0.0159,  0.0586,  0.0430]]],
       device='cuda:0', dtype=torch.bfloat16)

DinoML
tensor([[[-0.2275,  0.0698, -0.1084,  ...,  0.0464,  0.1289,  0.0708],
         [ 0.0564, -0.1201, -0.1396,  ..., -0.0620,  0.0903, -0.1416],
         [ 0.1641,  0.0894, -0.0049,  ..., -0.0874, -0.0928,  0.2197],
         ...,
         [-0.0840, -0.0791,  0.1709,  ..., -0.1963,  0.0391, -0.0376],
         [ 0.2949,  0.0229,  0.0874,  ..., -0.2188, -0.1338,  0.1533],
         [-0.0371, -0.2559, -0.0221,  ...,  0.0170,  0.0605,  0.0413]]],
       device='cuda:0', dtype=torch.bfloat16)

Mismatched elements: 928 / 2097152 (0.0%) at rtol/atol=1e-2

DinoML Mean: 108.353 ms, Std: 0.135 ms
PyTorch 118.367
```

Output is sufficiently accurate.

Benchmarks conducted on 3090.

We will look at performance later.