### PR TITLE
helpers

### DIFF
--- a/csrc/include/dinoml/device.h
+++ b/csrc/include/dinoml/device.h
@@ -1,8 +1,6 @@
 #pragma once
 
-#include <chrono>
 #include <cstdint>
-#include <random>
 #include <type_traits>
 
 #ifdef DINOML_CUDA
@@ -33,24 +31,6 @@ using DeviceStream = hipStream_t;
 #define HALF2DATA(x) x.data
 #endif
 
-inline uint64_t make_seed() {
-  std::random_device rd;
-
-  uint64_t time_seed = static_cast<uint64_t>(
-      std::chrono::high_resolution_clock::now().time_since_epoch().count());
-
-  uint64_t rd_seed = (static_cast<uint64_t>(rd()) << 32) ^ rd();
-
-  return rd_seed ^ time_seed;
-}
-
-
-template <typename integer>
-constexpr __host__ __device__ inline integer ceil_div(integer n, integer m) {
-  return (n + m - 1) / m;
-}
-
-
 } // namespace dinoml
 
 #ifdef DINOML_CUDA
@@ -60,44 +40,4 @@ using bfloat162 = __nv_bfloat162;
 #ifdef DINOML_HIP
 using bfloat16 = hip_bfloat16;
 using bfloat162 = __hip_bfloat162;
-#endif
-
-#ifdef DINOML_CUDA
-
-constexpr uint32_t kBlockSizeBound = 256;
-constexpr uint32_t kGridSizeBound = 4;
-
-constexpr uint32_t kMaxGeneratorOffsetsPerCurandCall = 4;
-
-static inline std::tuple<uint64_t, dim3, dim3> calc_execution_policy(
-    int64_t total_elements,
-    uint32_t unroll_factor) {
-  const uint64_t numel = static_cast<uint64_t>(total_elements);
-
-  const uint32_t block_size = kBlockSizeBound;
-  dim3 block(block_size);
-
-  uint32_t grid_x =
-      static_cast<uint32_t>((numel + block_size - 1) / block_size);
-
-  int dev = 0;
-  cudaGetDevice(&dev);
-  cudaDeviceProp prop{};
-  cudaGetDeviceProperties(&prop, dev);
-
-  uint32_t blocks_per_sm =
-      static_cast<uint32_t>(prop.maxThreadsPerMultiProcessor / block_size);
-
-  grid_x = std::min(prop.multiProcessorCount * blocks_per_sm, grid_x);
-
-  dim3 grid(grid_x);
-
-  const uint64_t denom = static_cast<uint64_t>(block_size) *
-      static_cast<uint64_t>(grid_x) * static_cast<uint64_t>(unroll_factor);
-
-  uint64_t counter_offset =
-      ((numel - 1) / denom + 1) * kMaxGeneratorOffsetsPerCurandCall;
-
-  return {counter_offset, grid, block};
-}
 #endif

