### PR TITLE
Some optimizations

### DIFF
--- a/csrc/include/kernels/cuda/groupnorm_kernel.cuh
+++ b/csrc/include/kernels/cuda/groupnorm_kernel.cuh
@@ -1076,7 +1076,7 @@ cudaError_t invokeGroupNorm(
   // C_G must be even, or we can have misaligned address for cp.async
   // reserve some shared_mem for block reduction
   if (H > 0 && H % 8 == 0 && C_G % 2 == 0 && smem <= max_smem_size - 1000) {
-    constexpr int num_threads = 1024;
+    constexpr int num_threads = 256;
     auto kernel_func = group_norm_smem<
         TInput,
         FuseSwish,

--- a/csrc/include/kernels/cuda/groupnorm_kernel.cuh
+++ b/csrc/include/kernels/cuda/groupnorm_kernel.cuh
@@ -673,7 +673,7 @@ cudaError_t invokeWelfordGroupNorm(
     max_vec_size /= 2;
   }
 
-  constexpr int64_t block_size = 1024;
+  constexpr int64_t block_size = 256;
   const int64_t elems_per_group_channel = C / num_groups;
   const int64_t elems_per_block = (D * H * W * C) / num_groups;
   const int64_t batch_stride = D * H * W * C;

--- a/src/dinoml/backend/common/concatenate_common.py
+++ b/src/dinoml/backend/common/concatenate_common.py
@@ -710,11 +710,9 @@ def gen_function(
     strides = [_stride(i._attrs["shape"], concat_dim) for i in inputs]
     # the max number of elements in each concat loop iteration
     elems_per_iter = max(strides) if len(strides) > 0 else 0
-    threads_per_block = 1024
+    threads_per_block = 128
     # minimal number of elems per thread is 8, max is 480
-    elems_per_thread = (
-        480  # min(480, (int((elems_per_iter / threads_per_block + 8) / 8) * 8))
-    )
+    elems_per_thread = min(480, (int((elems_per_iter / threads_per_block + 8) / 8) * 8))
 
     input_accessors = []
     input_accessor_refs = []

--- a/src/dinoml/backend/common/elementwise_common.py
+++ b/src/dinoml/backend/common/elementwise_common.py
@@ -32,7 +32,7 @@ from dinoml.utils import alignment as alignment_utils, shape_utils
 
 CONSTANT_TEMPLATE = jinja2.Template(
     """
-#define FUSED_ELE_THREAD_SIZE 1024
+#define FUSED_ELE_THREAD_SIZE 256
 
 const int N_ELEMENTS_PER_THREAD = sizeof({{read_t}}) / sizeof({{data_t}});
 const int N_ELEMENTS_PER_READ = sizeof({{read_t}}) / sizeof({{data_t}});

--- a/src/dinoml/backend/common/split_common.py
+++ b/src/dinoml/backend/common/split_common.py
@@ -511,8 +511,8 @@ def gen_function(func_attrs, backend_spec):
         real_num_splits=len(func_attrs["outputs"]),
         split_indices=split_indices,
         elem_type=input_type,
-        elems_per_thread=480,
-        threads_per_block=1024,
+        elems_per_thread=128,
+        threads_per_block=256,
         index_type=backend_spec.index_type,
     )
     header_src = backend_spec.header_src_template.render()

--- a/src/dinoml/backend/cuda/groupnorm/groupnorm_common.py
+++ b/src/dinoml/backend/cuda/groupnorm/groupnorm_common.py
@@ -31,7 +31,6 @@ cudaError_t {{func_name}}(void* output,
                           void* gamma,
                           void* beta,
                           int N,
-                          {{depth}}
                           int64_t* H,
                           int64_t* W,
                           const float eps,
@@ -52,7 +51,7 @@ FUNC_CALL_TEMPLATE = jinja2.Template(
 {{indent}}{
 {{indent}}  {{func_name}}(
 {{indent}}     {{output}}, {{input}}, {{gamma}}, {{beta}}, {{N}},
-{{indent}}     {{D}} {{H}}, {{W}},
+{{indent}}     {{H}}, {{W}},
 {{indent}}     {{eps}}, max_smem_size_, global_workspace_,
 {{indent}}  stream /* default stream */
 {{indent}}  );
@@ -88,16 +87,17 @@ using bfloat16_2 = __nv_bfloat162;
 
 {{func_signature}}
 {
-    return invokeWelfordGroupNorm<{{FuseSwish}}, {{C}}, {{G}}, {{elem_input_type}}>(
+    return invokeGroupNorm<{{elem_input_type}}, {{FuseSwish}}, {{C}}, {{G}}>(
             static_cast<{{elem_input_type}}*>(output),
             static_cast<{{elem_input_type}}*>(input),
             static_cast<{{elem_input_type}}*>(gamma),
             static_cast<{{elem_input_type}}*>(beta),
             N,
-            {{depth}}
             H,
             W,
             eps,
+            max_smem_size,
+            workspace,
             stream);
 }
     """

--- a/src/dinoml/mapping/mapping_functions.py
+++ b/src/dinoml/mapping/mapping_functions.py
@@ -16,7 +16,12 @@ def conv2d_permute(key: str, tensor: torch.Tensor, state_dict: Dict[str, torch.T
         return tensor
 
 
-def conv2d_pad(key: str, tensor: torch.Tensor, state_dict: Dict[str, torch.Tensor], pad_to_multiple_of: int = 4):
+def conv2d_pad(
+    key: str,
+    tensor: torch.Tensor,
+    state_dict: Dict[str, torch.Tensor],
+    pad_to_multiple_of: int = 4,
+):
     if (
         tensor.ndim == 4
         and "conv" in key

--- a/src/dinoml/mapping/mapping_functions.py
+++ b/src/dinoml/mapping/mapping_functions.py
@@ -4,7 +4,7 @@ import torch
 from dinoml.utils.torch_utils import string_to_torch_dtype
 
 
-def conv2d_permute(key: str, tensor: torch.Tensor):
+def conv2d_permute(key: str, tensor: torch.Tensor, state_dict: Dict[str, torch.Tensor]):
     if (
         tensor.ndim == 4
         and "conv" in key
@@ -16,7 +16,7 @@ def conv2d_permute(key: str, tensor: torch.Tensor):
         return tensor
 
 
-def conv2d_pad(key: str, tensor: torch.Tensor, pad_to_multiple_of: int = 4):
+def conv2d_pad(key: str, tensor: torch.Tensor, state_dict: Dict[str, torch.Tensor], pad_to_multiple_of: int = 4):
     if (
         tensor.ndim == 4
         and "conv" in key
@@ -59,7 +59,7 @@ def _map(
             tensor = tensor.to(dtype)
         key = key.replace(".", "_")
         for map_fn in mapping_fn:
-            tensor = map_fn(key, tensor)
+            tensor = map_fn(key, tensor, dinoml_params)
         if tensor.device != device:
             tensor = tensor.to(device)
         dinoml_params[key] = tensor

--- a/src/dinoml/mapping/unet2d_condition.py
+++ b/src/dinoml/mapping/unet2d_condition.py
@@ -22,6 +22,17 @@ def conv2d_pad(key: str, tensor: torch.Tensor, pad_to_multiple_of: int = 4):
     else:
         return tensor
 
+def geglu_split(key: str, tensor: torch.Tensor, state_dict: Dict[str, torch.Tensor]):
+    if key.endswith("ff_net_0_proj_weight"):
+        proj, gate = tensor.chunk(2, dim=0)
+        state_dict[key.replace("proj", "gate")] = gate
+        return proj
+    elif key.endswith("ff_net_0_proj_bias"):
+        proj, gate = tensor.chunk(2, dim=0)
+        state_dict[key.replace("proj", "gate")] = gate
+        return proj
+    else:
+        return tensor
 
 def map_unet2d_condition(
     self,
@@ -29,7 +40,7 @@ def map_unet2d_condition(
     dtype: Union[str, torch.dtype],
     device: Union[str, torch.device],
     skip_keys: Iterable[str],
-    mapping_fn: Iterable[Callable] = (conv2d_permute, conv2d_pad),
+    mapping_fn: Iterable[Callable] = (conv2d_permute, conv2d_pad, geglu_split),
 ):
     return _map(
         pt_module=pt_module,

--- a/src/dinoml/mapping/unet2d_condition.py
+++ b/src/dinoml/mapping/unet2d_condition.py
@@ -4,7 +4,7 @@ from typing import Callable, Dict, Iterable, Union
 import torch
 
 
-def conv2d_permute(key: str, tensor: torch.Tensor):
+def conv2d_permute(key: str, tensor: torch.Tensor, state_dict: Dict[str, torch.Tensor]):
     if tensor.ndim == 4:
         print(f"Permuting {key=}")
         return torch.permute(tensor, [0, 2, 3, 1]).contiguous()
@@ -12,7 +12,12 @@ def conv2d_permute(key: str, tensor: torch.Tensor):
         return tensor
 
 
-def conv2d_pad(key: str, tensor: torch.Tensor, pad_to_multiple_of: int = 4):
+def conv2d_pad(
+    key: str,
+    tensor: torch.Tensor,
+    state_dict: Dict[str, torch.Tensor],
+    pad_to_multiple_of: int = 4,
+):
     if tensor.ndim == 4 and tensor.shape[-1] % 4 != 0:
         channels = tensor.shape[-1]
         pad_by = pad_to_multiple_of - (channels - pad_to_multiple_of)
@@ -21,6 +26,7 @@ def conv2d_pad(key: str, tensor: torch.Tensor, pad_to_multiple_of: int = 4):
         return torch.nn.functional.pad(tensor, pad=pad)
     else:
         return tensor
+
 
 def geglu_split(key: str, tensor: torch.Tensor, state_dict: Dict[str, torch.Tensor]):
     if key.endswith("ff_net_0_proj_weight"):
@@ -33,6 +39,7 @@ def geglu_split(key: str, tensor: torch.Tensor, state_dict: Dict[str, torch.Tens
         return proj
     else:
         return tensor
+
 
 def map_unet2d_condition(
     self,

--- a/src/dinoml/modeling/diffusers/activations.py
+++ b/src/dinoml/modeling/diffusers/activations.py
@@ -108,15 +108,14 @@ class GEGLU(nn.Module):
         self, dim_in: int, dim_out: int, bias: bool = True, dtype: str = "float16"
     ):
         super().__init__()
-        self.proj = nn.Linear(dim_in, dim_out * 2, bias=bias, dtype=dtype)
+        self.proj = nn.Linear(dim_in, dim_out, bias=bias, dtype=dtype, specialization="mul")
+        self.gate = nn.Linear(dim_in, dim_out, bias=bias, dtype=dtype, specialization="fast_gelu")
 
     def gelu(self, gate: Tensor) -> Tensor:
         return ops.gelu(gate)
 
     def forward(self, hidden_states, *args, **kwargs):
-        hidden_states = self.proj(hidden_states)
-        hidden_states, gate = ops.chunk()(hidden_states, chunks=2, dim=-1)
-        return hidden_states * self.gelu(gate)
+        return self.proj(hidden_states, self.gate(hidden_states))
 
 
 class ApproximateGELU(nn.Module):

--- a/src/dinoml/modeling/diffusers/activations.py
+++ b/src/dinoml/modeling/diffusers/activations.py
@@ -108,8 +108,12 @@ class GEGLU(nn.Module):
         self, dim_in: int, dim_out: int, bias: bool = True, dtype: str = "float16"
     ):
         super().__init__()
-        self.proj = nn.Linear(dim_in, dim_out, bias=bias, dtype=dtype, specialization="mul")
-        self.gate = nn.Linear(dim_in, dim_out, bias=bias, dtype=dtype, specialization="fast_gelu")
+        self.proj = nn.Linear(
+            dim_in, dim_out, bias=bias, dtype=dtype, specialization="mul"
+        )
+        self.gate = nn.Linear(
+            dim_in, dim_out, bias=bias, dtype=dtype, specialization="fast_gelu"
+        )
 
     def gelu(self, gate: Tensor) -> Tensor:
         return ops.gelu(gate)

--- a/src/dinoml/utils/cutlass_lib/generator.py
+++ b/src/dinoml/utils/cutlass_lib/generator.py
@@ -2412,6 +2412,34 @@ def GenerateSM80_TensorOp_16816(manifest, cuda_version):
       TileDescription([128,  64, 64],  3, [2, 2, 1], math_inst, min_cc, max_cc),
       TileDescription([ 64, 128, 64],  3, [2, 2, 1], math_inst, min_cc, max_cc),
       TileDescription([ 64,  64, 64],  5, [2, 2, 1], math_inst, min_cc, max_cc),
+      TileDescription([256, 64, 32], 2, [4,1,1], math_inst, min_cc, max_cc),
+      TileDescription([64, 256, 32], 2, [1,4,1], math_inst, min_cc, max_cc),
+      TileDescription([192,128,32], 3, [4, 2, 1], math_inst, min_cc, max_cc),
+      TileDescription([128,192,32], 3, [4, 2, 1], math_inst, min_cc, max_cc),
+      TileDescription([192,128,32], 4, [4, 2, 1], math_inst, min_cc, max_cc),
+      TileDescription([128,192,32], 4, [4, 2, 1], math_inst, min_cc, max_cc),
+      TileDescription([160,128,32], 3, [4, 2, 1], math_inst, min_cc, max_cc),
+      TileDescription([128,160,32], 3, [4, 2, 1], math_inst, min_cc, max_cc),
+      TileDescription([160,128,32], 4, [4, 2, 1], math_inst, min_cc, max_cc),
+      TileDescription([128,160,32], 4, [4, 2, 1], math_inst, min_cc, max_cc),
+      TileDescription([224,128,32], 3, [4,2,1], math_inst, min_cc, max_cc),
+TileDescription([128,224,32], 3, [2,4,1], math_inst, min_cc, max_cc),
+
+TileDescription([224,128,32], 4, [4,2,1], math_inst, min_cc, max_cc),
+TileDescription([128,224,32], 4, [2,4,1], math_inst, min_cc, max_cc),
+TileDescription([192,160,32], 3, [4,2,1], math_inst, min_cc, max_cc),
+TileDescription([160,192,32], 3, [2,4,1], math_inst, min_cc, max_cc),
+
+TileDescription([192,160,32], 4, [4,2,1], math_inst, min_cc, max_cc),
+TileDescription([160,192,32], 4, [2,4,1], math_inst, min_cc, max_cc),
+TileDescription([256, 96, 32], 3, [4,2,1], math_inst, min_cc, max_cc),
+TileDescription([ 96,256,32], 3, [2,4,1], math_inst, min_cc, max_cc),
+
+TileDescription([256, 96, 32], 2, [4,2,1], math_inst, min_cc, max_cc),
+TileDescription([ 96,256,32], 2, [2,4,1], math_inst, min_cc, max_cc),
+TileDescription([192, 96, 32], 3, [4,2,1], math_inst, min_cc, max_cc),
+TileDescription([ 96,192,32], 3, [2,4,1], math_inst, min_cc, max_cc),
+
     ]
 
     data_type = [


### PR DESCRIPTION
- Use other group norm kernel
- Tune concatenate and elementwise
- Split GEGLU into 2 GEMMs with `mul` and `fast_gelu` respectively
- Add some tile descriptions to cutlass generator

For `UNet2DConditionModel` `runwayml/stable-diffusion-v1-5` @ `512x512` with `batch 2` on `3090`:

`29.6 ms` -> `25.8ms`, `33.78` it/s -> `38.76` it/s

Intermediates workspace `~120mb` -> `~80mb`