--- a/csrc/include/dinoml/helpers.h
+++ b/csrc/include/dinoml/helpers.h
@@ -1,0 +1,240 @@
+#pragma once
+#include <chrono>
+#include <random>
+#include "device.h"
+
+namespace dinoml {
+
+namespace helpers {
+
+template <typename To, typename From>
+struct convert;
+
+template <>
+struct convert<float2, float2> {
+  __device__ __forceinline__ static float2 run(const float2& v) {
+    return v;
+  }
+};
+
+template <>
+struct convert<float2, half2> {
+  __device__ __forceinline__ static float2 run(const half2& v) {
+    return __half22float2(v);
+  }
+};
+
+template <>
+struct convert<float2, bfloat162> {
+  __device__ __forceinline__ static float2 run(const bfloat162& v) {
+    return __bfloat1622float2(v);
+  }
+};
+
+template <>
+struct convert<half2, float2> {
+  __device__ __forceinline__ static half2 run(const float2& v) {
+    return __float22half2_rn(v);
+  }
+};
+
+template <>
+struct convert<half2, half2> {
+  __device__ __forceinline__ static half2 run(const half2& v) {
+    return v;
+  }
+};
+
+template <>
+struct convert<half2, bfloat162> {
+  __device__ __forceinline__ static half2 run(const bfloat162& v) {
+    return __float22half2_rn(__bfloat1622float2(v));
+  }
+};
+
+template <>
+struct convert<bfloat162, float2> {
+  __device__ __forceinline__ static bfloat162 run(const float2& v) {
+    return __float22bfloat162_rn(v);
+  }
+};
+
+template <>
+struct convert<bfloat162, half2> {
+  __device__ __forceinline__ static bfloat162 run(const half2& v) {
+    return __float22bfloat162_rn(__half22float2(v));
+  }
+};
+
+template <>
+struct convert<bfloat162, bfloat162> {
+  __device__ __forceinline__ static bfloat162 run(const bfloat162& v) {
+    return v;
+  }
+};
+
+template <typename T>
+struct add_op;
+
+template <>
+struct add_op<float2> {
+  __device__ __forceinline__ static float2 run(float2 a, float2 b) {
+    return {a.x + b.x, a.y + b.y};
+  }
+};
+
+template <>
+struct add_op<half2> {
+  __device__ __forceinline__ static half2 run(half2 a, half2 b) {
+    return __hadd2(a, b);
+  }
+};
+
+template <>
+struct add_op<bfloat162> {
+  __device__ __forceinline__ static bfloat162 run(bfloat162 a, bfloat162 b) {
+    return __hadd2(a, b);
+  }
+};
+
+template <>
+struct add_op<float> {
+  __device__ __forceinline__ static float run(float a, float b) {
+    return a + b;
+  }
+};
+
+template <>
+struct add_op<half> {
+  __device__ __forceinline__ static half run(half a, half b) {
+    return __hadd(a, b);
+  }
+};
+
+template <>
+struct add_op<bfloat16> {
+  __device__ __forceinline__ static bfloat16 run(bfloat16 a, bfloat16 b) {
+    return __hadd(a, b);
+  }
+};
+
+template <typename T1, typename T2>
+__device__ __forceinline__ T1 add2(T1 a, T2 b) {
+  return add_op<T1>::run(a, convert<T1, T2>::run(b));
+}
+
+template <typename Vec, typename Elem>
+struct add_op2; // Vec is storage type, Elem is logical element type
+
+template <typename T>
+struct add_op2<T, T> {
+  __device__ __forceinline__ static T run(const T& a, const T& b) {
+    return a + b;
+  }
+};
+
+template <>
+struct add_op2<float2, float> {
+  __device__ __forceinline__ static float2 run(
+      const float2& a,
+      const float2& b) {
+    return {a.x + b.x, a.y + b.y};
+  }
+};
+
+template <>
+struct add_op2<half2, half> {
+  __device__ __forceinline__ static half2 run(const half2& a, const half2& b) {
+    return __hadd2(a, b);
+  }
+};
+
+template <>
+struct add_op2<bfloat162, bfloat16> {
+  __device__ __forceinline__ static bfloat162 run(
+      const bfloat162& a,
+      const bfloat162& b) {
+    return __hadd2(a, b);
+  }
+};
+
+template <typename Vec, typename Elem>
+struct add_op2 {
+  __device__ __forceinline__ static Vec run(const Vec& a, const Vec& b) {
+    static_assert(
+        sizeof(Vec) % sizeof(Elem) == 0,
+        "Packed add requires Vec to be a multiple of Elem size.");
+    Vec out;
+    auto* po = reinterpret_cast<Elem*>(&out);
+    auto* pa = reinterpret_cast<const Elem*>(&a);
+    auto* pb = reinterpret_cast<const Elem*>(&b);
+
+    constexpr int N = sizeof(Vec) / sizeof(Elem);
+
+#pragma unroll
+    for (int i = 0; i < N; ++i) {
+      po[i] = pa[i] + pb[i];
+    }
+    return out;
+  }
+};
+
+#ifdef DINOML_CUDA
+
+constexpr uint32_t kBlockSizeBound = 256;
+constexpr uint32_t kGridSizeBound = 4;
+
+constexpr uint32_t kMaxGeneratorOffsetsPerCurandCall = 4;
+
+static inline std::tuple<uint64_t, dim3, dim3> calc_execution_policy(
+    int64_t total_elements,
+    uint32_t unroll_factor) {
+  const uint64_t numel = static_cast<uint64_t>(total_elements);
+
+  const uint32_t block_size = kBlockSizeBound;
+  dim3 block(block_size);
+
+  uint32_t grid_x =
+      static_cast<uint32_t>((numel + block_size - 1) / block_size);
+
+  int dev = 0;
+  cudaGetDevice(&dev);
+  cudaDeviceProp prop{};
+  cudaGetDeviceProperties(&prop, dev);
+
+  uint32_t blocks_per_sm =
+      static_cast<uint32_t>(prop.maxThreadsPerMultiProcessor / block_size);
+
+  grid_x = std::min(prop.multiProcessorCount * blocks_per_sm, grid_x);
+
+  dim3 grid(grid_x);
+
+  const uint64_t denom = static_cast<uint64_t>(block_size) *
+      static_cast<uint64_t>(grid_x) * static_cast<uint64_t>(unroll_factor);
+
+  uint64_t counter_offset =
+      ((numel - 1) / denom + 1) * kMaxGeneratorOffsetsPerCurandCall;
+
+  return {counter_offset, grid, block};
+}
+#endif
+
+template <typename integer>
+constexpr __host__ __device__ inline integer ceil_div(integer n, integer m) {
+  return (n + m - 1) / m;
+}
+
+inline uint64_t make_seed() {
+  std::random_device rd;
+
+  uint64_t time_seed = static_cast<uint64_t>(
+      std::chrono::high_resolution_clock::now().time_since_epoch().count());
+
+  uint64_t rd_seed = (static_cast<uint64_t>(rd()) << 32) ^ rd();
+
+  return rd_seed ^ time_seed;
+}
+
+} // namespace helpers
+
+} // namespace dinoml

--- a/csrc/include/ops/randn.h
+++ b/csrc/include/ops/randn.h
@@ -6,6 +6,7 @@
 #include <curand_kernel.h>
 
 #include "dinoml/device.h"
+#include "dinoml/helpers.h"
 
 namespace dinoml {
 
@@ -85,7 +86,7 @@ void invoke_randn(
       "Unsupported dtype for invoke_randn");
 
   auto [counter_offset, grid, block] =
-      calc_execution_policy(n, /*unroll_factor=*/4);
+      dinoml::helpers::calc_execution_policy(n, /*unroll_factor=*/4);
   dinoml::randn_philox<ElemOutputType><<<grid, block, 0, stream>>>(
       static_cast<ElemOutputType*>(out), n, mean, std, seed, offset_groups);
 }

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -17,3 +17,34 @@ ruff format src scripts tests inference builder setup.py --exclude src/dinoml/ut
 ```sh
 ruff check src scripts tests inference builder setup.py --exclude src/dinoml/utils/cutlass_lib/ src/dinoml/utils/ck_lib/ scripts/mk_cutlass_lib/ scripts/mk_ck_lib/ --ignore F821 --ignore F401 --ignore F841 --ignore F403 --ignore E741 --ignore E731 --ignore E402
 ```
+
+## VSCode Intellisense
+
+It is recommended to set `defines` for either `DINOML_CUDA` or `DINOML_HIP`, and add CUDA toolkit or HIP to includes.
+
+On Windows `.vscode/c_cpp_properties.json` looks something like:
+
+```json
+{
+    "configurations": [
+        {
+            "name": "Win32",
+            "includePath": [
+                "${workspaceFolder}/**",
+                "C:\\Program Files\\NVIDIA GPU Computing Toolkit\\CUDA\\v12.8\\include\\**"
+            ],
+            "defines": [
+                "_DEBUG",
+                "UNICODE",
+                "_UNICODE",
+                "DINOML_CUDA"
+            ],
+            "windowsSdkVersion": "10.0.22621.0",
+            "compilerPath": "cl.exe",
+            "cStandard": "c17",
+            "intelliSenseMode": "windows-msvc-x64"
+        }
+    ],
+    "version": 4
+}
+```

--- a/src/dinoml/backend/cuda/tensor/randn.py
+++ b/src/dinoml/backend/cuda/tensor/randn.py
@@ -50,10 +50,10 @@ FUNC_CALL_TEMPLATE = jinja2.Template(
     """
 {{indent}}{
     {{indent}}uint64_t {{func_name}}_n_elements = {{n}};
-    {{indent}}uint64_t {{func_name}}_seed = {% if seed is not none %}{{ seed }}{% else %}dinoml::make_seed(){% endif %};
+    {{indent}}uint64_t {{func_name}}_seed = {% if seed is not none %}{{ seed }}{% else %}dinoml::helpers::make_seed(){% endif %};
     {{indent}}uint64_t {{func_name}}_counter = {% if offset_groups is not none %}{{ offset_groups }}{% else %}global_counter_{% endif %};
     {{indent}}  auto [{{func_name}}_counter_offset, {{func_name}}_grid, {{func_name}}_block] =
-    {{indent}}      calc_execution_policy((int64_t){{func_name}}_n_elements, /*unroll_factor=*/4);
+    {{indent}}      dinoml::helpers::calc_execution_policy((int64_t){{func_name}}_n_elements, /*unroll_factor=*/4);
     {{indent}}{{func_name}}(
     {{indent}}    {{out_ptr}},
     {{indent}}    {{func_name}}_n_elements,

--- a/src/dinoml/backend/cuda/upsample/upsampling2d_add.py
+++ b/src/dinoml/backend/cuda/upsample/upsampling2d_add.py
@@ -36,6 +36,7 @@ def gen_function(
         shape_eval_template,
         shape_save_template,
         backend_spec=CUDASpec(),
+        bias_add=True,
     )
 
 

--- a/src/dinoml/backend/main_templates.py
+++ b/src/dinoml/backend/main_templates.py
@@ -25,6 +25,7 @@ MODEL_TEMPLATE = jinja2.Template(
 #include "debug_utility.h"
 {% endif %}
 #include <dinoml/device.h>
+#include <dinoml/helpers.h>
 #include "short_file.h"
 #include "logging.h"
 #include "device_functions-generated.h"

--- a/src/dinoml/backend/rocm/upsample/upsampling2d_add.py
+++ b/src/dinoml/backend/rocm/upsample/upsampling2d_add.py
@@ -36,6 +36,7 @@ def gen_function(
         shape_eval_template,
         shape_save_template,
         backend_spec=ROCMSpec(),
+        bias_add=True,
     )
 
 


### PR DESCRIPTION
Create `dinoml/helpers.h`

`make_seed` and `calc_execution_policy` moved to `dinoml::helpers`

Introduces `convert` for `float2`,`half2`,`bfloat162`<->`float2`,`half2`,`bfloat162`

`add_op` supports `float2`,`half2`,`bfloat162`,`float`,`half`,`bfloat16`, this is used in part for `add2(T1 a, T2 b)` which converts T2 to T1, for example, adding `float2` to `half2`

`add_op2` is similar but used for vectorized adds, mainly this is to handle e.g. alignment 8 with vector type `float4` and elem type `half`

See `csrc/include/ops/upsampling_2d.h` for how these helpers clean up the kernel

Upsampling 2d dispatch is also cleaned up