### PR TITLE
More updates for AMD and Flash Attention for CUDA and AMD

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -11,3 +11,9 @@
 [submodule "3rdparty/picojson"]
 	path = 3rdparty/picojson
 	url = https://github.com/kazuho/picojson.git
+[submodule "3rdparty/flash_attn"]
+	path = 3rdparty/flash_attn
+	url = https://github.com/hlky/flash_attn
+[submodule "3rdparty/flash_attn_ck"]
+	path = 3rdparty/flash_attn_ck
+	url = https://github.com/hlky/flash_attn_ck

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 | Platform | Support |
 | -------- |:-------:|
 | CUDA     | ✅ |
-| ROCm     | Partial |
+| ROCm     | ✅ |
 
 ## Optimizations
 

--- a/builder/autoencoder_kl.py
+++ b/builder/autoencoder_kl.py
@@ -72,7 +72,7 @@ height, width = resolution, resolution
 
 hf_hub = args.hf_hub
 label = args.label
-model_name = f"autoencoder_kl.decoder.{label}.{resolution[1]}.{device_name}.sm{sm}"
+model_name = f"autoencoder_kl.decoder.{label}.{resolution[1]}.{device_name}.{sm}"
 
 config, dinoml_cls, pt_cls = load_config(hf_hub, subfolder=args.subfolder)
 

--- a/builder/autoencoder_kl_encode.py
+++ b/builder/autoencoder_kl_encode.py
@@ -72,7 +72,7 @@ height, width = resolution, resolution
 
 hf_hub = args.hf_hub
 label = args.label
-model_name = f"autoencoder_kl.encoder.{label}.{resolution[1]}.{device_name}.sm{sm}"
+model_name = f"autoencoder_kl.encoder.{label}.{resolution[1]}.{device_name}.{sm}"
 
 config, dinoml_cls, pt_cls = load_config(hf_hub, subfolder=args.subfolder)
 

--- a/csrc/include/dinoml/custom_math.h
+++ b/csrc/include/dinoml/custom_math.h
@@ -51,6 +51,25 @@ __device__ half fast_tanh(half x) {
   return cdf;
 }
 
+
+__device__ bfloat16_2 fast_tanh(bfloat16_2 x) {
+  // 1-2/(e^(2x)+1)
+  const bfloat16_2 u = __hmul2(bfloat16_2(2), x);
+  const bfloat16_2 emu = h2exp(u);
+  const bfloat16_2 cdf =
+      __hsub2(bfloat16_2(1), __h2div(bfloat16_2(2), __hadd2(bfloat16_2(1), emu)));
+  return cdf;
+}
+
+__device__ bfloat16 fast_tanh(bfloat16 x) {
+  // 1-2/(e^(2x)+1)
+  const bfloat16 u = __hmul(bfloat16(2), x);
+  const bfloat16 emu = hexp(u);
+  const bfloat16 cdf = __hsub(bfloat16(1), __hdiv(bfloat16(2), __hadd(bfloat16(1), emu)));
+  return cdf;
+}
+
+
 // Return 1
 __device__ half one() {
   uint16_t bits = 0x3c00u;
@@ -61,6 +80,16 @@ __device__ half one() {
 __device__ half constant_half() {
   uint16_t bits = 0x3800u;
   return reinterpret_cast<half const&>(bits);
+}
+
+__device__ bfloat16 one_bf16() {
+    uint16_t bits = 0x3f80u;
+    return reinterpret_cast<bfloat16 const&>(bits);
+}
+
+__device__ bfloat16 constant_half_bf16() {
+    uint16_t bits = 0x3f00u;
+    return reinterpret_cast<bfloat16 const&>(bits);
 }
 
 __device__ float fsigmoid_custom(const float a) {
@@ -79,6 +108,13 @@ __device__ half2 h2sigmoid_custom(const half2 a) {
   return __hmul2((__hadd2(fast_tanh(__hmul2(a, halfX2)), oneX2)), halfX2);
 }
 
+__device__ bfloat16_2 h2sigmoid_custom(const bfloat16_2 a) {
+  bfloat16_2 halfX2 = bfloat16_2(constant_half_bf16(), constant_half_bf16());
+  bfloat16_2 oneX2 = bfloat16_2(one_bf16(), one_bf16());
+  return __hmul2((__hadd2(fast_tanh(__hmul2(a, halfX2)), oneX2)), halfX2);
+}
+
+
 __device__ float fsilu(const float a) {
   return a * fsigmoid_custom(a);
 }
@@ -90,6 +126,11 @@ __device__ half hsilu(const half a) {
 __device__ half2 h2silu(const half2 a) {
   return __hmul2(a, h2sigmoid_custom(a));
 }
+
+__device__ bfloat16_2 h2silu(const bfloat16_2 a) {
+  return __hmul2(a, h2sigmoid_custom(a));
+}
+
 
 __device__ half hsin_custom(const half a) {
   float x = __half2float(a);

--- a/csrc/include/dinoml/device.h
+++ b/csrc/include/dinoml/device.h
@@ -2,6 +2,7 @@
 
 #include <cstdint>
 #include <type_traits>
+#include "short_file.h"
 
 #ifdef DINOML_CUDA
 #include <cuda_bf16.h>
@@ -13,8 +14,8 @@
 #include "cutlass/util/host_tensor.h"
 #endif
 #ifdef DINOML_HIP
-#include <hip/hip_fp16.h>
 #include <hip/hip_bf16.h>
+#include <hip/hip_fp16.h>
 #include <hip/hip_runtime.h>
 #include "ck/library/utility/host_tensor.hpp"
 #endif
@@ -23,15 +24,28 @@ namespace dinoml {
 #ifdef DINOML_CUDA
 using bfloat16 = __nv_bfloat16;
 using bfloat162 = __nv_bfloat162;
+using bfloat16_2 = __nv_bfloat162;
 using DeviceStream = cudaStream_t;
 #define LDG(x) __ldg(x)
 #define HALF2DATA(x) x
+
+inline cudaDeviceProp get_device_properties() {
+
+  int dev = 0;
+  cudaGetDevice(&dev);
+  cudaDeviceProp prop;
+  cudaGetDeviceProperties(&prop, dev);
+
+  return prop;
+}
+
 #endif
 #ifdef DINOML_HIP
 using bfloat16 = __hip_bfloat16;
 using bfloat162 = __hip_bfloat162;
+using bfloat16_2 = __hip_bfloat162;
 using DeviceStream = hipStream_t;
-#define LDG(x) __ldg(x)
+#define LDG(x) *(x)
 #define HALF2DATA(x) x.data
 #endif
 

--- a/csrc/include/dinoml/helpers.h
+++ b/csrc/include/dinoml/helpers.h
@@ -224,6 +224,13 @@ constexpr __host__ __device__ inline integer ceil_div(integer n, integer m) {
   return (n + m - 1) / m;
 }
 
+
+template <typename T1, typename T2>
+constexpr inline T1 round_up_to_multiple(T1 n, T2 m) {
+  return (n + m - 1) / m * m;
+}
+
+
 inline uint64_t make_seed() {
   std::random_device rd;
 

--- a/csrc/include/kernels/flash_attention/flash_attention.h
+++ b/csrc/include/kernels/flash_attention/flash_attention.h
@@ -1,0 +1,113 @@
+#pragma once
+
+#include <stdexcept>
+
+#include <flash_attn/flash_attn_dinoml.h>
+
+#include <dinoml/device.h>
+#include <dinoml/helpers.h>
+#include "mask_type.h"
+#include "model_interface.h"
+
+namespace dinoml {
+
+inline flash::MaskType ConvertMaskType(DinoMLMaskType mask_type) {
+  switch (mask_type) {
+    case DinoMLMaskType::kNone:
+      return flash::MaskType::kNone;
+    case DinoMLMaskType::kCausalFromTopLeft:
+      return flash::MaskType::kCausalFromTopLeft;
+    case DinoMLMaskType::kCausalFromBottomRight:
+      return flash::MaskType::kCausalFromBottomRight;
+    default:
+      throw std::runtime_error("Unhandled MaskType");
+  }
+}
+
+inline flash::DataType ConvertDtype(DinoMLDtype dtype) {
+  switch (dtype) {
+    case DinoMLDtype::kHalf:
+      return flash::DataType::kFloat16;
+    case DinoMLDtype::kBFloat16:
+      return flash::DataType::kBFloat16;
+    default:
+      throw std::runtime_error("Unhandled dtype");
+  }
+}
+
+}
+
+inline void FlashAttention(
+    void* output,
+    int64_t output_batch_stride,
+    int64_t output_row_stride,
+    int64_t output_head_stride,
+    void* q,
+    int64_t q_batch_stride,
+    int64_t q_row_stride,
+    int64_t q_head_stride,
+    void* k,
+    int64_t k_batch_stride,
+    int64_t k_row_stride,
+    int64_t k_head_stride,
+    void* v,
+    int64_t v_batch_stride,
+    int64_t v_row_stride,
+    int64_t v_head_stride,
+    int64_t batch_size,
+    int64_t seqlen_q,
+    int64_t seqlen_k,
+    int64_t num_heads_q,
+    int64_t num_heads_k,
+    int64_t head_dim,
+    dinoml::DinoMLMaskType mask_type,
+    DinoMLDtype dtype,
+    int window_size_left,
+    int window_size_right,
+    void* workspace,
+    dinoml::DeviceStream stream) {
+  auto flash_mask_type = dinoml::ConvertMaskType(mask_type);
+
+  // TODO
+  int32_t num_splits = 1;
+
+  void* softmax_lse_ptr = workspace;
+
+  char* workspace_ptr =
+      static_cast<char*>(workspace) +
+      dinoml::helpers::round_up_to_multiple(
+          batch_size * num_heads_q * seqlen_q * sizeof(float), 16);
+
+  flash::FlashAttentionLauncher(
+      output,
+      output_batch_stride,
+      output_row_stride,
+      output_head_stride,
+      q,
+      q_batch_stride,
+      q_row_stride,
+      q_head_stride,
+      k,
+      k_batch_stride,
+      k_row_stride,
+      k_head_stride,
+      v,
+      v_batch_stride,
+      v_row_stride,
+      v_head_stride,
+      batch_size,
+      seqlen_q,
+      seqlen_k,
+      num_heads_q,
+      num_heads_k,
+      head_dim,
+      flash_mask_type,
+      workspace,
+      dinoml::ConvertDtype(dtype),
+      window_size_left,
+      window_size_right,
+      num_splits,
+      nullptr,
+      nullptr,
+      stream);
+}

--- a/csrc/include/kernels/flash_attention/flash_attention_ck.h
+++ b/csrc/include/kernels/flash_attention/flash_attention_ck.h
@@ -1,0 +1,98 @@
+#pragma once
+
+#include <stdexcept>
+
+#include <flash_attn_ck/flash_attn_dinoml.h>
+
+#include <dinoml/device.h>
+#include <dinoml/helpers.h>
+#include "mask_type.h"
+#include "model_interface.h"
+
+namespace dinoml {
+
+inline MaskType ConvertMaskType(DinoMLMaskType mask_type) {
+  switch (mask_type) {
+    case DinoMLMaskType::kNone:
+      return MaskType::kNone;
+    case DinoMLMaskType::kCausalFromTopLeft:
+      return MaskType::kCausalFromTopLeft;
+    case DinoMLMaskType::kCausalFromBottomRight:
+      return MaskType::kCausalFromBottomRight;
+    default:
+      throw std::runtime_error("Unhandled MaskType");
+  }
+}
+
+inline DataType ConvertDtype(DinoMLDtype dtype) {
+  switch (dtype) {
+    case DinoMLDtype::kHalf:
+      return DataType::kFloat16;
+    case DinoMLDtype::kBFloat16:
+      return DataType::kBFloat16;
+    default:
+      throw std::runtime_error("Unhandled dtype");
+  }
+}
+
+} // namespace dinoml
+
+inline void FlashAttention(
+    void* output,
+    int64_t output_batch_stride,
+    int64_t output_row_stride,
+    int64_t output_head_stride,
+    void* q,
+    int64_t q_batch_stride,
+    int64_t q_row_stride,
+    int64_t q_head_stride,
+    void* k,
+    int64_t k_batch_stride,
+    int64_t k_row_stride,
+    int64_t k_head_stride,
+    void* v,
+    int64_t v_batch_stride,
+    int64_t v_row_stride,
+    int64_t v_head_stride,
+    int64_t batch_size,
+    int64_t seqlen_q,
+    int64_t seqlen_k,
+    int64_t num_heads_q,
+    int64_t num_heads_k,
+    int64_t head_dim,
+    dinoml::DinoMLMaskType mask_type,
+    DinoMLDtype dtype,
+    int window_size_left,
+    int window_size_right,
+    dinoml::DeviceStream stream) {
+  auto flash_mask_type = dinoml::ConvertMaskType(mask_type);
+
+  FlashAttentionLauncher(
+      output,
+      output_batch_stride,
+      output_row_stride,
+      output_head_stride,
+      q,
+      q_batch_stride,
+      q_row_stride,
+      q_head_stride,
+      k,
+      k_batch_stride,
+      k_row_stride,
+      k_head_stride,
+      v,
+      v_batch_stride,
+      v_row_stride,
+      v_head_stride,
+      batch_size,
+      seqlen_q,
+      seqlen_k,
+      num_heads_q,
+      num_heads_k,
+      head_dim,
+      flash_mask_type,
+      dinoml::ConvertDtype(dtype),
+      window_size_left,
+      window_size_right,
+      stream);
+}

--- a/csrc/include/kernels/flash_attention/mask_type.h
+++ b/csrc/include/kernels/flash_attention/mask_type.h
@@ -1,0 +1,5 @@
+#pragma once
+
+namespace dinoml {
+enum class DinoMLMaskType { kNone, kCausalFromTopLeft, kCausalFromBottomRight };
+}

--- a/csrc/include/ops/get_timestep_embedding.h
+++ b/csrc/include/ops/get_timestep_embedding.h
@@ -14,8 +14,8 @@ __device__ __forceinline__ float to_float(const T& x) {
 
 template <typename TOut, typename TIn>
 __global__ void get_timestep_embedding_kernel(
-    TOut* __restrict__ out, // [N, embedding_dim]
-    const TIn* __restrict__ timesteps, // [N]
+    TOut* __restrict__ out,
+    const TIn* __restrict__ timesteps,
     const int64_t n,
     const int embedding_dim,
     const bool flip_sin_to_cos,
@@ -29,7 +29,6 @@ __global__ void get_timestep_embedding_kernel(
 
   const int half_dim = embedding_dim / 2;
 
-  // Handle degenerate case (embedding_dim == 1)
   if (half_dim <= 0) {
     if (threadIdx.x == 0) {
       out[t_idx * (int64_t)embedding_dim] = (TOut)0.0f;
@@ -43,7 +42,6 @@ __global__ void get_timestep_embedding_kernel(
   const float log_max_period = (float)log((float)max_period);
 
   for (int i = threadIdx.x; i < half_dim; i += blockDim.x) {
-    // exponent = -log(max_period) * i / (half_dim - downscale_freq_shift)
     const float exponent = -log_max_period * (float)i * inv_denom;
     const float freq = expf(exponent);
 
@@ -66,7 +64,6 @@ __global__ void get_timestep_embedding_kernel(
     }
   }
 
-  // Zero-pad last column if embedding_dim is odd.
   if ((embedding_dim & 1) && threadIdx.x == 0) {
     out[t_idx * (int64_t)embedding_dim + (embedding_dim - 1)] = (TOut)0.0f;
   }
@@ -85,10 +82,8 @@ void invoke_get_timestep_embedding(
     float scale,
     int max_period,
     dinoml::DeviceStream stream) {
-  // One block per timestep.
   int64_t blocks = n;
 
-  // Threads cover half_dim since we compute pairs (sin/cos) per i.
   int threads = std::min(std::max(embedding_dim / 2, 1), 1024);
 
   dinoml::get_timestep_embedding_kernel<TOut, TIn>

--- a/docs/MODULES.md
+++ b/docs/MODULES.md
@@ -9,7 +9,7 @@ Builders are implemented in `dinoml/builder`.
 ```python
 
 class AutoencoderKLDecodeBuilder(Build):
-    model_name = "autoencoder_kl.{model_type}.{label}.{resolution}.{device_name}.sm{sm}"
+    model_name = "autoencoder_kl.{model_type}.{label}.{resolution}.{device_name}.{sm}"
     model_type = "decode"
     map_function = map_autoencoder_kl
     map_function_skip_keys = (

--- a/scripts/mk_ck_lib/conv2d_operation.py
+++ b/scripts/mk_ck_lib/conv2d_operation.py
@@ -60,7 +60,7 @@ XdlOpTag = {
     XdlOpType.DeviceConv2d_Xdl_CShuffle_Bias_Relu: "ck::tensor_operation::device::DeviceConv2dFwdXdl_C_Shuffle_Bias_Activation_Input_N_Hi_Wi_C_Weight_K_Y_X_C_Output_N_Ho_Wo_K",
     XdlOpType.DeviceConv2d_Xdl_CShuffle_Bias_Relu_Add: "ck::tensor_operation::device::DeviceConv2dFwdXdl_C_Shuffle_Bias_Activation_Add_Input_N_Hi_Wi_C_Weight_K_Y_X_C_Output_N_Ho_Wo_K",
     XdlOpType.DeviceConv2d_Xdl_CShuffle_Bias_Sigmoid: "ck::tensor_operation::device::DeviceConv2dFwdXdl_C_Shuffle_Bias_Activation_Input_N_Hi_Wi_C_Weight_K_Y_X_C_Output_N_Ho_Wo_K",
-    XdlOpType.DeviceGroupedConv2D_Xdl_CShuffle_Bias_Relu: "ck::tensor_operation::device::DeviceGroupedConvFwdMultipleD_Xdl_CShuffle",
+    XdlOpType.DeviceGroupedConv2D_Xdl_CShuffle_Bias_Relu: "ck::tensor_operation::device::DeviceGroupedConvFwdMultipleABD_Xdl_CShuffle",
     XdlOpType.DeviceConvNdBwdDataNwcKxcNwk_Xdl: "ck::tensor_operation::device::DeviceConvNdBwdDataNwcKxcNwk_Xdl",
     XdlOpType.DeviceGroupedConvBwdDataMultipleD_Xdl_CShuffle_v1: "ck::tensor_operation::device::DeviceGroupedConvBwdDataMultipleD_Xdl_CShuffle_v1",
 }

--- a/scripts/mk_ck_lib/groupnorm_operation.py
+++ b/scripts/mk_ck_lib/groupnorm_operation.py
@@ -76,12 +76,13 @@ class GroupNormOperation:
     def emit(self) -> str:
         template = jinja2.Template(
             """
-using {{name}} = ck::tensor_operation::device::DeviceNormalizationImpl<
+using {{name}} = ck::tensor_operation::device::DeviceNormalizationFwdImpl<
     {{InDType}},
     {{InDType}},
     {{InDType}},
     {{AccDType}},
     {{OutDType}},
+    {{InDType}},
     YElementOp,
     {{Rank}},
     {{NumReduceDim}},

--- a/scripts/mk_ck_lib/layernorm_operation.py
+++ b/scripts/mk_ck_lib/layernorm_operation.py
@@ -76,12 +76,13 @@ class LayerNormOperation:
     def emit(self) -> str:
         template = jinja2.Template(
             """
-using {{name}} = ck::tensor_operation::device::DeviceNormalizationImpl<
+using {{name}} = ck::tensor_operation::device::DeviceNormalizationFwdImpl<
     {{InDType}},
     {{InDType}},
     {{InDType}},
     {{AccDType}},
     {{OutDType}},
+    {{InDType}},
     ck::tensor_operation::element_wise::PassThrough,
     {{Rank}},
     {{NumReduceDim}},

--- a/scripts/mk_ck_lib/library.py
+++ b/scripts/mk_ck_lib/library.py
@@ -39,6 +39,7 @@ class DataType(enum.Enum):
 ShortDataTypeNames = {
     DataType.s32: "i",
     DataType.f16: "h",
+    DataType.bf16: "bf",
     DataType.f32: "s",
     DataType.f64: "d",
 }
@@ -305,7 +306,7 @@ class TensorOperation(enum.Enum):
 TensorOperationTag = {
     TensorOperation.PassThrough: "ck::tensor_operation::element_wise::PassThrough",
     TensorOperation.Add: "ck::tensor_operation::element_wise::Add",
-    TensorOperation.AddAdd: "ck::tensor_operation::element_wise::AddAdd",
+    TensorOperation.AddAdd: "ck::tensor_operation::element_wise::AddAdd_",
     TensorOperation.AddMul: "ck::tensor_operation::element_wise::AddMul",
     TensorOperation.AddMulTanh: "ck::tensor_operation::element_wise::AddMulTanh",
     TensorOperation.AlphaBetaAdd: "ck::tensor_operation::element_wise::AlphaBetaAdd",

--- a/scripts/mk_ck_lib/mk_ck_lib.py
+++ b/scripts/mk_ck_lib/mk_ck_lib.py
@@ -37,7 +37,7 @@ def mk_ck_lib(scripts_path, ck_lib_path):
                 name = match.groups()[0]
                 if name + ".py" in code_set:
                     line = "from .{name} import *\n".format(name=name)
-                    
+
             output.append(line)
         with open(dst_path, "w") as fo:
             fo.writelines(output)
@@ -51,9 +51,14 @@ def mk_ck_lib(scripts_path, ck_lib_path):
         process_code(src_path, dst_path, srcs)
     return ck_lib_path
 
+
 def main() -> None:
     scripts_path = pathlib.Path(__file__).parent.resolve()
-    ck_lib_path = pathlib.Path(__file__).parent.resolve().parent.parent.joinpath("src/dinoml/utils/ck_lib")
+    ck_lib_path = (
+        pathlib.Path(__file__)
+        .parent.resolve()
+        .parent.parent.joinpath("src/dinoml/utils/ck_lib")
+    )
     print(scripts_path)
     print(ck_lib_path)
     mk_ck_lib(

--- a/scripts/unet2d_condition_build.py
+++ b/scripts/unet2d_condition_build.py
@@ -12,6 +12,7 @@ builder = UNet2DConditionBuilder(
     },
     model_kwargs={
         "subfolder": "unet",
+        "variant": "fp16",
     },
 )
 builder()

--- a/src/dinoml/backend/backend_spec.py
+++ b/src/dinoml/backend/backend_spec.py
@@ -481,6 +481,7 @@ class ROCMSpec(GPUBackendSpec):
 #include <hip/hip_runtime.h>
 using bfloat16 = __hip_bfloat16;
 using bfloat162 = __hip_bfloat162;
+using bfloat16_2 = __hip_bfloat162;
 {{extra_header}}
         """
     )
@@ -488,6 +489,7 @@ using bfloat162 = __hip_bfloat162;
 
     dtype_to_ck_type: Dict[str, str] = field(
         default_factory=lambda: {
+            "bfloat16": "ck::bhalf_t",
             "float16": "ck::half_t",
             "float32": "float",
             "float": "float",

--- a/src/dinoml/backend/builder.py
+++ b/src/dinoml/backend/builder.py
@@ -453,7 +453,23 @@ clean_constants:
 """
         )
 
+        flash_attn_lib = "../libflash_attention.a"
+        has_flash_attention_lib = False
+        if os.path.exists(flash_attn_lib):
+            has_flash_attention_lib = True
+        has_flash_attention = False
+        for pair in file_pairs:
+            if "flash_attn" in pair[1]:
+                has_flash_attention = True
+                break
+
+        if has_flash_attention and not has_flash_attention_lib:
+            raise ValueError("libflash_attention.a is missing.")
+
         build_so_cmd = "$(CC) -shared $(fPIC_flag) $(CFLAGS) -o $@ $(obj_files)"
+        if has_flash_attention:
+            build_so_cmd += f" {flash_attn_lib}"
+
         standalone_src = "standalone.cu"
         standalone_obj = "standalone.obj"
         windll_obj = "windll.obj"

--- a/src/dinoml/backend/builder.py
+++ b/src/dinoml/backend/builder.py
@@ -453,9 +453,9 @@ clean_constants:
 """
         )
 
-        flash_attn_lib = "../libflash_attention.a"
+        flash_attn_lib = Path(workdir) / "libflash_attention.a"
         has_flash_attention_lib = False
-        if os.path.exists(flash_attn_lib):
+        if flash_attn_lib.exists():
             has_flash_attention_lib = True
         has_flash_attention = False
         for pair in file_pairs:
@@ -468,7 +468,7 @@ clean_constants:
 
         build_so_cmd = "$(CC) -shared $(fPIC_flag) $(CFLAGS) -o $@ $(obj_files)"
         if has_flash_attention:
-            build_so_cmd += f" {flash_attn_lib}"
+            build_so_cmd += f" {flash_attn_lib.resolve().as_posix()}"
 
         standalone_src = "standalone.cu"
         standalone_obj = "standalone.obj"

--- a/src/dinoml/backend/codegen.py
+++ b/src/dinoml/backend/codegen.py
@@ -605,6 +605,11 @@ class ModelContainerGenerator:
         )
         self.set_inputs.append(check_not_null(tensor))
         self._record_param_tensor_info(tensor, self.input_idx)
+        if (
+            self.debug_settings.check_all_outputs
+            or tensor._attrs.get("check_outputs", False)
+        ) and (not isinstance(tensor, IntVarTensor)):
+            self._append_check_outputs(tensor, self.debug_settings.elements_to_check)
         self.input_idx += 1
 
     def _get_output_idx(self, name: str) -> int:

--- a/src/dinoml/backend/common/tensor/arange_common.py
+++ b/src/dinoml/backend/common/tensor/arange_common.py
@@ -112,7 +112,7 @@ def gen_function(func_attrs: Dict[str, Any], header_files: str, backend_spec) ->
         "float32",
         "float16",
         "bfloat16",
-        "int",
+        "int32",
         "int64",
     ]:
         raise NotImplementedError("Unsupported data type for arange " + output_type)

--- a/src/dinoml/backend/cuda/attention/__init__.py
+++ b/src/dinoml/backend/cuda/attention/__init__.py
@@ -16,6 +16,6 @@
 cuda flash_attention module init
 """
 
-from dinoml.backend.cuda.attention import flash_attention, mem_eff_attention
+from dinoml.backend.cuda.attention import flash_attention, mem_eff_attention, flash_attn
 
-__all__ = ["flash_attention", "mem_eff_attention"]
+__all__ = ["flash_attention", "mem_eff_attention", "flash_attn"]

--- a/src/dinoml/backend/cuda/attention/flash_attn.py
+++ b/src/dinoml/backend/cuda/attention/flash_attn.py
@@ -1,0 +1,201 @@
+from typing import Any, Dict
+
+import jinja2
+
+from dinoml.backend import registry
+from dinoml.backend.backend_spec import CUDASpec
+from dinoml.compiler.base import IntImm, IntVar
+
+
+SRC_TEMPLATE = jinja2.Template(
+    """
+#include <dinoml/device.h>
+#include <dinoml/helpers.h>
+
+#include <kernels/flash_attention/flash_attention.h>
+
+void {{function_name}}(
+    void* out,
+    const void* q,
+    const void* k,
+    const void* v,
+    int64_t batch_size,
+    int64_t seqlen_q,
+    int64_t seqlen_k,
+    int64_t num_heads_q,
+    int64_t num_heads_k,
+    int64_t head_dim,
+    void* workspace,
+    dinoml::DeviceStream stream
+) {
+  const int64_t q_head_stride = head_dim;
+  const int64_t q_row_stride  = num_heads_q * head_dim;
+  const int64_t q_batch_stride = seqlen_q * q_row_stride;
+
+  const int64_t k_head_stride = head_dim;
+  const int64_t k_row_stride  = num_heads_k * head_dim;
+  const int64_t k_batch_stride = seqlen_k * k_row_stride;
+
+  const int64_t v_head_stride = head_dim;
+  const int64_t v_row_stride  = num_heads_k * head_dim;
+  const int64_t v_batch_stride = seqlen_k * v_row_stride;
+
+  const int64_t out_head_stride = head_dim;
+  const int64_t out_row_stride  = num_heads_q * head_dim;
+  const int64_t out_batch_stride = seqlen_q * out_row_stride;
+
+  FlashAttention(
+      out,
+      out_batch_stride,
+      out_row_stride,
+      out_head_stride,
+      const_cast<void*>(q),
+      q_batch_stride,
+      q_row_stride,
+      q_head_stride,
+      const_cast<void*>(k),
+      k_batch_stride,
+      k_row_stride,
+      k_head_stride,
+      const_cast<void*>(v),
+      v_batch_stride,
+      v_row_stride,
+      v_head_stride,
+      batch_size,
+      seqlen_q,
+      seqlen_k,
+      num_heads_q,
+      num_heads_k,
+      head_dim,
+      {{mask_type}},
+      {{dtype}},
+      {{window_size_left}},
+      {{window_size_right}},
+      workspace,
+      stream
+  );
+}
+"""
+)
+
+FUNC_DECL_TEMPLATE = jinja2.Template(
+    """
+void {{func_name}}(
+    void*,
+    const void*,
+    const void*,
+    const void*,
+    int64_t,
+    int64_t,
+    int64_t,
+    int64_t,
+    int64_t,
+    int64_t,
+    void*,
+    dinoml::DeviceStream
+);
+"""
+)
+
+FUNC_CALL_TEMPLATE = jinja2.Template(
+    """
+{{indent}}{{func_name}}(
+{{indent}}    {{out}},
+{{indent}}    {{q}},
+{{indent}}    {{k}},
+{{indent}}    {{v}},
+{{indent}}    {{batch_size}},
+{{indent}}    {{seqlen_q}},
+{{indent}}    {{seqlen_k}},
+{{indent}}    {{num_heads_q}},
+{{indent}}    {{num_heads_k}},
+{{indent}}    {{head_dim}},
+{{indent}}    global_workspace_,
+{{indent}}    stream
+{{indent}});
+"""
+)
+
+
+def _dim_to_str(d) -> str:
+    if isinstance(d, IntImm):
+        return str(d._attrs["values"][0])
+    if isinstance(d, IntVar):
+        return d._attrs["name"]
+    raise RuntimeError(f"Expected IntImm/IntVar, got: {type(d)}")
+
+
+def gen_function(func_attrs: Dict[str, Any], backend_spec: CUDASpec) -> str:
+    func_name = func_attrs["name"]
+
+    q = func_attrs["inputs"][0]
+    dtype = q._attrs["dtype"]
+    dtype_map = {
+        "float16": "DinoMLDtype::kHalf",
+        "bfloat16": "DinoMLDtype::kBFloat16",
+    }
+    dtype = dtype_map.get(dtype)
+
+    mask_type = func_attrs.get("mask_type", "none")
+    mask_map = {
+        "none": "dinoml::DinoMLMaskType::kNone",
+        "causal_topleft": "dinoml::DinoMLMaskType::kCausalFromTopLeft",
+        "causal_bottomright": "dinoml::DinoMLMaskType::kCausalFromBottomRight",
+    }
+    mask_type = mask_map.get(mask_type, "dinoml::DinoMLMaskType::kNone")
+
+    return SRC_TEMPLATE.render(
+        function_name=func_name,
+        dtype=dtype,
+        mask_type=mask_type,
+        window_size_left=int(func_attrs.get("window_size_left", -1)),
+        window_size_right=int(func_attrs.get("window_size_right", -1)),
+        num_splits=int(func_attrs.get("num_splits", 0)),
+    )
+
+
+def gen_function_decl(func_attrs: Dict[str, Any], backend_spec: CUDASpec) -> str:
+    return FUNC_DECL_TEMPLATE.render(func_name=func_attrs["name"])
+
+
+def gen_function_call(func_attrs: Dict[str, Any], indent: str = "  ") -> str:
+    q, k, v = func_attrs["inputs"]
+    out = func_attrs["outputs"][0]
+
+    b = _dim_to_str(q._attrs["shape"][0])
+    seqlen_q = _dim_to_str(q._attrs["shape"][1])
+    num_heads_q = _dim_to_str(q._attrs["shape"][2])
+    head_dim = _dim_to_str(q._attrs["shape"][3])
+
+    seqlen_k = _dim_to_str(k._attrs["shape"][1])
+    num_heads_k = _dim_to_str(k._attrs["shape"][2])
+
+    return FUNC_CALL_TEMPLATE.render(
+        func_name=func_attrs["name"],
+        out=out._attrs["name"],
+        q=q._attrs["name"],
+        k=k._attrs["name"],
+        v=v._attrs["name"],
+        batch_size=b,
+        seqlen_q=seqlen_q,
+        seqlen_k=seqlen_k,
+        num_heads_q=num_heads_q,
+        num_heads_k=num_heads_k,
+        head_dim=head_dim,
+        indent=indent,
+    )
+
+
+@registry.reg("cuda.flash_attn.gen_function")
+def cuda_flash_attention_gen_function(func_attrs):
+    return gen_function(func_attrs, CUDASpec())
+
+
+@registry.reg("cuda.flash_attn.func_decl")
+def cuda_flash_attention_gen_function_decl(func_attrs: Dict[str, Any]) -> str:
+    return gen_function_decl(func_attrs, CUDASpec())
+
+
+@registry.reg("cuda.flash_attn.func_call")
+def cuda_flash_attention_func_call(func_attrs, indent="  "):
+    return gen_function_call(func_attrs, indent)

--- a/src/dinoml/backend/cuda/target_def.py
+++ b/src/dinoml/backend/cuda/target_def.py
@@ -30,6 +30,7 @@ from dinoml.backend import registry
 from dinoml.backend.target import (
     DINOML_STATIC_FILES_PATH,
     CUTLASS_PATH,
+    _3RDPARTY_PATH,
     Target,
 )
 
@@ -89,9 +90,15 @@ class CUDA(Target):
             self._dinoml_include_path, "include/kernels"
         )
         dinoml_static_path = os.path.join(self._dinoml_include_path, "include")
+        flash_attn = [
+            str(_3RDPARTY_PATH),
+            os.path.join(_3RDPARTY_PATH, "flash_attn"),
+            os.path.join(str(os.path.join(_3RDPARTY_PATH, "flash_attn")), "src"),
+        ]
 
         output = [dinoml_kernels_static_path, dinoml_static_path]
         output.extend(cutlass_path)
+        output.extend(flash_attn)
         return output
 
     def get_include_directories(self) -> List[str]:

--- a/src/dinoml/backend/registry.py
+++ b/src/dinoml/backend/registry.py
@@ -98,12 +98,16 @@ def get(func_name: str) -> Callable:
     """
     func_override = {"func_decl", "func_call"}
     func_split = func_name.split(".")
+
+    from dinoml.backend.target import Target
+
     if len(func_split) == 3:
         backend, op, func = func_split
-        if op.startswith("conv2d") and func in func_override:
-            op = "conv2d"
-        if op.startswith("transposed_conv2d") and func in func_override:
-            op = "transposed_conv2d"
+        if Target.current().name() == "cuda":
+            if op.startswith("conv2d") and func in func_override:
+                op = "conv2d"
+            if op.startswith("transposed_conv2d") and func in func_override:
+                op = "transposed_conv2d"
         func_name = f"{backend}.{op}.{func}"
     if func_name not in BACKEND_FUNCTIONS:
         raise RuntimeError(f"{func_name} function has not been registered.")

--- a/src/dinoml/backend/rocm/attention/__init__.py
+++ b/src/dinoml/backend/rocm/attention/__init__.py
@@ -13,6 +13,6 @@
 #  limitations under the License.
 #
 
-from dinoml.backend.rocm.attention import mem_eff_attention
+from dinoml.backend.rocm.attention import mem_eff_attention, flash_attn
 
-__all__ = ["mem_eff_attention"]
+__all__ = ["mem_eff_attention", "flash_attn"]

--- a/src/dinoml/backend/rocm/attention/flash_attn.py
+++ b/src/dinoml/backend/rocm/attention/flash_attn.py
@@ -1,0 +1,196 @@
+from typing import Any, Dict
+
+import jinja2
+
+from dinoml.backend import registry
+from dinoml.backend.backend_spec import ROCMSpec
+from dinoml.compiler.base import IntImm, IntVar
+
+
+SRC_TEMPLATE = jinja2.Template(
+    """
+#include <dinoml/device.h>
+#include <dinoml/helpers.h>
+
+#include <kernels/flash_attention/flash_attention_ck.h>
+
+void {{function_name}}(
+    void* out,
+    const void* q,
+    const void* k,
+    const void* v,
+    int64_t batch_size,
+    int64_t seqlen_q,
+    int64_t seqlen_k,
+    int64_t num_heads_q,
+    int64_t num_heads_k,
+    int64_t head_dim,
+    dinoml::DeviceStream stream
+) {
+  const int64_t q_head_stride = head_dim;
+  const int64_t q_row_stride  = num_heads_q * head_dim;
+  const int64_t q_batch_stride = seqlen_q * q_row_stride;
+
+  const int64_t k_head_stride = head_dim;
+  const int64_t k_row_stride  = num_heads_k * head_dim;
+  const int64_t k_batch_stride = seqlen_k * k_row_stride;
+
+  const int64_t v_head_stride = head_dim;
+  const int64_t v_row_stride  = num_heads_k * head_dim;
+  const int64_t v_batch_stride = seqlen_k * v_row_stride;
+
+  const int64_t out_head_stride = head_dim;
+  const int64_t out_row_stride  = num_heads_q * head_dim;
+  const int64_t out_batch_stride = seqlen_q * out_row_stride;
+
+  FlashAttention(
+      out,
+      out_batch_stride,
+      out_row_stride,
+      out_head_stride,
+      const_cast<void*>(q),
+      q_batch_stride,
+      q_row_stride,
+      q_head_stride,
+      const_cast<void*>(k),
+      k_batch_stride,
+      k_row_stride,
+      k_head_stride,
+      const_cast<void*>(v),
+      v_batch_stride,
+      v_row_stride,
+      v_head_stride,
+      batch_size,
+      seqlen_q,
+      seqlen_k,
+      num_heads_q,
+      num_heads_k,
+      head_dim,
+      {{mask_type}},
+      {{dtype}},
+      {{window_size_left}},
+      {{window_size_right}},
+      stream
+  );
+}
+"""
+)
+
+FUNC_DECL_TEMPLATE = jinja2.Template(
+    """
+void {{func_name}}(
+    void*,
+    const void*,
+    const void*,
+    const void*,
+    int64_t,
+    int64_t,
+    int64_t,
+    int64_t,
+    int64_t,
+    int64_t,
+    dinoml::DeviceStream
+);
+"""
+)
+
+FUNC_CALL_TEMPLATE = jinja2.Template(
+    """
+{{indent}}{{func_name}}(
+{{indent}}    {{out}},
+{{indent}}    {{q}},
+{{indent}}    {{k}},
+{{indent}}    {{v}},
+{{indent}}    {{batch_size}},
+{{indent}}    {{seqlen_q}},
+{{indent}}    {{seqlen_k}},
+{{indent}}    {{num_heads_q}},
+{{indent}}    {{num_heads_k}},
+{{indent}}    {{head_dim}},
+{{indent}}    stream
+{{indent}});
+"""
+)
+
+
+def _dim_to_str(d) -> str:
+    if isinstance(d, IntImm):
+        return str(d._attrs["values"][0])
+    if isinstance(d, IntVar):
+        return d._attrs["name"]
+    raise RuntimeError(f"Expected IntImm/IntVar, got: {type(d)}")
+
+
+def gen_function(func_attrs: Dict[str, Any], backend_spec: ROCMSpec) -> str:
+    func_name = func_attrs["name"]
+
+    q = func_attrs["inputs"][0]
+    dtype = q._attrs["dtype"]
+    dtype_map = {
+        "float16": "DinoMLDtype::kHalf",
+        "bfloat16": "DinoMLDtype::kBFloat16",
+    }
+    dtype = dtype_map.get(dtype)
+
+    mask_type = func_attrs.get("mask_type", "none")
+    mask_map = {
+        "none": "dinoml::DinoMLMaskType::kNone",
+        "causal_topleft": "dinoml::DinoMLMaskType::kCausalFromTopLeft",
+        "causal_bottomright": "dinoml::DinoMLMaskType::kCausalFromBottomRight",
+    }
+    mask_type = mask_map.get(mask_type, "dinoml::DinoMLMaskType::kNone")
+
+    return SRC_TEMPLATE.render(
+        function_name=func_name,
+        dtype=dtype,
+        mask_type=mask_type,
+        window_size_left=int(func_attrs.get("window_size_left", -1)),
+        window_size_right=int(func_attrs.get("window_size_right", -1)),
+    )
+
+
+def gen_function_decl(func_attrs: Dict[str, Any], backend_spec: ROCMSpec) -> str:
+    return FUNC_DECL_TEMPLATE.render(func_name=func_attrs["name"])
+
+
+def gen_function_call(func_attrs: Dict[str, Any], indent: str = "  ") -> str:
+    q, k, v = func_attrs["inputs"]
+    out = func_attrs["outputs"][0]
+
+    b = _dim_to_str(q._attrs["shape"][0])
+    seqlen_q = _dim_to_str(q._attrs["shape"][1])
+    num_heads_q = _dim_to_str(q._attrs["shape"][2])
+    head_dim = _dim_to_str(q._attrs["shape"][3])
+
+    seqlen_k = _dim_to_str(k._attrs["shape"][1])
+    num_heads_k = _dim_to_str(k._attrs["shape"][2])
+
+    return FUNC_CALL_TEMPLATE.render(
+        func_name=func_attrs["name"],
+        out=out._attrs["name"],
+        q=q._attrs["name"],
+        k=k._attrs["name"],
+        v=v._attrs["name"],
+        batch_size=b,
+        seqlen_q=seqlen_q,
+        seqlen_k=seqlen_k,
+        num_heads_q=num_heads_q,
+        num_heads_k=num_heads_k,
+        head_dim=head_dim,
+        indent=indent,
+    )
+
+
+@registry.reg("rocm.flash_attn.gen_function")
+def rocm_flash_attention_gen_function(func_attrs):
+    return gen_function(func_attrs, ROCMSpec())
+
+
+@registry.reg("rocm.flash_attn.func_decl")
+def rocm_flash_attention_gen_function_decl(func_attrs: Dict[str, Any]) -> str:
+    return gen_function_decl(func_attrs, ROCMSpec())
+
+
+@registry.reg("rocm.flash_attn.func_call")
+def rocm_flash_attention_func_call(func_attrs, indent="  "):
+    return gen_function_call(func_attrs, indent)

--- a/src/dinoml/backend/rocm/attention/mem_eff_attention.py
+++ b/src/dinoml/backend/rocm/attention/mem_eff_attention.py
@@ -38,8 +38,10 @@ FUNC_TEMPLATE = jinja2.Template(
 #include "logging.h"
 #include "ck/ck.hpp"
 #include "ck/tensor_operation/gpu/device/gemm_specialization.hpp"
+#include "ck/tensor_operation/gpu/element/element_wise_operation.hpp"
+#include "ck/tensor_operation/gpu/device/masking_specialization.hpp"
 #include "ck/tensor_operation/gpu/device/tensor_specialization.hpp"
-#include "ck/tensor_operation/gpu/device/device_grouped_gemm_softmax_gemm_permute_xdl_cshuffle.hpp"
+#include "ck/tensor_operation/gpu/device/impl/device_grouped_gemm_softmax_gemm_permute_xdl_cshuffle.hpp"
 #include "ck/tensor_operation/gpu/element/element_wise_operation.hpp"
 
 
@@ -118,11 +120,11 @@ using DeviceGemmInstance =
         8,           // AK1
         8,           // BK1
         2,           // B1K1
-        32,          // MPerXDL
-        32,          // NPerXDL
-        1,           // MXdlPerWave
-        4,           // NXdlPerWave
-        2,           // Gemm1NXdlPerWave
+        16,          // MPerXDL
+        16,          // NPerXDL
+        2,           // MXdlPerWave
+        8,           // NXdlPerWave
+        4,           // Gemm1NXdlPerWave
         S<4, 64, 1>, // ABlockTransfer
         S<1, 0, 2>,
         S<1, 0, 2>,
@@ -147,7 +149,7 @@ using DeviceGemmInstance =
         1,              // CShuffleMXdlPerWavePerShuffle
         2,              // CShuffleNXdlPerWavePerShuffle
         S<1, 32, 1, 8>, // CShuffleBlockTransferClusterLengths_MBlock_MPerBlock_NBlock_NPerBlock
-        8,              // CShuffleBlockTransferScalarPerVector_NPerBlock
+        4,              // CShuffleBlockTransferScalarPerVector_NPerBlock
 {% if is_causal %}
         MaskingSpec_causal
 {% else %}
@@ -179,8 +181,8 @@ using DeviceGemmInstance =
     std::vector<void*> output_ptrs;
 
     for(int64_t i = 0; i < batch_size ; i++){
-        int M = seqlens[i];
-        int N = seqlens[i];
+        int M = seqlen;
+        int N = seqlen;
         int K = head_dim;
         int O = head_dim;
         int G0 = 1;
@@ -271,8 +273,7 @@ void {{func_name}}(void* output,
                    const void* q,
                    const void* k,
                    const void* v,
-                   const int* seqlens,
-                   const int max_seqlen,
+                   const int seqlen,
                    int64_t batch_size,
                    int num_heads,
                    int head_dim,
@@ -291,8 +292,8 @@ FUNC_DECL = jinja2.Template(
 FUNC_CALL_TEMPLATE = jinja2.Template(
     """
 {{indent}}{{func_name}}(
-{{indent}}   {{output}}, {{q}}, {{k}}, {{v}}, {{seqlens}},
-{{indent}}    {{max_seqlen}}, {{batch_size}},
+{{indent}}   {{output}}, {{q}}, {{k}}, {{v}}, {{seqlen}},
+{{indent}}    {{batch_size}},
 {{indent}}    {{num_heads}},
 {{indent}}    {{head_dim}},
 {{indent}}    {{softmax_scale}},
@@ -329,7 +330,6 @@ def mem_eff_attention_gen_function_decl(func_attrs: Dict[str, Any]):
 def mem_eff_attention_gen_function_call(func_attrs, indent="  "):
     """the function for generating a function call for attention"""
     assert len(func_attrs["outputs"]) == 1
-    assert len(func_attrs["inputs"]) in [4, 5]
 
     output_name = func_attrs["outputs"][0]._attrs["name"]
 
@@ -337,18 +337,14 @@ def mem_eff_attention_gen_function_call(func_attrs, indent="  "):
     k_name = func_attrs["inputs"][1]._attrs["name"]
     v_name = func_attrs["inputs"][2]._attrs["name"]
 
-    seqlens_name = FUNC_CALL_INT32_PARAM_TEMPLATE.render(
-        name=func_attrs["inputs"][3]._attrs["name"]
-    )
-
     q = func_attrs["inputs"][0]
 
-    batch_size = func_attrs["inputs"][3].shape()[0]._attrs["name"]
-    num_heads = q._attrs["shape"][1]._attrs["values"][0]
-    max_seqlen = q._attrs["shape"][0].upper_bound() // 16
-    head_dim = q._attrs["shape"][3]._attrs["values"][0]
+    batch_size = q._attrs["shape"][0]._attrs["name"]
+    num_heads = q._attrs["shape"][1]._attrs["name"]
+    seqlen = q._attrs["shape"][2]._attrs["name"]
+    head_dim = q._attrs["shape"][3]._attrs["name"]
 
-    softmax_scale = head_dim ** (-0.5)
+    softmax_scale = q._attrs["shape"][3].value() ** (-0.5)
 
     return FUNC_CALL_TEMPLATE.render(
         func_name=func_attrs["name"],
@@ -356,8 +352,7 @@ def mem_eff_attention_gen_function_call(func_attrs, indent="  "):
         q=q_name,
         k=k_name,
         v=v_name,
-        seqlens=seqlens_name,
-        max_seqlen=max_seqlen,
+        seqlen=seqlen,
         batch_size=batch_size,
         num_heads=num_heads,
         head_dim=head_dim,

--- a/src/dinoml/backend/rocm/builder_cmake.py
+++ b/src/dinoml/backend/rocm/builder_cmake.py
@@ -74,7 +74,10 @@ set(WorkaroundCmakeCompileOptions {{CMAKE_COMPILE_OPTIONS}})
 # compile a supplemental library
 add_library(objlib OBJECT ${SOURCE_FILES} ${THIRD_PARTY_SOURCE_FILES})
 target_include_directories(objlib PRIVATE ${HEADER_FILES} ${THIRD_PARTY_HEADER_FILES})
-target_link_libraries(objlib  PRIVATE hip-lang::device)
+target_link_libraries(objlib  PRIVATE
+hip-lang::host
+hip-lang::device
+)
 target_compile_options(objlib PRIVATE ${WorkaroundCmakeCompileOptions})
 set_target_properties(objlib PROPERTIES LINKER_LANGUAGE CXX CXX_STANDARD 17)
 
@@ -82,7 +85,12 @@ set_target_properties(objlib PROPERTIES LINKER_LANGUAGE CXX CXX_STANDARD 17)
 # compile model library
 add_library(model SHARED $<TARGET_OBJECTS:objlib>)
 target_include_directories(model PRIVATE ${HEADER_FILES} ${THIRD_PARTY_HEADER_FILES})
+{% if has_flash_attention %}
+find_library(flash_attention NAMES flash_attention HINTS {{flash_attention_dir}})
+target_link_libraries(model  PRIVATE hip-lang::device ${flash_attention})
+{% else %}
 target_link_libraries(model  PRIVATE hip-lang::device)
+{% endif %}
 target_compile_options(model PRIVATE ${WorkaroundCmakeCompileOptions})
 set_target_properties(model PROPERTIES LINKER_LANGUAGE CXX CXX_STANDARD 17)
 
@@ -94,6 +102,9 @@ CMAKELISTS_TXT_PROFILER_TEMPLATE = """
 cmake_minimum_required(VERSION 3.21)
 cmake_policy(VERSION 3.21.3...3.27)
 project({{CMAKE_PROJECT}} LANGUAGES  CXX HIP)
+
+set (HIP_PLATFORM amd CACHE STRING "HIP Platform")
+
 find_package(hip-lang REQUIRED)
 find_package(rocrand REQUIRED)
 
@@ -120,7 +131,8 @@ set(WorkaroundCmakeCompileOptions {{CMAKE_COMPILE_OPTIONS}})
 add_executable(profiler ${SOURCE_FILES} ${THIRD_PARTY_SOURCE_FILES})
 target_include_directories(profiler PRIVATE ${HEADER_FILES} ${THIRD_PARTY_HEADER_FILES})
 target_compile_options(profiler PRIVATE ${WorkaroundCmakeCompileOptions})
-target_link_libraries(profiler PRIVATE hip-lang::device roc::rocrand)
+link_directories(${_IMPORT_PREFIX}/lib)
+target_link_libraries(profiler PRIVATE amdhip64 rocrand)
 set_target_properties(profiler PROPERTIES LINKER_LANGUAGE CXX CXX_STANDARD 17)
 """
 
@@ -248,9 +260,7 @@ class BuilderCMake:
             # execute cmake
             cmake_build_dir = build_dir / "build"
             cmake_cmd = Target.current().cmake()
-            prefix_path = os.environ["HIP_PATH"]
-            prefix_path = os.environ["HIP_PATH"].replace("\\", "/")
-            cmake_command_line = f'{_render_path(cmake_cmd)} -DCMAKE_BUILD_TYPE=Release -D CMAKE_PREFIX_PATH={prefix_path}  -B {_render_path(cmake_build_dir)} -S {_render_path(build_dir)} -G "Ninja"'
+            cmake_command_line = f'{_render_path(cmake_cmd)} -D CMAKE_PREFIX_PATH="C:/TheRock/" -D CMAKE_CXX_COMPILER="C:/TheRock/bin/hipcc.exe" -DCMAKE_RC_COMPILER="C:/Program Files (x86)/Windows Kits/10/bin/10.0.22621.0/x64/rc.exe" -D CMAKE_BUILD_TYPE=Release -D GPU_TARGETS="gfx1201"  -B {_render_path(cmake_build_dir)} -S {_render_path(build_dir)} -G "Ninja"'
             _run_cmd(cmake_command_line, self._timeout)
 
             # execute build system
@@ -295,6 +305,19 @@ class BuilderCMake:
             _LOGGER.warning("Caching is not yet supported")
 
         build_dir = Path(workdir) / test_name
+
+        flash_attn_lib = Path(workdir) / "flash_attention.lib"
+        has_flash_attention_lib = False
+        if flash_attn_lib.exists():
+            has_flash_attention_lib = True
+        has_flash_attention = False
+        for pair in file_pairs:
+            if "flash_attn" in pair[1]:
+                has_flash_attention = True
+                break
+
+        if has_flash_attention and not has_flash_attention_lib:
+            raise ValueError("flash_attention.lib is missing.")
 
         cmake_template = jinja2.Template(CMAKELISTS_TXT_TEMPLATE)
 
@@ -345,6 +368,8 @@ class BuilderCMake:
             cuda_static=is_windows(),
             is_linux=is_linux(),
             build_standalone=debug_settings.gen_standalone,
+            has_flash_attention=has_flash_attention,
+            flash_attention_dir=Path(workdir).resolve().as_posix(),
         )
 
         cmake_filename = build_dir / "CMakeLists.txt"
@@ -356,8 +381,7 @@ class BuilderCMake:
         # execute cmake
         cmake_build_dir = build_dir / "build"
         cmake_cmd = Target.current().cmake()
-        prefix_path = os.environ["HIP_PATH"].replace("\\", "/")
-        cmake_command_line = f'{_render_path(cmake_cmd)} -DCMAKE_BUILD_TYPE=Release -D CMAKE_PREFIX_PATH={prefix_path}  -B {_render_path(cmake_build_dir)} -S {_render_path(build_dir)} -G "Ninja"'
+        cmake_command_line = f'{_render_path(cmake_cmd)} -D CMAKE_PREFIX_PATH="C:/TheRock/" -D CMAKE_CXX_COMPILER="C:/TheRock/bin/hipcc.exe" -DCMAKE_RC_COMPILER="C:/Program Files (x86)/Windows Kits/10/bin/10.0.22621.0/x64/rc.exe" -D CMAKE_BUILD_TYPE=Release -D GPU_TARGETS="gfx1201"  -B {_render_path(cmake_build_dir)} -S {_render_path(build_dir)} -G "Ninja"'
         _run_cmd(cmake_command_line, self._timeout)
 
         # execute build system

--- a/src/dinoml/backend/rocm/conv2d/common.py
+++ b/src/dinoml/backend/rocm/conv2d/common.py
@@ -23,6 +23,7 @@ from hashlib import sha1
 
 import jinja2
 
+from dinoml.backend.backend_spec import ROCMSpec
 from dinoml.backend.target import Target
 
 # pylint: disable=C0103,C0415,W0611,C0301
@@ -36,17 +37,17 @@ using {{name}} = {{ config_name }};
 )
 PROBLEM_ARGS_TEMPLATE = jinja2.Template(
     """
-{{indent}}                                static_cast<ck::half_t *>(in_ptr),
-{{indent}}                                static_cast<ck::half_t *>(weight_ptr),
+{{indent}}                                static_cast<{{dtype}} *>(in_ptr),
+{{indent}}                                static_cast<{{dtype}} *>(weight_ptr),
 
 {% if conv2d_flag == "" %}
 {{indent}}                                {},
 {% elif conv2d_flag in ["bias", "bias_relu", "bias_sigmoid"] %}
-{{indent}}                                std::array<const void*, 1>{static_cast<ck::half_t *>(bias_ptr)},
+{{indent}}                                std::array<const void*, 1>{static_cast<{{dtype}} *>(bias_ptr)},
 {% elif conv2d_flag in ["bias_add_relu", "bias_add_identity"] %}
-{{indent}}                                std::array<const void*, 2>{static_cast<ck::half_t *>(bias_ptr), static_cast<ck::half_t *>(res_ptr)},
+{{indent}}                                std::array<const void*, 2>{static_cast<{{dtype}} *>(bias_ptr), static_cast<{{dtype}} *>(res_ptr)},
 {% endif %}
-{{indent}}                                static_cast<ck::half_t *>(out_ptr),
+{{indent}}                                static_cast<{{dtype}} *>(out_ptr),
 {{indent}}                                a_g_n_c_wis_lengths,
 {{indent}}                                a_g_n_c_wis_strides,
 {{indent}}                                b_g_k_c_xs_lengths,
@@ -77,7 +78,7 @@ PROBLEM_ARGS_TEMPLATE = jinja2.Template(
 {% elif conv2d_flag == "bias_sigmoid" %}
 {{indent}}                                ck::tensor_operation::element_wise::AddSigmoid{}
 {% elif conv2d_flag == "bias_add_identity" %}
-{{indent}}                                ck::tensor_operation::element_wise::AddAdd{}
+{{indent}}                                ck::tensor_operation::element_wise::AddAdd_{}
 {% elif conv2d_flag == "bias_add_relu" %}
 {{indent}}                                ck::tensor_operation::element_wise::AddAddRelu{}
 {% endif %}
@@ -92,7 +93,9 @@ EXEC_TEMPLATE = jinja2.Template(
 {{problem_args}}
 {{indent}});
 {{indent}}if(!op.IsSupportedArgument(argument)) {
-{{indent}}  LOG(FATAL) << "wrong! " << op.GetTypeString() << " with the specified compilation parameters does not support this Conv problem.";
+{{indent}}  throw std::runtime_error(
+{{indent}}  "wrong! Conv with the specified compilation parameters does "
+{{indent}}  "not support this Conv problem");
 {{indent}}}
 {% if is_profiler %}
 {{indent}}auto workspace_size = op.GetWorkSpaceSize(&argument);
@@ -105,7 +108,50 @@ EXEC_TEMPLATE = jinja2.Template(
 
 HEADER_CODE = jinja2.Template(
     """
-#include "ck/tensor_operation/gpu/device/impl/device_grouped_conv_fwd_multiple_d_xdl_cshuffle.hpp"
+#include "ck/tensor_operation/gpu/device/impl/device_grouped_conv_fwd_multiple_abd_xdl_cshuffle.hpp"
+
+#include "ck/utility/data_type.hpp"
+
+namespace ck {
+namespace tensor_operation {
+namespace element_wise {
+namespace {
+
+// C = A * B
+// E = C + D0 + D1
+struct AddAdd_
+{
+    static constexpr const char* name = "AddAdd";
+
+    template <typename E, typename C, typename D0, typename D1>
+    __host__ __device__ void operator()(E& e, const C& c, const D0& d0, const D1& d1) const
+    {
+        // Only support floating so far
+        static_assert(is_same<E, half_t>::value || is_same<E, bhalf_t>::value || is_same<E, float>::value ||
+                          is_same<E, double>::value,
+                      "Data type is not supported by this operation!");
+
+        static_assert(is_same<C, half_t>::value || is_same<C, bhalf_t>::value || is_same<C, float>::value ||
+                          is_same<C, double>::value,
+                      "Data type is not supported by this operation!");
+
+        static_assert(is_same<D0, half_t>::value || is_same<D0, bhalf_t>::value || is_same<D0, float>::value ||
+                          is_same<D0, double>::value,
+                      "Data type is not supported by this operation!");
+
+        static_assert(is_same<D1, half_t>::value || is_same<D1, bhalf_t>::value || is_same<D1, float>::value ||
+                          is_same<D1, double>::value,
+                      "Data type is not supported by this operation!");
+
+        const C y = c + type_convert<C>(d0) + type_convert<C>(d1);
+        e         = type_convert<E>(y);
+    }
+};
+
+} // namespace
+} // namespace element_wise
+} // namespace tensor_operation
+} // namespace ck
 """
 )
 
@@ -116,11 +162,9 @@ SRC_TEMPLATE = jinja2.Template(
 #include <initializer_list>
 #include <cstdlib>
 #include <stdlib.h>
-// #include <half.hpp>
 #include <random>
 #include <rocrand/rocrand.h>
 #include "logging.h"
-//include "ck/utility/print.hpp"
 #include "ck/library/utility/device_memory.hpp"
 #include "ck/library/utility/host_tensor.hpp"
 #include "ck/library/utility/host_tensor_generator.hpp"
@@ -242,6 +286,58 @@ void {{function_name}}(
 """
 )
 
+
+PROFILER_SRC_TEMPLATE = jinja2.Template(
+    """
+#include <iostream>
+#include <numeric>
+#include <initializer_list>
+#include <cstdlib>
+#include <stdlib.h>
+#include <random>
+#include <rocrand/rocrand.h>
+#include "logging.h"
+#include "ck/library/utility/device_memory.hpp"
+#include "ck/library/utility/host_tensor.hpp"
+#include "ck/library/utility/host_tensor_generator.hpp"
+#include "ck/tensor_operation/gpu/device/tensor_layout.hpp"
+#include "ck/tensor_operation/gpu/element/element_wise_operation.hpp"
+
+
+struct KernelTimerImpl
+{
+  KernelTimerImpl() {
+    hipGetErrorString(hipEventCreateWithFlags(&mStart, hipEventDisableSystemFence));
+    hipGetErrorString(hipEventCreateWithFlags(&mEnd, hipEventDisableSystemFence));
+  }
+  ~KernelTimerImpl() {
+    hipGetErrorString(hipEventDestroy(mStart));
+    hipGetErrorString(hipEventDestroy(mEnd));
+  }
+  void Start() {
+    hipGetErrorString(hipDeviceSynchronize());
+    hipGetErrorString(hipEventRecord(mStart, nullptr));
+  }
+  void End() {
+    hipGetErrorString(hipEventRecord(mEnd, nullptr));
+    hipGetErrorString(hipEventSynchronize(mEnd));
+  }
+  float GetElapsedTime() const {
+    float time;
+    hipGetErrorString(hipEventElapsedTime(&time, mStart, mEnd));
+    return time;
+  }
+  hipEvent_t mStart, mEnd;
+};
+
+{{extra_code}}
+
+{{instances}}
+
+"""
+)
+
+
 FUNC_CALL_TEMPLATE = jinja2.Template(
     """
 {{indent}}{{func_name}}(
@@ -323,25 +419,23 @@ struct ProfilerMemoryPool {
     strides.reserve(512);
     copies.reserve(512);
     ptrs.reserve(512);
+    rocrand_status st = rocrand_create_generator(&generator, ROCRAND_RNG_PSEUDO_DEFAULT);
+    if(st != ROCRAND_STATUS_SUCCESS) {
+      throw std::runtime_error("rocrand_create_generator failed");
+    }
   }
   ~ProfilerMemoryPool() {
     for(int i = 0; i < ptrs.size(); i++){
-      if (hipFree(&ptrs[i]) != hipSuccess) {
-      // ...
-      }
+      hipFree(ptrs[i]);
     }
+    if(generator) rocrand_destroy_generator(generator);
   }
 
   template <typename DType>
   DType* AllocateGaussianTensor(int64_t size) {
     size_t length = size * sizeof(DType);
     DType *d_x;
-    //hipMalloc(&d_x, length);
-    if (hipMalloc(&d_x, length) != hipSuccess) {
-      throw std::runtime_error(
-          " ROCMWorkspace: hipMalloc( " + std::to_string(length) +
-          " ) failed.");
-    }
+    hipMalloc(&d_x, length);
 
     float mean = 0.0f;
     float stddev = 1.0f;
@@ -351,9 +445,9 @@ struct ProfilerMemoryPool {
     return d_x;
   }
 
-  ck::half_t* AllocateHalfGaussianTensor(int64_t size) {
-    return reinterpret_cast<ck::half_t*>(
-        AllocateGaussianTensor<ck::half_t>(size));
+  {{dtype}}* AllocateHalfGaussianTensor(int64_t size) {
+    return reinterpret_cast<{{dtype}}*>(
+        AllocateGaussianTensor<float>(size));
   }
 
   int AllocateHalfTensor(int64_t size, int64_t copy) {
@@ -365,11 +459,11 @@ struct ProfilerMemoryPool {
     return ptrs.size() - 1;
   }
 
-  ck::half_t* RequestHalfTensorByIdx(int idx) {
+  {{dtype}}* RequestHalfTensorByIdx(int idx) {
     auto copy = copies.at(idx);
     auto offset = offsets.at(idx);
     auto stride = strides.at(idx);
-    ck::half_t* ptr = reinterpret_cast<ck::half_t*>(ptrs.at(idx));
+    {{dtype}}* ptr = reinterpret_cast<{{dtype}}*>(ptrs.at(idx));
     ptr += offset;
     offset += stride;
     if (offset == copy * stride) {
@@ -387,46 +481,8 @@ struct ProfilerMemoryPool {
   rocrand_generator generator;
 };
 
-
 """
 )
-
-PROFILER_TEMPLATE = jinja2.Template(
-    """
-size_t GLOBAL_WORKSPACE_SIZE = 0;
-{{op_func}}
-
-{{structs_def}}
-
-int main(int argc, char** argv) {
-  if (argc < 10) {
-    throw std::runtime_error("wrong params");
-  }
-  {{args_parse}}
-  {{shape_func}}
-  auto memory_pool = std::make_unique<ProfilerMemoryPool>();
-  hipStream_t stream = nullptr;
-  {{tensor_decl}}
-  // TODO: random init
-  // warmup
-  for(int i = 0; i < 3; ++i) {
-    {{func_call}}
-  }
-  // run
-  auto timer = new KernelTimerImpl();
-  timer->Start();
-  for(int i = 0; i < 5; ++i) {
-    {{func_call}}
-  }
-  timer->End();
-  std::cout << "OP:" << "{{op_name}}" << ",";
-  std::cout << "TIME:" << timer->GetElapsedTime() << ",";
-  std::cout << "WS:" << GLOBAL_WORKSPACE_SIZE << std::endl;
-  delete(timer);
-}
-"""
-)
-
 
 FUNC_DECL_TEMPLATE = jinja2.Template(
     """
@@ -459,6 +515,170 @@ void {{func_name}}(
 """
 )
 
+PROFILER_TEMPLATE = jinja2.Template(
+    r"""
+template <typename Instance>
+int benchmark_conv(
+  Instance& device_instance,
+  const char* op_name,
+  void* in_ptr,
+  void* weight_ptr,
+  void* out_ptr,
+{% if "bias" in conv2d_flag %}
+  void* bias_ptr,
+{% endif %}
+{% if conv2d_flag in ["bias_add_relu", "bias_add_identity"] %}
+  void* res_ptr,
+{% endif %}
+  int64_t* batch,
+  int64_t* out_ch,
+  int64_t* in_ch,
+  int64_t* kernel_h,
+  int64_t* kernel_w,
+  int64_t* in_h,
+  int64_t* in_w,
+  int64_t* out_batch,
+  int64_t* out_h,
+  int64_t* out_w,
+  int64_t stride,
+  int64_t dilation,
+  int64_t pad,
+  int64_t group,
+  hipStream_t stream)
+{
+  int C_ = (*in_ch) / group;
+  int K_ = (*out_ch) / group;
+  int N_ = (*batch);
+  const int NDimSpatial = 2;
+
+  std::array<ck::index_t, NDimSpatial + 3> a_g_n_c_wis_lengths{
+    static_cast<ck::index_t>(group),
+    static_cast<ck::index_t>(N_),
+    static_cast<ck::index_t>(C_),
+    static_cast<ck::index_t>(*in_h),
+    static_cast<ck::index_t>(*in_w)
+  };
+
+  std::array<ck::index_t, NDimSpatial + 3> a_g_n_c_wis_strides{
+    static_cast<ck::index_t>(C_),
+    static_cast<ck::index_t>((*in_h) * (*in_w) * group * C_),
+    static_cast<ck::index_t>(1),
+    static_cast<ck::index_t>((*in_w) * group * C_),
+    static_cast<ck::index_t>(group * C_)
+  };
+
+  std::array<ck::index_t, NDimSpatial + 3> b_g_k_c_xs_lengths{
+    static_cast<ck::index_t>(group),
+    static_cast<ck::index_t>(K_),
+    static_cast<ck::index_t>(C_),
+    static_cast<ck::index_t>(*kernel_h),
+    static_cast<ck::index_t>(*kernel_w)
+  };
+
+  std::array<ck::index_t, NDimSpatial + 3> b_g_k_c_xs_strides{
+    static_cast<ck::index_t>((*kernel_h) * (*kernel_w) * C_ * K_),
+    static_cast<ck::index_t>((*kernel_h) * (*kernel_w) * C_),
+    static_cast<ck::index_t>(1),
+    static_cast<ck::index_t>((*kernel_w) * C_),
+    static_cast<ck::index_t>(C_)
+  };
+
+  std::array<ck::index_t, NDimSpatial + 3> d_g_n_k_wos_lengths{
+    static_cast<ck::index_t>(group),
+    static_cast<ck::index_t>(N_),
+    static_cast<ck::index_t>(K_),
+    static_cast<ck::index_t>(*out_h),
+    static_cast<ck::index_t>(*out_w)
+  };
+  std::array<ck::index_t, NDimSpatial + 3> d_g_n_k_wos_strides{
+    static_cast<ck::index_t>(K_), 0, 1, 0, 0
+  };
+
+  std::array<ck::index_t, NDimSpatial + 3> e_g_n_k_wos_lengths{
+    static_cast<ck::index_t>(group),
+    static_cast<ck::index_t>(N_),
+    static_cast<ck::index_t>(K_),
+    static_cast<ck::index_t>(*out_h),
+    static_cast<ck::index_t>(*out_w)
+  };
+
+  std::array<ck::index_t, NDimSpatial + 3> e_g_n_k_wos_strides{
+    static_cast<ck::index_t>(K_),
+    static_cast<ck::index_t>((*out_h) * (*out_w) * group * K_),
+    static_cast<ck::index_t>(1),
+    static_cast<ck::index_t>((*out_w) * group * K_),
+    static_cast<ck::index_t>(group * K_)
+  };
+
+  std::array<ck::index_t, NDimSpatial> conv_filter_strides{
+    static_cast<ck::index_t>(stride), static_cast<ck::index_t>(stride)
+  };
+  std::array<ck::index_t, NDimSpatial> conv_filter_dilations{
+    static_cast<ck::index_t>(dilation), static_cast<ck::index_t>(dilation)
+  };
+  std::array<ck::index_t, NDimSpatial> input_left_pads{
+    static_cast<ck::index_t>(pad), static_cast<ck::index_t>(pad)
+  };
+  std::array<ck::index_t, NDimSpatial> input_right_pads{
+    static_cast<ck::index_t>(pad), static_cast<ck::index_t>(pad)
+  };
+
+  auto invoker = device_instance.MakeInvoker();
+
+  auto argument = device_instance.MakeArgument(
+    {{problem_args}}
+  );
+
+  if(!device_instance.IsSupportedArgument(argument)) {
+    return -1;
+  }
+
+  auto workspace_size = device_instance.GetWorkSpaceSize(&argument);
+
+  // warmup
+  for(int i = 0; i < 3; ++i) {
+    invoker.Run(argument, StreamConfig{stream, false});
+  }
+
+  KernelTimerImpl timer;
+  timer.Start();
+  for(int i = 0; i < 5; ++i) {
+    invoker.Run(argument, StreamConfig{stream, false});
+  }
+  timer.End();
+
+  std::cout << "OP:" << op_name << ",";
+  std::cout << "TIME:" << timer.GetElapsedTime() << ",";
+  std::cout << "WS:" << workspace_size << std::endl 
+              << std::flush;
+
+  return 0;
+}
+"""
+)
+
+PROFILE_CALL_TEMPLATE = jinja2.Template(
+    r"""
+{
+  {{instance_type}} device_instance;
+  benchmark_conv(
+  device_instance,
+  "{{op_name}}",
+  (void*)memory_pool->RequestHalfTensorByIdx(0),
+  (void*)memory_pool->RequestHalfTensorByIdx(1),
+  (void*)memory_pool->RequestHalfTensorByIdx(2),
+{% if "bias" in conv2d_flag %}
+  (void*)memory_pool->RequestHalfTensorByIdx(3),
+{% endif %}
+{% if conv2d_flag in ["bias_add_relu", "bias_add_identity"] %}
+  (void*)memory_pool->RequestHalfTensorByIdx(4),
+{% endif %}
+  &NI, &CO, &CI, &KH, &KW, &HI, &WI, &NO, &HO, &WO,
+  SH, DH, PH, group, stream);
+}
+"""
+)
+
 
 def emit_instance(op):
     """Emits instance."""
@@ -468,7 +688,11 @@ def emit_instance(op):
     return op_def
 
 
-def extract_config(op_kind, extra_kind):
+def extract_config(
+    op_kind,
+    extra_kind,
+    dtype="float16",
+):
     """
     Parameters
     ----------
@@ -486,10 +710,44 @@ def extract_config(op_kind, extra_kind):
     """
     import dinoml.utils.ck_lib as ck_lib  # noqa: F401
 
+    spec = ROCMSpec()
+    lib_dtype = spec.dtype_to_lib_type(dtype)
+
+    if lib_dtype == "float":
+        data_type = ck_lib.library.DataType.f32
+        acc_type = ck_lib.library.DataType.f32
+    elif lib_dtype == "ck::half_t":
+        data_type = ck_lib.library.DataType.f16
+        acc_type = ck_lib.library.DataType.f32
+        # check target use fp16 acc
+        if (
+            "use_fp16_acc" in Target.current()._kwargs
+            and Target.current().name() != "rocm"
+        ):
+            if Target.current()._kwargs["use_fp16_acc"]:
+                acc_type = ck_lib.library.DataType.f16
+    elif lib_dtype == "ck::bhalf_t":
+        data_type = ck_lib.library.DataType.bf16
+        acc_type = ck_lib.library.DataType.f32
+    else:
+        raise RuntimeError(f"Unsupported dtype {lib_dtype}")
+
+    def f_proc_op(op: ck_lib.conv2d_operation.Conv2DOperation):
+        if (
+            op.A.element == data_type
+            and op.B.element == data_type
+            and op.C.element == data_type
+            and op.acc_dtype == acc_type
+        ):
+            return op
+        return None
+
     conv2d_ops = OrderedDict()
     extract_ops = list(Target.current()._operators[op_kind][extra_kind].items())
     for key, value in extract_ops:
-        conv2d_ops[key] = value[0]
+        op = value[0]
+        if f_proc_op(op) is not None:
+            conv2d_ops[key] = op
     return conv2d_ops
 
 
@@ -524,28 +782,21 @@ def gen_profiler(
     shape_template,
     conv2d_flag,
     extra_code="",
-    src_template=SRC_TEMPLATE,
+    src_template=PROFILER_SRC_TEMPLATE,
     prob_args_template=PROBLEM_ARGS_TEMPLATE,
+    profile_filename=None,
 ):
-    """Generates standalone executables for profiler.
+    x = func_attrs["inputs"][0]
+    spec = ROCMSpec()
+    lib_dtype = spec.dtype_to_lib_type(x._attrs["dtype"])
 
-    Parameters
-    ----------
-    func_attrs : Dict
-        Operation attributes.
-    workdir : str
-        Directory to store the generated outputs.
-    shape_template : jinja2.Template
-        Generates shape calculation.
-        The template is passed from compiler/ops/pool.
-    conv2d_flag : str
-        Flag telling which backend should be generated. options are '','bias','bias_relu','bias_add_relu','bias_add_identity'.
-    extra_code : str
-        Extra code for self-defined operators.
-    """
     op_type = func_attrs["op"]
+    prefix = os.path.join(workdir, "profiler", op_type)
+    src_path = os.path.join(prefix, f"{profile_filename}.cpp")
+    obj_path = os.path.join(prefix, profile_filename)
+    if os.path.exists(obj_path):
+        return
     op_instance = func_attrs["op_instance"]
-    # shape function
     shape_func = shape_template.render(
         indent="  ",
         dtype="int64_t ",
@@ -564,78 +815,94 @@ def gen_profiler(
         dilatew="dilation",
         padw="pad",
     )
-    file_pairs = []
-    for op_name, op in op_instance.items():
+
+    instances_code = []
+    profile_calls = []
+
+    for i, (op_name, op) in enumerate(op_instance.items()):
         config = emit_instance(op)
         config_name = extract_config_name(config)
-        instance = INSTANCE_TEMPLATE.render(
-            name="DeviceConvFwdInstance", config_name=config_name, config=config
-        )
-        problem_args = prob_args_template.render(
-            indent="  ",
-            conv2d_flag=conv2d_flag,
-        )
-        exec_program = EXEC_TEMPLATE.render(
-            indent="  ",
-            instance="DeviceConvFwdInstance",
-            problem_args=problem_args,
-            is_profiler=True,
-        )
-        op_func = src_template.render(
-            instances=instance,
-            function_name="conv",
-            shape_func="",
-            exec_paths=exec_program,
-            extra_code=extra_code,
-            conv2d_flag=conv2d_flag,
-        )
-        structs_def = STRUCTS_DEF_TEMPLATE.render()
-        args_parse = ARGS_PARSE_TEMPLATE.render()
-        tensor_decl = TENSOR_DECL_TEMPLATE.render(conv2d_flag=conv2d_flag)
-        func_call = FUNC_CALL_TEMPLATE.render(
-            func_name="conv",
-            in_ptr="(void *) memory_pool->RequestHalfTensorByIdx(0)",
-            weight_ptr="(void *) memory_pool->RequestHalfTensorByIdx(1)",
-            out_ptr="(void *) memory_pool->RequestHalfTensorByIdx(2)",
-            bias_ptr="(void *) memory_pool->RequestHalfTensorByIdx(3)",
-            res_ptr="(void *) memory_pool->RequestHalfTensorByIdx(4)",
-            p_batch="&NI",
-            p_out_ch="&CO",
-            p_in_ch="&CI",
-            p_kernel_h="&KH",
-            p_kernel_w="&KW",
-            p_in_h="&HI",
-            p_in_w="&WI",
-            p_out_batch="&NO",
-            p_out_h="&HO",
-            p_out_w="&WO",
-            stride="SH",
-            dilation="DH",
-            pad="PH",
-            group="group",
-            conv2d_flag=conv2d_flag,
+
+        instance_typedef_name = f"DeviceConvFwdInstance_{i}"
+
+        instances_code.append(
+            INSTANCE_TEMPLATE.render(
+                name=instance_typedef_name,
+                config_name=config_name,
+                config=config,
+            )
         )
 
-        code = PROFILER_TEMPLATE.render(
-            structs_def=structs_def,
-            op_func=op_func,
-            shape_func=shape_func,
-            args_parse=args_parse,
-            tensor_decl=tensor_decl,
-            func_call=func_call,
-            op_name=op_name,
+        profile_calls.append(
+            PROFILE_CALL_TEMPLATE.render(
+                instance_type=instance_typedef_name,
+                op_name=op_name,
+                conv2d_flag=conv2d_flag,
+            )
         )
-        prefix = os.path.join(workdir, "profiler", op_type)
-        if not os.path.exists(prefix):
-            os.makedirs(prefix)
-        src_path = os.path.join(prefix, op_name + ".cpp")
-        obj_path = os.path.join(prefix, op_name)
-        if os.path.exists(obj_path):
-            continue
-        with open(src_path, "w") as fo:
-            fo.write(code)
-        file_pairs.append((src_path, obj_path))
-    return file_pairs
+
+    instances = "\n".join(instances_code)
+    calls = "\n".join(profile_calls)
+
+    problem_args = prob_args_template.render(
+        indent="  ", conv2d_flag=conv2d_flag, dtype=lib_dtype
+    )
+
+    profile_one = PROFILER_TEMPLATE.render(
+        conv2d_flag=conv2d_flag,
+        problem_args=problem_args,
+    )
+
+    op_func = src_template.render(
+        instances=instances + "\n" + profile_one,
+        shape_func="",
+        exec_paths="",
+        extra_code=extra_code,
+        conv2d_flag=conv2d_flag,
+    )
+
+    structs_def = STRUCTS_DEF_TEMPLATE.render(dtype=lib_dtype)
+    args_parse = ARGS_PARSE_TEMPLATE.render()
+    tensor_decl = TENSOR_DECL_TEMPLATE.render(conv2d_flag=conv2d_flag)
+
+    code = jinja2.Template(
+        r"""
+size_t GLOBAL_WORKSPACE_SIZE = 0;
+{{op_func}}
+
+{{structs_def}}
+
+int main(int argc, char** argv) {
+  if (argc < 12) {
+    throw std::runtime_error("wrong params");
+  }
+
+  {{args_parse}}
+  {{shape_func}}
+
+  auto memory_pool = std::make_unique<ProfilerMemoryPool>();
+  hipStream_t stream = nullptr;
+
+  {{tensor_decl}}
+
+  {{calls}}
+}
+"""
+    ).render(
+        op_func=op_func,
+        structs_def=structs_def,
+        args_parse=args_parse,
+        shape_func=shape_func,
+        tensor_decl=tensor_decl,
+        calls=calls,
+    )
+
+    os.makedirs(prefix, exist_ok=True)
+
+    with open(src_path, "w") as fo:
+        fo.write(code)
+
+    return [(src_path, obj_path)]
 
 
 def gen_function(
@@ -672,6 +939,10 @@ def gen_function(
     str
         The rendered template of generated function body.
     """
+    x = func_attrs["inputs"][0]
+    spec = ROCMSpec()
+    lib_dtype = spec.dtype_to_lib_type(x._attrs["dtype"])
+
     func_name = func_attrs["name"]
     exec_path = func_attrs["exec_path"]
     op_instance = func_attrs["op_instance"]
@@ -724,6 +995,7 @@ def gen_function(
         problem_args = prob_args_template.render(
             indent="    ",
             conv2d_flag=conv2d_flag,
+            dtype=lib_dtype,
         )
         program = EXEC_TEMPLATE.render(
             indent="    ",

--- a/src/dinoml/backend/rocm/conv2d/conv2d.py
+++ b/src/dinoml/backend/rocm/conv2d/conv2d.py
@@ -23,7 +23,7 @@ from dinoml.backend.rocm.conv2d import common
 
 
 @registry.reg("rocm.conv2d.config")
-def conv2d_config(func_attrs):
+def conv2d_config(func_attrs, **kwargs):
     """Extract (operation name, operation instance) pair from
     all operation candidates.
 
@@ -40,13 +40,16 @@ def conv2d_config(func_attrs):
     """
     import dinoml.utils.ck_lib as ck_lib
 
+    x = func_attrs["inputs"][0]
+    dtype = x._attrs["dtype"]
+
     op_kind = ck_lib.library.Conv2dKind.GroupConv2dBiasRelu
     extra_kind = ck_lib.library.TensorOperation.PassThrough
-    func_attrs["op_instance"] = common.extract_config(op_kind, extra_kind)
+    func_attrs["op_instance"] = common.extract_config(op_kind, extra_kind, dtype=dtype)
 
 
 @registry.reg("rocm.conv2d.gen_profiler")
-def conv2d_gen_profiler(func_attrs, workdir, shape_template):
+def conv2d_gen_profiler(func_attrs, workdir, profile_filename, shape_template):
     """Generates standalone executables for profiler.
 
     Parameters
@@ -65,6 +68,7 @@ def conv2d_gen_profiler(func_attrs, workdir, shape_template):
         shape_template=shape_template,
         conv2d_flag="",
         extra_code=common.HEADER_CODE.render(),
+        profile_filename=profile_filename,
     )
 
 

--- a/src/dinoml/backend/rocm/conv2d/conv2d_bias.py
+++ b/src/dinoml/backend/rocm/conv2d/conv2d_bias.py
@@ -23,7 +23,7 @@ from dinoml.backend.rocm.conv2d import common
 
 
 @registry.reg("rocm.conv2d_bias.config")
-def conv2d_config(func_attrs):
+def conv2d_config(func_attrs, **kwargs):
     """Extract (operation name, operation instance) pair from
     all operation candidates.
 
@@ -40,13 +40,16 @@ def conv2d_config(func_attrs):
     """
     import dinoml.utils.ck_lib as ck_lib
 
+    x = func_attrs["inputs"][0]
+    dtype = x._attrs["dtype"]
+
     op_kind = ck_lib.library.Conv2dKind.GroupConv2dBiasRelu
     extra_kind = ck_lib.library.TensorOperation.Add
-    func_attrs["op_instance"] = common.extract_config(op_kind, extra_kind)
+    func_attrs["op_instance"] = common.extract_config(op_kind, extra_kind, dtype=dtype)
 
 
 @registry.reg("rocm.conv2d_bias.gen_profiler")
-def conv2d_gen_profiler(func_attrs, workdir, shape_template):
+def conv2d_gen_profiler(func_attrs, workdir, profile_filename, shape_template):
     """Generates standalone executables for profiler.
 
     Parameters
@@ -65,6 +68,7 @@ def conv2d_gen_profiler(func_attrs, workdir, shape_template):
         shape_template=shape_template,
         conv2d_flag="bias",
         extra_code=common.HEADER_CODE.render(),
+        profile_filename=profile_filename,
     )
 
 

--- a/src/dinoml/backend/rocm/conv2d/conv2d_bias_add.py
+++ b/src/dinoml/backend/rocm/conv2d/conv2d_bias_add.py
@@ -23,22 +23,26 @@ from . import common
 
 
 @registry.reg("rocm.conv2d_bias_add_identity.config")
-def conv2d_config(func_attrs):
+def conv2d_config(func_attrs, **kwargs):
     import dinoml.utils.ck_lib as ck_lib
+
+    x = func_attrs["inputs"][0]
+    dtype = x._attrs["dtype"]
 
     op_kind = ck_lib.library.Conv2dKind.GroupConv2dBiasRelu
     extra_kind = ck_lib.library.TensorOperation.AddAdd
-    func_attrs["op_instance"] = common.extract_config(op_kind, extra_kind)
+    func_attrs["op_instance"] = common.extract_config(op_kind, extra_kind, dtype=dtype)
 
 
 @registry.reg("rocm.conv2d_bias_add_identity.gen_profiler")
-def gen_profiler(func_attrs, workdir, shape_template):
+def gen_profiler(func_attrs, workdir, profile_filename, shape_template):
     return common.gen_profiler(
         func_attrs=func_attrs,
         workdir=workdir,
         shape_template=shape_template,
         conv2d_flag="bias_add_identity",
         extra_code=common.HEADER_CODE.render(),
+        profile_filename=profile_filename,
     )
 
 

--- a/src/dinoml/backend/rocm/conv2d/conv2d_bias_add_relu.py
+++ b/src/dinoml/backend/rocm/conv2d/conv2d_bias_add_relu.py
@@ -25,18 +25,51 @@ from dinoml.backend.rocm.conv2d import common
 
 EXTRA_CODE = jinja2.Template(
     """
-#include "ck/tensor_operation/gpu/device/impl/device_grouped_conv_fwd_multiple_d_xdl_cshuffle.hpp"
+#include "ck/tensor_operation/gpu/device/impl/device_grouped_conv_fwd_multiple_abd_xdl_cshuffle.hpp"
 
 
 namespace ck {
 namespace tensor_operation {
 namespace element_wise {
 namespace {
+
+
+// C = A * B
+// E = C + D0 + D1
+struct AddAdd_
+{
+    static constexpr const char* name = "AddAdd";
+
+    template <typename E, typename C, typename D0, typename D1>
+    __host__ __device__ void operator()(E& e, const C& c, const D0& d0, const D1& d1) const
+    {
+        // Only support floating so far
+        static_assert(is_same<E, half_t>::value || is_same<E, bhalf_t>::value || is_same<E, float>::value ||
+                          is_same<E, double>::value,
+                      "Data type is not supported by this operation!");
+
+        static_assert(is_same<C, half_t>::value || is_same<C, bhalf_t>::value || is_same<C, float>::value ||
+                          is_same<C, double>::value,
+                      "Data type is not supported by this operation!");
+
+        static_assert(is_same<D0, half_t>::value || is_same<D0, bhalf_t>::value || is_same<D0, float>::value ||
+                          is_same<D0, double>::value,
+                      "Data type is not supported by this operation!");
+
+        static_assert(is_same<D1, half_t>::value || is_same<D1, bhalf_t>::value || is_same<D1, float>::value ||
+                          is_same<D1, double>::value,
+                      "Data type is not supported by this operation!");
+
+        const C y = c + type_convert<C>(d0) + type_convert<C>(d1);
+        e         = type_convert<E>(y);
+    }
+};
+
 struct AddAddRelu
 {
     template <typename T>
     __host__ __device__ constexpr void operator()(T& y, const T& x0, const T& x1, const T& x2) const{
-        ck::tensor_operation::element_wise::AddAdd{}(y, x0, x1, x2);
+        ck::tensor_operation::element_wise::AddAdd_{}(y, x0, x1, x2);
         ck::tensor_operation::element_wise::Relu{}(y, y);
     };
 };
@@ -49,7 +82,7 @@ struct AddAddRelu
 
 
 @registry.reg("rocm.conv2d_bias_add_relu.config")
-def conv2d_config(func_attrs):
+def conv2d_config(func_attrs, **kwargs):
     """Extracts (operation name, operation instance) pair from
     all operation candidates.
 
@@ -66,13 +99,16 @@ def conv2d_config(func_attrs):
     """
     import dinoml.utils.ck_lib as ck_lib
 
+    x = func_attrs["inputs"][0]
+    dtype = x._attrs["dtype"]
+
     op_kind = ck_lib.library.Conv2dKind.GroupConv2dBiasRelu
     extra_kind = ck_lib.library.TensorOperation.AddAddRelu
-    func_attrs["op_instance"] = common.extract_config(op_kind, extra_kind)
+    func_attrs["op_instance"] = common.extract_config(op_kind, extra_kind, dtype=dtype)
 
 
 @registry.reg("rocm.conv2d_bias_add_relu.gen_profiler")
-def conv2d_gen_profiler(func_attrs, workdir, shape_template):
+def conv2d_gen_profiler(func_attrs, workdir, profile_filename, shape_template):
     """Generates standalone executables for profiler.
 
     Parameters
@@ -92,6 +128,7 @@ def conv2d_gen_profiler(func_attrs, workdir, shape_template):
         shape_template=shape_template,
         conv2d_flag="bias_add_relu",
         extra_code=extra_code,
+        profile_filename=profile_filename,
     )
 
 

--- a/src/dinoml/backend/rocm/conv2d/conv2d_bias_relu.py
+++ b/src/dinoml/backend/rocm/conv2d/conv2d_bias_relu.py
@@ -23,7 +23,7 @@ from dinoml.backend.rocm.conv2d import common
 
 
 @registry.reg("rocm.conv2d_bias_relu.config")
-def conv2d_config(func_attrs):
+def conv2d_config(func_attrs, **kwargs):
     """Extracts (operation name, operation instance) pair from
     all operation candidates.
 
@@ -41,13 +41,16 @@ def conv2d_config(func_attrs):
     """
     import dinoml.utils.ck_lib as ck_lib
 
+    x = func_attrs["inputs"][0]
+    dtype = x._attrs["dtype"]
+
     op_kind = ck_lib.library.Conv2dKind.GroupConv2dBiasRelu
     extra_kind = ck_lib.library.TensorOperation.AddRelu
-    func_attrs["op_instance"] = common.extract_config(op_kind, extra_kind)
+    func_attrs["op_instance"] = common.extract_config(op_kind, extra_kind, dtype=dtype)
 
 
 @registry.reg("rocm.conv2d_bias_relu.gen_profiler")
-def conv2d_gen_profiler(func_attrs, workdir, shape_template):
+def conv2d_gen_profiler(func_attrs, workdir, profile_filename, shape_template):
     """Generates standalone executables for profiler.
 
     Parameters
@@ -66,6 +69,7 @@ def conv2d_gen_profiler(func_attrs, workdir, shape_template):
         shape_template=shape_template,
         conv2d_flag="bias_relu",
         extra_code=common.HEADER_CODE.render(),
+        profile_filename=profile_filename,
     )
 
 

--- a/src/dinoml/backend/rocm/conv2d/conv2d_bias_sigmoid.py
+++ b/src/dinoml/backend/rocm/conv2d/conv2d_bias_sigmoid.py
@@ -25,7 +25,7 @@ from dinoml.backend.rocm.conv2d import common
 
 EXTRA_CODE = jinja2.Template(
     """
-#include "ck/tensor_operation/gpu/device/impl/device_grouped_conv_fwd_multiple_d_xdl_cshuffle.hpp"
+#include "ck/tensor_operation/gpu/device/impl/device_grouped_conv_fwd_multiple_abd_xdl_cshuffle.hpp"
 
 #include "ck/utility/data_type.hpp"
 
@@ -68,7 +68,7 @@ struct AddSigmoid
 
 
 @registry.reg("rocm.conv2d_bias_sigmoid.config")
-def conv2d_config(func_attrs):
+def conv2d_config(func_attrs, **kwargs):
     """Extracts (operation name, operation instance) pair from
     all operation candidates.
 
@@ -86,13 +86,16 @@ def conv2d_config(func_attrs):
     """
     import dinoml.utils.ck_lib as ck_lib
 
+    x = func_attrs["inputs"][0]
+    dtype = x._attrs["dtype"]
+
     op_kind = ck_lib.library.Conv2dKind.GroupConv2dBiasRelu
     extra_kind = ck_lib.library.TensorOperation.AddSigmoid
-    func_attrs["op_instance"] = common.extract_config(op_kind, extra_kind)
+    func_attrs["op_instance"] = common.extract_config(op_kind, extra_kind, dtype=dtype)
 
 
 @registry.reg("rocm.conv2d_bias_sigmoid.gen_profiler")
-def conv2d_gen_profiler(func_attrs, workdir, shape_template):
+def conv2d_gen_profiler(func_attrs, workdir, profile_filename, shape_template):
     """Generates standalone executables for profiler.
 
     Parameters
@@ -111,6 +114,7 @@ def conv2d_gen_profiler(func_attrs, workdir, shape_template):
         shape_template=shape_template,
         conv2d_flag="bias_sigmoid",
         extra_code=EXTRA_CODE.render(),
+        profile_filename=profile_filename,
     )
 
 

--- a/src/dinoml/backend/rocm/conv2d/transposed_conv2d.py
+++ b/src/dinoml/backend/rocm/conv2d/transposed_conv2d.py
@@ -50,7 +50,7 @@ PROBLEM_ARGS_TEMPLATE = jinja2.Template(
 
 
 @registry.reg("rocm.transposed_conv2d.config")
-def conv2d_config(func_attrs):
+def conv2d_config(func_attrs, **kwargs):
     """Extract (operation name, operation instance) pair from
     all operation candidates.
 
@@ -73,7 +73,7 @@ def conv2d_config(func_attrs):
 
 
 @registry.reg("rocm.transposed_conv2d.gen_profiler")
-def conv2d_gen_profiler(func_attrs, workdir, shape_template):
+def conv2d_gen_profiler(func_attrs, workdir, profile_filename, shape_template):
     """Generates standalone executables for profiler.
 
     Parameters
@@ -93,6 +93,7 @@ def conv2d_gen_profiler(func_attrs, workdir, shape_template):
         conv2d_flag="",
         prob_args_template=PROBLEM_ARGS_TEMPLATE,
         extra_code=EXTRA_CODE.render(),
+        profile_filename=profile_filename,
     )
 
 

--- a/src/dinoml/backend/rocm/conv2d/transposed_conv2d_bias_relu.py
+++ b/src/dinoml/backend/rocm/conv2d/transposed_conv2d_bias_relu.py
@@ -32,7 +32,7 @@ EXTRA_CODE = jinja2.Template(
 
 
 @registry.reg("rocm.transposed_conv2d_bias_relu.config")
-def conv2d_config(func_attrs):
+def conv2d_config(func_attrs, **kwargs):
     """Extract (operation name, operation instance) pair from
     all operation candidates.
 
@@ -56,7 +56,7 @@ def conv2d_config(func_attrs):
 
 
 @registry.reg("rocm.transposed_conv2d_bias_relu.gen_profiler")
-def conv2d_gen_profiler(func_attrs, workdir, shape_template):
+def conv2d_gen_profiler(func_attrs, workdir, profile_filename, shape_template):
     """Generates standalone executables for profiler.
 
     Parameters
@@ -75,6 +75,7 @@ def conv2d_gen_profiler(func_attrs, workdir, shape_template):
         shape_template=shape_template,
         conv2d_flag="bias_relu",
         extra_code=EXTRA_CODE.render(),
+        profile_filename=profile_filename,
     )
 
 

--- a/src/dinoml/backend/rocm/elementwise/__init__.py
+++ b/src/dinoml/backend/rocm/elementwise/__init__.py
@@ -12,6 +12,6 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 #
-from dinoml.backend.rocm.elementwise import fused_elementwise
+from dinoml.backend.rocm.elementwise import fused_elementwise, int_elementwise
 
-__all__ = ["fused_elementwise"]
+__all__ = ["fused_elementwise", "int_elementwise"]

--- a/src/dinoml/backend/rocm/elementwise/int_elementwise.py
+++ b/src/dinoml/backend/rocm/elementwise/int_elementwise.py
@@ -1,0 +1,68 @@
+#  Copyright 2025 hlky. All rights reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+"""
+IntElementwise codegen for rocm.
+"""
+
+import jinja2
+
+from dinoml.backend import registry
+
+from dinoml.backend.backend_spec import CPUBackendSpec
+
+from dinoml.compiler.base import IntVarTensor
+
+
+INT_VAR_FUNC_TEMPLATE = jinja2.Template(
+    """
+      {{lhs}} = {{rhs}};
+"""
+)
+
+
+@registry.reg("rocm.int_elementwise.gen_function")
+def dummpy_int_elementwise_gen_function(func_attrs):
+    return ""
+
+
+@registry.reg("rocm.int_elementwise.func_decl")
+def dummpy_int_elementwise_gen_function_decl(func_attrs):
+    return ""
+
+
+@registry.reg("rocm.int_elementwise.func_call")
+def int_elementwise_gen_function_call(func_attrs, indent):
+    """Generates int_elementwise function call."""
+    func_enum = func_attrs["func"]
+    inputs = func_attrs["inputs"]
+    outputs = func_attrs["outputs"]
+    assert len(outputs) == 1, (
+        f"Elementwise op for IntVarTensor should only generate 1 output, got {len(outputs)}"
+    )
+    input_params_vec = []
+    for inp in inputs:
+        assert isinstance(inp, IntVarTensor), (
+            f"only inputs of IntVarTensor are allowed for OP with output of IntVarTensor, got type{inp}"
+        )
+        input_params_vec.append(inp._attrs["int_var"]._attrs["name"])
+    backend_spec = CPUBackendSpec()
+    op = backend_spec.func_enum_to_func_name.get(func_enum)
+    rhs = op.join(input_params_vec)
+    lhs = outputs[0]._attrs["name"]
+    func_call = INT_VAR_FUNC_TEMPLATE.render(
+        lhs=lhs,
+        rhs=rhs,
+    )
+    return func_call

--- a/src/dinoml/backend/rocm/gemm/bmm_ccr.py
+++ b/src/dinoml/backend/rocm/gemm/bmm_ccr.py
@@ -140,7 +140,7 @@ def bmm_gen_function_decl(func_attrs):
         The rentered template of function declaration.
     """
     func_name = func_attrs["name"]
-    return bmm_common.gen_function_decl(func_name=func_name, gemm_flag="")
+    return bmm_common.gen_function_decl(func_attrs, gemm_flag="")
 
 
 @registry.reg("rocm.bmm_ccr.func_call")

--- a/src/dinoml/backend/rocm/gemm/bmm_ccr_add.py
+++ b/src/dinoml/backend/rocm/gemm/bmm_ccr_add.py
@@ -140,7 +140,7 @@ def bmm_gen_function_decl(func_attrs):
         The rentered template of function declaration.
     """
     func_name = func_attrs["name"]
-    return bmm_common.gen_function_decl(func_name=func_name, gemm_flag="add")
+    return bmm_common.gen_function_decl(func_attrs, gemm_flag="add")
 
 
 @registry.reg("rocm.bmm_ccr_add.func_call")

--- a/src/dinoml/backend/rocm/gemm/bmm_common.py
+++ b/src/dinoml/backend/rocm/gemm/bmm_common.py
@@ -72,12 +72,12 @@ EXTRA_HEADER_TEMPLATE_MULTI_D = jinja2.Template(
 
 PROBLEM_ARGS_TEMPLATE = jinja2.Template(
     """
-{{indent}}                                static_cast<ck::half_t *>(in_ptr) + offset_a,
-{{indent}}                                static_cast<ck::half_t *>(weight_ptr) + offset_b,
+{{indent}}                                static_cast<{{dtype}} *>(in_ptr) + offset_a,
+{{indent}}                                static_cast<{{dtype}} *>(weight_ptr) + offset_b,
 {% if "bias" in gemm_flag %}
-{{indent}}                                std::array<const void*, 1>{static_cast<ck::half_t *>(bias_ptr)},
+{{indent}}                                std::array<const void*, 1>{static_cast<{{dtype}} *>(bias_ptr)},
 {% endif %}
-{{indent}}                                static_cast<ck::half_t *>(out_ptr) + offset_c,
+{{indent}}                                static_cast<{{dtype}} *>(out_ptr) + offset_c,
 {{indent}}                                M,
 {{indent}}                                N,
 {{indent}}                                K,
@@ -107,14 +107,14 @@ PROBLEM_ARGS_TEMPLATE = jinja2.Template(
 
 PROBLEM_ARGS_TEMPLATE_MULTI_D = jinja2.Template(
     """
-{{indent}}                                static_cast<ck::half_t *>(in_ptr),
-{{indent}}                                static_cast<ck::half_t *>(weight_ptr),
+{{indent}}                                static_cast<{{dtype}} *>(in_ptr),
+{{indent}}                                static_cast<{{dtype}} *>(weight_ptr),
 {% if "bias" in gemm_flag or gemm_flag == "add" %}
-{{indent}}                                std::array<const void*, 1>{static_cast<ck::half_t *>(bias_ptr)},
+{{indent}}                                std::array<const void*, 1>{static_cast<{{dtype}} *>(bias_ptr)},
 {% else %}
 {{indent}}                                {},
 {% endif %}
-{{indent}}                                static_cast<ck::half_t *>(out_ptr),
+{{indent}}                                static_cast<{{dtype}} *>(out_ptr),
 {{indent}}                                M,
 {{indent}}                                N,
 {{indent}}                                K,

--- a/src/dinoml/backend/rocm/gemm/bmm_crr.py
+++ b/src/dinoml/backend/rocm/gemm/bmm_crr.py
@@ -140,7 +140,7 @@ def bmm_gen_function_decl(func_attrs):
         The rentered template of function declaration.
     """
     func_name = func_attrs["name"]
-    return bmm_common.gen_function_decl(func_name=func_name, gemm_flag="")
+    return bmm_common.gen_function_decl(func_attrs, gemm_flag="")
 
 
 @registry.reg("rocm.bmm_crr.func_call")

--- a/src/dinoml/backend/rocm/gemm/bmm_crr_add.py
+++ b/src/dinoml/backend/rocm/gemm/bmm_crr_add.py
@@ -140,7 +140,7 @@ def bmm_gen_function_decl(func_attrs):
         The rentered template of function declaration.
     """
     func_name = func_attrs["name"]
-    return bmm_common.gen_function_decl(func_name=func_name, gemm_flag="add")
+    return bmm_common.gen_function_decl(func_attrs, gemm_flag="add")
 
 
 @registry.reg("rocm.bmm_crr_add.func_call")

--- a/src/dinoml/backend/rocm/gemm/bmm_permute_common.py
+++ b/src/dinoml/backend/rocm/gemm/bmm_permute_common.py
@@ -37,12 +37,12 @@ EXTRA_SHAPE_TEMPLATE = jinja2.Template(
 
 PROBLEM_ARGS_TEMPLATE = jinja2.Template(
     """
-{{indent}}                                static_cast<ck::half_t *>(in_ptr),
-{{indent}}                                static_cast<ck::half_t *>(weight_ptr),
+{{indent}}                                static_cast<{{dtype}} *>(in_ptr),
+{{indent}}                                static_cast<{{dtype}} *>(weight_ptr),
 {% if "bias" in gemm_flag %}
-{{indent}}                                std::array<const void*, 1>{static_cast<ck::half_t *>(bias_ptr)},
+{{indent}}                                std::array<const void*, 1>{static_cast<{{dtype}} *>(bias_ptr)},
 {% endif %}
-{{indent}}                                static_cast<ck::half_t *>(out_ptr),
+{{indent}}                                static_cast<{{dtype}} *>(out_ptr),
 {{indent}}                                M,
 {{indent}}                                N,
 {{indent}}                                K,

--- a/src/dinoml/backend/rocm/gemm/bmm_rcr.py
+++ b/src/dinoml/backend/rocm/gemm/bmm_rcr.py
@@ -140,7 +140,7 @@ def bmm_gen_function_decl(func_attrs):
         The rentered template of function declaration.
     """
     func_name = func_attrs["name"]
-    return bmm_common.gen_function_decl(func_name=func_name, gemm_flag="")
+    return bmm_common.gen_function_decl(func_attrs, gemm_flag="")
 
 
 @registry.reg("rocm.bmm_rcr.func_call")

--- a/src/dinoml/backend/rocm/gemm/bmm_rrr.py
+++ b/src/dinoml/backend/rocm/gemm/bmm_rrr.py
@@ -140,7 +140,7 @@ def bmm_gen_function_decl(func_attrs):
         The rentered template of function declaration.
     """
     func_name = func_attrs["name"]
-    return bmm_common.gen_function_decl(func_name=func_name, gemm_flag="")
+    return bmm_common.gen_function_decl(func_attrs, gemm_flag="")
 
 
 @registry.reg("rocm.bmm_rrr.func_call")

--- a/src/dinoml/backend/rocm/gemm/bmm_rrr_add.py
+++ b/src/dinoml/backend/rocm/gemm/bmm_rrr_add.py
@@ -140,7 +140,7 @@ def bmm_gen_function_decl(func_attrs):
         The rentered template of function declaration.
     """
     func_name = func_attrs["name"]
-    return bmm_common.gen_function_decl(func_name=func_name, gemm_flag="add")
+    return bmm_common.gen_function_decl(func_attrs, gemm_flag="add")
 
 
 @registry.reg("rocm.bmm_rrr_add.func_call")

--- a/src/dinoml/backend/rocm/gemm/bmm_softmax_bmm.py
+++ b/src/dinoml/backend/rocm/gemm/bmm_softmax_bmm.py
@@ -21,6 +21,7 @@ This is used for `ops.bmm_rcr`.
 import jinja2
 
 from dinoml.backend import registry
+from dinoml.backend.backend_spec import ROCMSpec
 from dinoml.backend.rocm.gemm import bmm_common, common
 from dinoml.backend.rocm.gemm.layout import RCR
 
@@ -28,7 +29,7 @@ EXTRA_CODE = jinja2.Template(
     """
 #include "ck/utility/data_type.hpp"
 
-const ck::half_t alpha = {{scale}};
+const {{dtype}} alpha = {{scale}};
 
 namespace ck {
 namespace tensor_operation {
@@ -38,7 +39,7 @@ struct AttnMul
 {
     AttnMul(){};
 
-    __host__ __device__ void operator()(ck::half_t& e, const ck::half_t& c) const
+    __host__ __device__ void operator()({{dtype}}& e, const {{dtype}}& c) const
     {
         float s = {{scale}};
         e = c * type_convert<half_t>(s);
@@ -78,10 +79,10 @@ EXTRA_HEADER_TEMPLATE = jinja2.Template(
 
 PROBLEM_ARGS_TEMPLATE = jinja2.Template(
     """
-{{indent}}                                static_cast<ck::half_t *>(in_ptr),
-{{indent}}                                static_cast<ck::half_t *>(weight_ptr),
-{{indent}}                                static_cast<ck::half_t *>(bias_ptr),
-{{indent}}                                static_cast<ck::half_t *>(out_ptr),
+{{indent}}                                static_cast<{{dtype}} *>(in_ptr),
+{{indent}}                                static_cast<{{dtype}} *>(weight_ptr),
+{{indent}}                                static_cast<{{dtype}} *>(bias_ptr),
+{{indent}}                                static_cast<{{dtype}} *>(out_ptr),
 {{indent}}                                M,
 {{indent}}                                N,
 {{indent}}                                K,
@@ -187,6 +188,10 @@ def bmm_gen_profiler(func_attrs, workdir, profiler_name, dim_info_dict):
         Generated from bmm._extract_dims().
         Used to store mapping between dim_names to input / output tensor dims.
     """
+    x = func_attrs["inputs"][0]
+    spec = ROCMSpec()
+    lib_dtype = spec.dtype_to_lib_type(x._attrs["dtype"])
+
     return bmm_common.gen_profiler(
         func_attrs=func_attrs,
         workdir=workdir,
@@ -197,7 +202,7 @@ def bmm_gen_profiler(func_attrs, workdir, profiler_name, dim_info_dict):
         tensor_decl_template=TENSOR_DECL_TEMPLATE,
         problem_args_template=PROBLEM_ARGS_TEMPLATE,
         extra_shape_template=EXTRA_SHAPE_TEMPLATE,
-        extra_code=EXTRA_CODE.render(scale=func_attrs["scale"]),
+        extra_code=EXTRA_CODE.render(scale=func_attrs["scale"], dtype=lib_dtype),
     )
 
 
@@ -220,6 +225,10 @@ def bmm_gen_function(func_attrs, exec_cond_template, dim_info_dict):
     str
         The rendered template of generated function body.
     """
+    x = func_attrs["inputs"][0]
+    spec = ROCMSpec()
+    lib_dtype = spec.dtype_to_lib_type(x._attrs["dtype"])
+
     return bmm_common.gen_function(
         func_attrs,
         exec_cond_template,
@@ -228,7 +237,7 @@ def bmm_gen_function(func_attrs, exec_cond_template, dim_info_dict):
         problem_args_template=PROBLEM_ARGS_TEMPLATE,
         extra_shape_template=EXTRA_SHAPE_TEMPLATE,
         extra_header_template=EXTRA_HEADER_TEMPLATE,
-        extra_code=EXTRA_CODE.render(scale=func_attrs["scale"]),
+        extra_code=EXTRA_CODE.render(scale=func_attrs["scale"], dtype=lib_dtype),
     )
 
 
@@ -247,7 +256,7 @@ def bmm_gen_function_decl(func_attrs):
         The rentered template of function declaration.
     """
     func_name = func_attrs["name"]
-    return bmm_common.gen_function_decl(func_name=func_name, gemm_flag="bias_b1")
+    return bmm_common.gen_function_decl(func_attrs, gemm_flag="bias_b1")
 
 
 @registry.reg("rocm.bmm_softmax_bmm.func_call")

--- a/src/dinoml/backend/rocm/gemm/bmm_softmax_bmm_permute.py
+++ b/src/dinoml/backend/rocm/gemm/bmm_softmax_bmm_permute.py
@@ -26,6 +26,7 @@ This is used for `ops.bmm_softmax_bmm_permute`.
 import jinja2
 
 from dinoml.backend import registry
+from dinoml.backend.backend_spec import ROCMSpec
 from dinoml.backend.common import gemm_common
 from dinoml.backend.rocm.gemm import bmm_common, common
 from dinoml.backend.rocm.gemm.layout import RCR
@@ -47,7 +48,7 @@ INPUT_ADDR_CALCULATOR = jinja2.Template(
 
 EXTRA_CODE = jinja2.Template(
     """
-const ck::half_t alpha = {{scale}};
+const {{dtype}} alpha = {{scale}};
 """
 )
 
@@ -84,10 +85,10 @@ EXTRA_HEADER_TEMPLATE = jinja2.Template(
 
 PROBLEM_ARGS_TEMPLATE = jinja2.Template(
     """
-{{indent}}                                static_cast<ck::half_t*>(in_ptr) + in_offset,
-{{indent}}                                static_cast<ck::half_t*>(weight_ptr) + weight_offset,
-{{indent}}                                static_cast<ck::half_t*>(bias_ptr) + bias_offset,
-{{indent}}                                static_cast<ck::half_t*>(out_ptr),
+{{indent}}                                static_cast<{{dtype}}*>(in_ptr) + in_offset,
+{{indent}}                                static_cast<{{dtype}}*>(weight_ptr) + weight_offset,
+{{indent}}                                static_cast<{{dtype}}*>(bias_ptr) + bias_offset,
+{{indent}}                                static_cast<{{dtype}}*>(out_ptr),
 {{indent}}                                {},
 {{indent}}                                {},
 {{indent}}                                {B/G1, G1, M, K},
@@ -220,6 +221,10 @@ def bmm_gen_profiler(func_attrs, workdir, profiler_name, dim_info_dict):
         Generated from bmm._extract_dims().
         Used to store mapping between dim_names to input / output tensor dims.
     """
+    x = func_attrs["inputs"][0]
+    spec = ROCMSpec()
+    lib_dtype = spec.dtype_to_lib_type(x._attrs["dtype"])
+
     return bmm_common.gen_profiler(
         func_attrs=func_attrs,
         workdir=workdir,
@@ -230,7 +235,7 @@ def bmm_gen_profiler(func_attrs, workdir, profiler_name, dim_info_dict):
         tensor_decl_template=TENSOR_DECL_TEMPLATE,
         problem_args_template=PROBLEM_ARGS_TEMPLATE,
         extra_shape_template=PROFILER_EXTRA_SHAPE_TEMPLATE,
-        extra_code=EXTRA_CODE.render(scale=func_attrs["scale"]),
+        extra_code=EXTRA_CODE.render(scale=func_attrs["scale"], dtype=lib_dtype),
     )
 
 
@@ -312,6 +317,10 @@ def bmm_gen_function(func_attrs, exec_cond_template, dim_info_dict):
     )
     # TODO: add support for output_tensor_accessors
 
+    x = func_attrs["inputs"][0]
+    spec = ROCMSpec()
+    lib_dtype = spec.dtype_to_lib_type(x._attrs["dtype"])
+
     return bmm_common.gen_function(
         func_attrs,
         exec_cond_template,
@@ -320,7 +329,7 @@ def bmm_gen_function(func_attrs, exec_cond_template, dim_info_dict):
         problem_args_template=PROBLEM_ARGS_TEMPLATE,
         extra_shape_template=EXTRA_SHAPE_TEMPLATE,
         extra_header_template=EXTRA_HEADER_TEMPLATE,
-        extra_code=EXTRA_CODE.render(scale=func_attrs["scale"]),
+        extra_code=EXTRA_CODE.render(scale=func_attrs["scale"], dtype=lib_dtype),
         input_addr_calculator=input_addr_calculator,
         output_addr_calculator="",
     )

--- a/src/dinoml/backend/rocm/gemm/common.py
+++ b/src/dinoml/backend/rocm/gemm/common.py
@@ -23,6 +23,7 @@ from hashlib import sha1
 
 import jinja2
 
+from dinoml.backend.backend_spec import ROCMSpec
 from dinoml.backend.common import gemm_common
 from dinoml.backend.target import Target
 from dinoml.compiler.base import IntVar
@@ -52,9 +53,32 @@ OUTPUT_ADDR_CALCULATOR = jinja2.Template(
 
 EXTRA_SHAPE_TEMPLATE = jinja2.Template(
     """
-{{indent}}ck::index_t stride_a = *a_dim1;
-{{indent}}ck::index_t stride_b = *b_dim1;
-{{indent}}ck::index_t stride_c = *c_dim1;
+auto f_get_default_stride =
+    [](std::size_t row, std::size_t col, ck::index_t stride, auto layout) {
+        if(stride == -1 || stride == 0)
+        {
+            // give a chance if stride is -1, return a default packed stride
+            if constexpr(std::is_same_v<decltype(layout), ck::tensor_layout::gemm::RowMajor>)
+            {
+                return static_cast<std::size_t>(col);
+            }
+            else
+            {
+                return static_cast<std::size_t>(row);
+            }
+        }
+        else
+            return static_cast<std::size_t>(stride);
+    };
+
+{{indent}}ck::index_t stride_a = -1;
+{{indent}}ck::index_t stride_b = -1;
+{{indent}}ck::index_t stride_c = -1;
+
+stride_a = f_get_default_stride(M, K, stride_a, ck::tensor_layout::gemm::RowMajor{});
+stride_b = f_get_default_stride(K, N, stride_b, ck::tensor_layout::gemm::ColumnMajor{});
+stride_c = f_get_default_stride(M, N, stride_c, ck::tensor_layout::gemm::RowMajor{});
+
 """
 )
 
@@ -114,11 +138,9 @@ SRC_TEMPLATE = jinja2.Template(
 #include <initializer_list>
 #include <cstdlib>
 #include <stdlib.h>
-// #include <half.hpp>
 #include <random>
 #include <rocrand/rocrand.h>
 #include "logging.h"
-//#include "include/ck/utility/print.hpp"
 
 #include "ck/ck.hpp"
 #include "ck/tensor_operation/gpu/device/gemm_specialization.hpp"
@@ -152,13 +174,13 @@ void {{function_name}}(
 {% if has_d1 %}
     void * d1_ptr,
 {% endif %}
-{% for idx in range(ndims) %}
+{% for idx in range(adims) %}
     int64_t* a_dim{{idx}},
 {% endfor %}
-{% for idx in range(ndims) %}
+{% for idx in range(bdims) %}
     int64_t* b_dim{{idx}},
 {% endfor %}
-{% for idx in range(ndims) %}
+{% for idx in range(cdims) %}
     int64_t* c_dim{{idx}},
 {% endfor %}
 {% for idx in range(pdims) %}
@@ -246,30 +268,30 @@ FUNC_CALL_TEMPLATE = jinja2.Template(
 
 PROBLEM_ARGS_TEMPLATE = jinja2.Template(
     """
-{{indent}}                                static_cast<ck::half_t *>(in_ptr) + offset_a,
-{{indent}}                                static_cast<ck::half_t *>(weight_ptr) + offset_b,
+{{indent}}                                static_cast<{{dtype}} *>(in_ptr) + offset_a,
+{{indent}}                                static_cast<{{dtype}} *>(weight_ptr) + offset_b,
 
 {% if gemm_flag == "bias_permute" %}
-{{indent}}                                static_cast<ck::half_t *>(bias_ptr),
+{{indent}}                                static_cast<{{dtype}} *>(bias_ptr),
 {% elif gemm_flag == "permute" %}
 {{indent}}                                nullptr,
 {% elif gemm_flag == "bias_permute_m2n3" %}
-{{indent}}                                std::array<const void*, 1>{static_cast<ck::half_t *>(bias_ptr)},
+{{indent}}                                std::array<const void*, 1>{static_cast<{{dtype}} *>(bias_ptr)},
 {% elif gemm_flag == "permute_m2n3" %}
 {{indent}}                                {},
 {% else %}
 {% if "bias" in gemm_flag and not has_d0 %}
-{{indent}}                                std::array<const void*, 1>{static_cast<ck::half_t *>(bias_ptr)},
+{{indent}}                                std::array<const void*, 1>{static_cast<{{dtype}} *>(bias_ptr)},
 {% elif has_d0 and not has_d1 %}
-{{indent}}                                std::array<const void*, 2>{static_cast<ck::half_t *>(bias_ptr),
-                                                                    static_cast<ck::half_t *>(d0_ptr)},
+{{indent}}                                std::array<const void*, 2>{static_cast<{{dtype}} *>(bias_ptr),
+                                                                    static_cast<{{dtype}} *>(d0_ptr)},
 {% elif has_d1 %}
-{{indent}}                                std::array<const void*, 3>{static_cast<ck::half_t *>(bias_ptr),
-                                                                    static_cast<ck::half_t *>(d0_ptr),
-                                                                    static_cast<ck::half_t *>(d1_ptr)},
+{{indent}}                                std::array<const void*, 3>{static_cast<{{dtype}} *>(bias_ptr),
+                                                                    static_cast<{{dtype}} *>(d0_ptr),
+                                                                    static_cast<{{dtype}} *>(d1_ptr)},
 {% endif %}
 {% endif %}
-{{indent}}                                static_cast<ck::half_t *>(out_ptr) + offset_c,
+{{indent}}                                static_cast<{{dtype}} *>(out_ptr) + offset_c,
 {% if gemm_flag not in ["permute_m2n3", "bias_permute_m2n3", "bias_permute_m3n2"]  %}
 {{indent}}                                M,
 {{indent}}                                N,
@@ -328,7 +350,7 @@ PROBLEM_ARGS_TEMPLATE = jinja2.Template(
 {% elif gemm_flag == "bias_sigmoid" %}
 {{indent}}                                ck::tensor_operation::element_wise::AddSigmoid{}
 {% elif gemm_flag == "bias_add" %}
-{{indent}}                                ck::tensor_operation::element_wise::AddAdd{}
+{{indent}}                                ck::tensor_operation::element_wise::AddAdd_{}
 {% elif gemm_flag == "bias_mul" %}
 {{indent}}                                ck::tensor_operation::element_wise::AddMul{}
 {% elif gemm_flag == "bias_mul_tanh" %}
@@ -414,9 +436,9 @@ struct ProfilerMemoryPool {
     return d_x;
   }
 
-  ck::half_t* AllocateHalfGaussianTensor(int64_t size) {
-    return reinterpret_cast<ck::half_t*>(
-        AllocateGaussianTensor<ck::half_t>(size));
+  {{dtype}}* AllocateHalfGaussianTensor(int64_t size) {
+    return reinterpret_cast<{{dtype}}*>(
+        AllocateGaussianTensor<float>(size));
   }
 
   int AllocateHalfTensor(int64_t size, int64_t copy) {
@@ -428,11 +450,11 @@ struct ProfilerMemoryPool {
     return ptrs.size() - 1;
   }
 
-  ck::half_t* RequestHalfTensorByIdx(int idx) {
+  {{dtype}}* RequestHalfTensorByIdx(int idx) {
     auto copy = copies.at(idx);
     auto offset = offsets.at(idx);
     auto stride = strides.at(idx);
-    ck::half_t* ptr = reinterpret_cast<ck::half_t*>(ptrs.at(idx));
+    {{dtype}}* ptr = reinterpret_cast<{{dtype}}*>(ptrs.at(idx));
     ptr += offset;
     offset += stride;
     if (offset == copy * stride) {
@@ -529,7 +551,7 @@ int benchmark_{{function_name}}(
   );
 
    if (!op.IsSupportedArgument(argument)) {
-     return 0; // not supported => skip (CUDA-style "try next")
+     return 0;
    }
 
   GLOBAL_WORKSPACE_SIZE = op.GetWorkSpaceSize(&argument);
@@ -584,13 +606,13 @@ void {{func_name}}(
 {% if has_d1 %}
   void *,
 {% endif %}
-{% for idx in range(ndims) %}
+{% for idx in range(adims) %}
   int64_t*,
 {% endfor %}
-{% for idx in range(ndims) %}
+{% for idx in range(bdims) %}
   int64_t*,
 {% endfor %}
-{% for idx in range(ndims) %}
+{% for idx in range(cdims) %}
   int64_t*,
 {% endfor %}
 {% for idx in range(pdims) %}
@@ -661,7 +683,7 @@ def emit_instance(op):
     return op_def
 
 
-def extract_config(op_kind, extra_kind, f_proc_op):
+def extract_config(op_kind, extra_kind, layout, dtype="float16"):
     """Extract (operation name, operation instance) pair
     from all operation candidates.
 
@@ -680,15 +702,52 @@ def extract_config(op_kind, extra_kind, f_proc_op):
     Dict
         Extracted (operation name, operation instance) pair.
     """
+    import dinoml.utils.ck_lib as ck_lib
+
+    spec = ROCMSpec()
+    lib_dtype = spec.dtype_to_lib_type(dtype)
+
+    if lib_dtype == "float":
+        data_type = ck_lib.library.DataType.f32
+        acc_type = ck_lib.library.DataType.f32
+    elif lib_dtype == "ck::half_t":
+        data_type = ck_lib.library.DataType.f16
+        acc_type = ck_lib.library.DataType.f32
+        # check target use fp16 acc
+        if (
+            "use_fp16_acc" in Target.current()._kwargs
+            and Target.current().name() != "rocm"
+        ):
+            if Target.current()._kwargs["use_fp16_acc"]:
+                acc_type = ck_lib.library.DataType.f16
+    elif lib_dtype == "ck::bhalf_t":
+        data_type = ck_lib.library.DataType.bf16
+        acc_type = ck_lib.library.DataType.f32
+    else:
+        raise RuntimeError(f"Unsupported dtype {lib_dtype}")
+
+    a_layout, b_layout, c_layout = layout.ck_lib_layouts()
+
     gemm_ops = OrderedDict()
     extract_ops = list(Target.current()._operators[op_kind][extra_kind].items())
 
+    def f_proc_op(op: ck_lib.gemm_operation.GemmOperation):
+        if (
+            op.A.element == data_type
+            and op.B.element == data_type
+            and op.C.element == data_type
+            and op.acc_dtype == acc_type
+            and op.A.layout == a_layout
+            and op.B.layout == b_layout
+            and op.C.layout == c_layout
+        ):
+            return op
+        return None
+
     for key, value in extract_ops:
         op = value[0]
-        ret = f_proc_op(op)
-        if len(ret) > 0:
-            for op_inst in ret:
-                gemm_ops[key] = op_inst
+        if f_proc_op(op) is not None:
+            gemm_ops[key] = op
     return gemm_ops
 
 
@@ -771,6 +830,10 @@ def gen_profiler(
     tensor_decl_template: jinja2.Template
         Tensor declaration template.
     """
+    x = func_attrs["inputs"][0]
+    spec = ROCMSpec()
+    lib_dtype = spec.dtype_to_lib_type(x._attrs["dtype"])
+
     op_type = func_attrs["op"]
     file_pairs = []
     if check_profiler_exists(workdir, op_type, profiler_name):
@@ -847,23 +910,26 @@ def gen_profiler(
         gemm_flag=gemm_flag,
         has_d0=has_d0_flag,
         has_d1=has_d1_flag,
+        dtype=lib_dtype,
     )
 
     code = PROFILER_TEMPLATE.render(
         op_func=op_func,
-        structs_def=STRUCTS_DEF_TEMPLATE.render(),
+        structs_def=STRUCTS_DEF_TEMPLATE.render(dtype=lib_dtype),
         args_parse=args_parse,
         tensor_decl=tensor_decl_template.render(
             gemm_flag=gemm_flag, has_d0=has_d0_flag, has_d1=has_d1_flag
         ),
         benchmark_instances="\n".join(benchmark_instances),
         function_name="gemm",
-        ndims=ndims,
+        ndims=2,
         pdims=len(pdims),
         shape_func=op_func_shape,
         extra_shape=extra_shape_func,
         problem_args=problem_args,
         gemm_flag=gemm_flag,
+        has_d0=has_d0_flag,
+        has_d1=has_d1_flag,
     )
     src_path = os.path.join(prefix, f"{profiler_name}.cpp")
     obj_path = os.path.join(prefix, f"{profiler_name}")
@@ -879,7 +945,7 @@ def gen_function(
     dim_info_dict,
     gemm_flag,
     extra_code="",
-    ndims=2,
+    ndims=3,
     extra_shape_template=EXTRA_SHAPE_TEMPLATE,
     problem_args_template=PROBLEM_ARGS_TEMPLATE,
     extra_header_template=EXTRA_HEADER_TEMPLATE,
@@ -918,6 +984,10 @@ def gen_function(
     str
         The rendered template of generated function body.
     """
+    x = func_attrs["inputs"][0]
+    spec = ROCMSpec()
+    lib_dtype = spec.dtype_to_lib_type(x._attrs["dtype"])
+
     func_name = func_attrs["name"]
     exec_path = func_attrs["exec_path"]
     op_instance = func_attrs["op_instance"]
@@ -953,6 +1023,7 @@ def gen_function(
             gemm_flag=gemm_flag,
             has_d0=has_d0_flag,
             has_d1=has_d1_flag,
+            dtype=lib_dtype,
         )
         program = EXEC_TEMPLATE.render(
             indent="    ",
@@ -973,6 +1044,12 @@ def gen_function(
         gemm_flag=gemm_flag, has_d0=has_d0(func_attrs)
     )
     pdims = len(func_attrs["shape"]) if func_attrs.get("shape") is not None else 0
+    a = func_attrs["inputs"][0]
+    b = func_attrs["inputs"][1]
+    c = func_attrs["outputs"][0]
+    adims = len([dim_expr(dim) for dim in a._attrs["shape"]])
+    bdims = len([dim_expr(dim) for dim in b._attrs["shape"]])
+    cdims = len([dim_expr(dim) for dim in c._attrs["shape"]])
     return SRC_TEMPLATE.render(
         instances=instance_decl,
         function_name=func_name,
@@ -984,14 +1061,16 @@ def gen_function(
         extra_code=extra_code,
         extra_header=extra_header,
         gemm_flag=gemm_flag,
-        ndims=ndims,
+        adims=adims,
+        bdims=bdims,
+        cdims=cdims,
         pdims=pdims,
         has_d0=has_d0_flag,
         has_d1=has_d1_flag,
     )
 
 
-def gen_function_decl(func_name, gemm_flag, ndims=2, pdims=0, has_d0="", has_d1=""):
+def gen_function_decl(func_attrs, gemm_flag, ndims=3, pdims=0, has_d0="", has_d1=""):
     """Generates function declarations.
 
     Parameters
@@ -1008,14 +1087,27 @@ def gen_function_decl(func_name, gemm_flag, ndims=2, pdims=0, has_d0="", has_d1=
     str
         The rentered template of function declaration.
     """
+    a = func_attrs["inputs"][0]
+    b = func_attrs["inputs"][1]
+    c = func_attrs["outputs"][0]
+    adims = [dim_expr(dim) for dim in a._attrs["shape"]]
+    bdims = [dim_expr(dim) for dim in b._attrs["shape"]]
+    cdims = [dim_expr(dim) for dim in c._attrs["shape"]]
     return FUNC_DECL_TEMPLATE.render(
-        func_name=func_name,
+        func_name=func_attrs["name"],
         gemm_flag=gemm_flag,
-        ndims=ndims,
+        adims=len(adims),
+        bdims=len(bdims),
+        cdims=len(cdims),
         pdims=pdims,
         has_d0=has_d0,
         has_d1=has_d1,
     )
+
+
+def dim_expr(d):
+    n = d._attrs.get("name", None)
+    return "&" + n if n is not None else str(d.symbolic_value())
 
 
 def gen_function_call(func_attrs, indent="  ", gemm_flag=""):
@@ -1050,23 +1142,14 @@ def gen_function_call(func_attrs, indent="  ", gemm_flag=""):
     if has_d1(func_attrs):
         d1 = func_attrs["inputs"][4]
         d1_ptr = d1._attrs["name"]
-    adims = [
-        "&" + dim._attrs["name"]
-        for dim in func_attrs["input_accessors"][0].original_shapes
-    ]
-    bdims = [
-        "&" + dim._attrs["name"]
-        for dim in func_attrs["input_accessors"][1].original_shapes
-    ]
-    cdims = [
-        "&" + dim._attrs["name"]
-        for dim in func_attrs["output_accessors"][0].original_shapes
-    ]
+    adims = [dim_expr(dim) for dim in a._attrs["shape"]]
+    bdims = [dim_expr(dim) for dim in b._attrs["shape"]]
+    cdims = [dim_expr(dim) for dim in c._attrs["shape"]]
     pdims = []
     if func_attrs.get("shape") is not None:
         pdims = list(func_attrs["shape"])
 
-    return FUNC_CALL_TEMPLATE.render(
+    func_call = FUNC_CALL_TEMPLATE.render(
         func_name=func_attrs["name"],
         in_ptr=a._attrs["name"],
         weight_ptr=b._attrs["name"],
@@ -1081,44 +1164,7 @@ def gen_function_call(func_attrs, indent="  ", gemm_flag=""):
         indent=indent,
         gemm_flag=gemm_flag,
     )
-
-
-def default_fproc_f16(*, op, a_layout, b_layout, c_layout):
-    """Filter the input operation by layouts.
-
-    Parameters
-    ----------
-    op: operation
-        dinoml operation
-    a_layout: ck_lib.library.LayoutType
-        a layout type.
-    b_layout: ck_lib.library.LayoutType
-        b layout type.
-    c_layout: ck_lib.library.LayoutType
-        c layout type.
-    Returns
-    -------
-    List
-        List of filtered op (can be empty).
-    """
-    import copy
-
-    import dinoml.utils.ck_lib as ck_lib
-
-    ret = []
-    data_type = ck_lib.library.DataType.f16
-    acc_type = ck_lib.library.DataType.f32
-    if (
-        op.A.element == data_type
-        and op.B.element == data_type
-        and op.C.element == data_type
-        and op.accumulator_type() == acc_type
-        and op.A.layout == a_layout
-        and op.B.layout == b_layout
-        and op.C.layout == c_layout
-    ):
-        ret += [copy.deepcopy(op)]
-    return ret
+    return func_call
 
 
 def make_fproc_f16(func_attrs, layout, op_kind, extra_kind):
@@ -1137,22 +1183,15 @@ def make_fproc_f16(func_attrs, layout, op_kind, extra_kind):
         Used to as extra flag to distinguish kernels.
         E.g. bias_add_relu vs. add_relu_bias
     """
-
-    def fproc_f16(op):
-        a_layout, b_layout, c_layout = layout.ck_lib_layouts()
-        return default_fproc_f16(
-            op=op,
-            a_layout=a_layout,
-            b_layout=b_layout,
-            c_layout=c_layout,
-        )
+    x = func_attrs["inputs"][0]
+    dtype = x._attrs["dtype"]
 
     has_dynamic_shape = False
     for inp in func_attrs["inputs"]:
         for dim in inp.shape():
             if isinstance(dim, IntVar):
                 has_dynamic_shape = True
-    func_attrs["op_instance"] = extract_config(op_kind, extra_kind, fproc_f16)
+    func_attrs["op_instance"] = extract_config(op_kind, extra_kind, layout, dtype=dtype)
     if has_dynamic_shape:
         filtered_op_instance = {}
         for op_name, op in func_attrs["op_instance"].items():

--- a/src/dinoml/backend/rocm/gemm/gemm_rcr.py
+++ b/src/dinoml/backend/rocm/gemm/gemm_rcr.py
@@ -121,8 +121,7 @@ def gemm_gen_function_decl(func_attrs):
     str
         The rentered template of function declaration.
     """
-    func_name = func_attrs["name"]
-    return common.gen_function_decl(func_name=func_name, gemm_flag="")
+    return common.gen_function_decl(func_attrs, gemm_flag="")
 
 
 @registry.reg("rocm.gemm_rcr.func_call")

--- a/src/dinoml/backend/rocm/gemm/gemm_rcr_bias.py
+++ b/src/dinoml/backend/rocm/gemm/gemm_rcr_bias.py
@@ -122,7 +122,7 @@ def gemm_gen_function_decl(func_attrs):
         The rentered template of function declaration.
     """
     func_name = func_attrs["name"]
-    return common.gen_function_decl(func_name=func_name, gemm_flag="bias")
+    return common.gen_function_decl(func_attrs, gemm_flag="bias")
 
 
 @registry.reg("rocm.gemm_rcr_bias.func_call")

--- a/src/dinoml/backend/rocm/gemm/gemm_rcr_bias_add.py
+++ b/src/dinoml/backend/rocm/gemm/gemm_rcr_bias_add.py
@@ -22,6 +22,7 @@ bias[RowMajor][N], D0[RowMajor][M, N]
 import jinja2
 
 from dinoml.backend import registry
+from dinoml.backend.backend_spec import ROCMSpec
 from dinoml.backend.rocm.gemm import common
 from dinoml.backend.rocm.gemm.layout import RCR
 
@@ -34,16 +35,38 @@ namespace ck {
 namespace tensor_operation {
 namespace element_wise {
 namespace {
-struct AddAdd
-{
-    AddAdd(){};
 
-    __host__ __device__ void operator()(ck::half_t& e, const ck::half_t& c, const ck::half_t& bias, const ck::half_t& d0) const
+// C = A * B
+// E = C + D0 + D1
+struct AddAdd_
+{
+    static constexpr const char* name = "AddAdd";
+
+    template <typename E, typename C, typename D0, typename D1>
+    __host__ __device__ void operator()(E& e, const C& c, const D0& d0, const D1& d1) const
     {
-        const ck::half_t x = c + bias;
-        e = x + d0;
-    };
+        // Only support floating so far
+        static_assert(is_same<E, half_t>::value || is_same<E, bhalf_t>::value || is_same<E, float>::value ||
+                          is_same<E, double>::value,
+                      "Data type is not supported by this operation!");
+
+        static_assert(is_same<C, half_t>::value || is_same<C, bhalf_t>::value || is_same<C, float>::value ||
+                          is_same<C, double>::value,
+                      "Data type is not supported by this operation!");
+
+        static_assert(is_same<D0, half_t>::value || is_same<D0, bhalf_t>::value || is_same<D0, float>::value ||
+                          is_same<D0, double>::value,
+                      "Data type is not supported by this operation!");
+
+        static_assert(is_same<D1, half_t>::value || is_same<D1, bhalf_t>::value || is_same<D1, float>::value ||
+                          is_same<D1, double>::value,
+                      "Data type is not supported by this operation!");
+
+        const C y = c + type_convert<C>(d0) + type_convert<C>(d1);
+        e         = type_convert<E>(y);
+    }
 };
+
 } // namespace
 } // namespace element_wise
 } // namespace tensor_operation
@@ -89,13 +112,17 @@ def gen_profiler(func_attrs, workdir, profiler_name, dim_info_dict):
         Generated from gemm._extract_dims().
         Used to store mapping between dim_names to input / output tensor dims.
     """
+    x = func_attrs["inputs"][0]
+    spec = ROCMSpec()
+    lib_dtype = spec.dtype_to_lib_type(x._attrs["dtype"])
+
     return common.gen_profiler(
         func_attrs=func_attrs,
         workdir=workdir,
         dim_info_dict=dim_info_dict,
         args_parse=RCR.args_parse,
         gemm_flag="bias_add",
-        extra_code=EXTRA_CODE.render(),
+        extra_code=EXTRA_CODE.render(dtype=lib_dtype),
         profiler_name=profiler_name,
     )
 
@@ -123,12 +150,16 @@ def gen_function(
     str
         The rendered template of generated function body.
     """
+    x = func_attrs["inputs"][0]
+    spec = ROCMSpec()
+    lib_dtype = spec.dtype_to_lib_type(x._attrs["dtype"])
+
     return common.gen_function(
         func_attrs,
         exec_cond_template,
         dim_info_dict,
         "bias_add",
-        extra_code=EXTRA_CODE.render(),
+        extra_code=EXTRA_CODE.render(dtype=lib_dtype),
         input_addr_calculator=common.INPUT_ADDR_CALCULATOR.render(
             accessor_a=func_attrs["input_accessors"][0],
             accessor_b=func_attrs["input_accessors"][1],
@@ -155,7 +186,7 @@ def gen_function_decl(func_attrs):
     """
     func_name = func_attrs["name"]
     return common.gen_function_decl(
-        func_name=func_name,
+        func_attrs,
         gemm_flag="bias_add",
         has_d0=common.has_d0(func_attrs),
         has_d1=common.has_d1(func_attrs),

--- a/src/dinoml/backend/rocm/gemm/gemm_rcr_bias_add_add.py
+++ b/src/dinoml/backend/rocm/gemm/gemm_rcr_bias_add_add.py
@@ -22,6 +22,7 @@ bias[RowMajor][N], D0[RowMajor][M, N], D1[RowMajor][M, N]
 import jinja2
 
 from dinoml.backend import registry
+from dinoml.backend.backend_spec import ROCMSpec
 from dinoml.backend.rocm.gemm import common
 from dinoml.backend.rocm.gemm.layout import RCR
 
@@ -38,7 +39,7 @@ struct AddAddAdd
 {
     AddAddAdd(){};
 
-    __host__ __device__ void operator()(ck::half_t& e, const ck::half_t& c, const ck::half_t& bias, const ck::half_t& d0, const ck::half_t& d1) const
+    __host__ __device__ void operator()({{dtype}}& e, const {{dtype}}& c, const {{dtype}}& bias, const {{dtype}}& d0, const {{dtype}}& d1) const
     {
         e = c + bias + d0 + d1;
     };
@@ -89,13 +90,17 @@ def gen_profiler(func_attrs, workdir, profiler_name, dim_info_dict):
         Generated from gemm._extract_dims().
         Used to store mapping between dim_names to input / output tensor dims.
     """
+    x = func_attrs["inputs"][0]
+    spec = ROCMSpec()
+    lib_dtype = spec.dtype_to_lib_type(x._attrs["dtype"])
+
     return common.gen_profiler(
         func_attrs=func_attrs,
         workdir=workdir,
         dim_info_dict=dim_info_dict,
         args_parse=RCR.args_parse,
         gemm_flag="bias_add_add",
-        extra_code=EXTRA_CODE.render(),
+        extra_code=EXTRA_CODE.render(dtype=lib_dtype),
         profiler_name=profiler_name,
     )
 
@@ -123,12 +128,16 @@ def gen_function(
     str
         The rendered template of generated function body.
     """
+    x = func_attrs["inputs"][0]
+    spec = ROCMSpec()
+    lib_dtype = spec.dtype_to_lib_type(x._attrs["dtype"])
+
     return common.gen_function(
         func_attrs,
         exec_cond_template,
         dim_info_dict,
         "bias_add_add",
-        extra_code=EXTRA_CODE.render(),
+        extra_code=EXTRA_CODE.render(dtype=lib_dtype),
         input_addr_calculator=common.INPUT_ADDR_CALCULATOR.render(
             accessor_a=func_attrs["input_accessors"][0],
             accessor_b=func_attrs["input_accessors"][1],
@@ -155,7 +164,7 @@ def gen_function_decl(func_attrs):
     """
     func_name = func_attrs["name"]
     return common.gen_function_decl(
-        func_name=func_name,
+        func_attrs,
         gemm_flag="bias_add_add_relu",
         has_d0=common.has_d0(func_attrs),
         has_d1=common.has_d1(func_attrs),

--- a/src/dinoml/backend/rocm/gemm/gemm_rcr_bias_add_add_relu.py
+++ b/src/dinoml/backend/rocm/gemm/gemm_rcr_bias_add_add_relu.py
@@ -22,6 +22,7 @@ bias[RowMajor][N], D0[RowMajor][M, N], D1[RowMajor][M, N]
 import jinja2
 
 from dinoml.backend import registry
+from dinoml.backend.backend_spec import ROCMSpec
 from dinoml.backend.rocm.gemm import common
 from dinoml.backend.rocm.gemm.layout import RCR
 
@@ -38,9 +39,9 @@ struct AddAddAddRelu
 {
     AddAddAddRelu(){};
 
-    __host__ __device__ void operator()(ck::half_t& e, const ck::half_t& c, const ck::half_t& bias, const ck::half_t& d0, const ck::half_t& d1) const
+    __host__ __device__ void operator()({{dtype}}& e, const {{dtype}}& c, const {{dtype}}& bias, const {{dtype}}& d0, const {{dtype}}& d1) const
     {
-        const ck::half_t x = c + bias + d0 + d1;
+        const {{dtype}} x = c + bias + d0 + d1;
         e = x > 0 ? x : 0;
     };
 
@@ -90,13 +91,17 @@ def gen_profiler(func_attrs, workdir, profiler_name, dim_info_dict):
         Generated from gemm._extract_dims().
         Used to store mapping between dim_names to input / output tensor dims.
     """
+    x = func_attrs["inputs"][0]
+    spec = ROCMSpec()
+    lib_dtype = spec.dtype_to_lib_type(x._attrs["dtype"])
+
     return common.gen_profiler(
         func_attrs=func_attrs,
         workdir=workdir,
         dim_info_dict=dim_info_dict,
         args_parse=RCR.args_parse,
         gemm_flag="bias_add_add_relu",
-        extra_code=EXTRA_CODE.render(),
+        extra_code=EXTRA_CODE.render(dtype=lib_dtype),
         profiler_name=profiler_name,
     )
 
@@ -124,12 +129,16 @@ def gen_function(
     str
         The rendered template of generated function body.
     """
+    x = func_attrs["inputs"][0]
+    spec = ROCMSpec()
+    lib_dtype = spec.dtype_to_lib_type(x._attrs["dtype"])
+
     return common.gen_function(
         func_attrs,
         exec_cond_template,
         dim_info_dict,
         "bias_add_add_relu",
-        extra_code=EXTRA_CODE.render(),
+        extra_code=EXTRA_CODE.render(dtype=lib_dtype),
         input_addr_calculator=common.INPUT_ADDR_CALCULATOR.render(
             accessor_a=func_attrs["input_accessors"][0],
             accessor_b=func_attrs["input_accessors"][1],
@@ -156,7 +165,7 @@ def gen_function_decl(func_attrs):
     """
     func_name = func_attrs["name"]
     return common.gen_function_decl(
-        func_name=func_name,
+        func_attrs,
         gemm_flag="bias_add_add_relu",
         has_d0=common.has_d0(func_attrs),
         has_d1=common.has_d1(func_attrs),

--- a/src/dinoml/backend/rocm/gemm/gemm_rcr_bias_add_relu.py
+++ b/src/dinoml/backend/rocm/gemm/gemm_rcr_bias_add_relu.py
@@ -22,6 +22,7 @@ bias[RowMajor][N], D0[RowMajor][M, N]
 import jinja2
 
 from dinoml.backend import registry
+from dinoml.backend.backend_spec import ROCMSpec
 from dinoml.backend.rocm.gemm import common
 from dinoml.backend.rocm.gemm.layout import RCR
 
@@ -38,9 +39,9 @@ struct AddAddRelu
 {
     AddAddRelu(){};
 
-    __host__ __device__ void operator()(ck::half_t& e, const ck::half_t& c, const ck::half_t& bias, const ck::half_t& d0) const
+    __host__ __device__ void operator()({{dtype}}& e, const {{dtype}}& c, const {{dtype}}& bias, const {{dtype}}& d0) const
     {
-        const ck::half_t x = c + bias + d0;
+        const {{dtype}} x = c + bias + d0;
         e = x > 0 ? x : 0;
     };
 
@@ -90,13 +91,17 @@ def gen_profiler(func_attrs, workdir, profiler_name, dim_info_dict):
         Generated from gemm._extract_dims().
         Used to store mapping between dim_names to input / output tensor dims.
     """
+    x = func_attrs["inputs"][0]
+    spec = ROCMSpec()
+    lib_dtype = spec.dtype_to_lib_type(x._attrs["dtype"])
+
     return common.gen_profiler(
         func_attrs=func_attrs,
         workdir=workdir,
         dim_info_dict=dim_info_dict,
         args_parse=RCR.args_parse,
         gemm_flag="bias_add_relu",
-        extra_code=EXTRA_CODE.render(),
+        extra_code=EXTRA_CODE.render(dtype=lib_dtype),
         profiler_name=profiler_name,
     )
 
@@ -124,12 +129,16 @@ def gen_function(
     str
         The rendered template of generated function body.
     """
+    x = func_attrs["inputs"][0]
+    spec = ROCMSpec()
+    lib_dtype = spec.dtype_to_lib_type(x._attrs["dtype"])
+
     return common.gen_function(
         func_attrs,
         exec_cond_template,
         dim_info_dict,
         "bias_add_relu",
-        extra_code=EXTRA_CODE.render(),
+        extra_code=EXTRA_CODE.render(dtype=lib_dtype),
         input_addr_calculator=common.INPUT_ADDR_CALCULATOR.render(
             accessor_a=func_attrs["input_accessors"][0],
             accessor_b=func_attrs["input_accessors"][1],
@@ -156,7 +165,7 @@ def gen_function_decl(func_attrs):
     """
     func_name = func_attrs["name"]
     return common.gen_function_decl(
-        func_name=func_name,
+        func_attrs,
         gemm_flag="bias_add_relu",
         has_d0=common.has_d0(func_attrs),
         has_d1=common.has_d1(func_attrs),

--- a/src/dinoml/backend/rocm/gemm/gemm_rcr_bias_fast_gelu.py
+++ b/src/dinoml/backend/rocm/gemm/gemm_rcr_bias_fast_gelu.py
@@ -126,7 +126,7 @@ def gemm_gen_function_decl(func_attrs):
         The rentered template of function declaration.
     """
     func_name = func_attrs["name"]
-    return common.gen_function_decl(func_name=func_name, gemm_flag="bias_fast_gelu")
+    return common.gen_function_decl(func_attrs, gemm_flag="bias_fast_gelu")
 
 
 @registry.reg("rocm.gemm_rcr_bias_fast_gelu.func_call")

--- a/src/dinoml/backend/rocm/gemm/gemm_rcr_bias_hardswish.py
+++ b/src/dinoml/backend/rocm/gemm/gemm_rcr_bias_hardswish.py
@@ -122,7 +122,7 @@ def gemm_gen_function_decl(func_attrs):
         The rentered template of function declaration.
     """
     func_name = func_attrs["name"]
-    return common.gen_function_decl(func_name=func_name, gemm_flag="bias_hardswish")
+    return common.gen_function_decl(func_attrs, gemm_flag="bias_hardswish")
 
 
 @registry.reg("rocm.gemm_rcr_bias_hardswish.func_call")

--- a/src/dinoml/backend/rocm/gemm/gemm_rcr_bias_mul.py
+++ b/src/dinoml/backend/rocm/gemm/gemm_rcr_bias_mul.py
@@ -22,6 +22,7 @@ bias[RowMajor][N], D0[RowMajor][M, N]
 import jinja2
 
 from dinoml.backend import registry
+from dinoml.backend.backend_spec import ROCMSpec
 from dinoml.backend.rocm.gemm import common
 from dinoml.backend.rocm.gemm.layout import RCR
 
@@ -38,10 +39,21 @@ struct AddMul
 {
     AddMul(){};
 
-    __host__ __device__ void operator()(ck::half_t& e, const ck::half_t& c, const ck::half_t& bias, const ck::half_t& d0) const
+    template <typename E, typename C, typename D0, typename D1>
+    __host__ __device__ void operator()(E& e, const C& c, const D0& d0, const D1& d1) const;
+
+    template <>
+    __host__ __device__ void operator()<{{dtype}}, float, {{dtype}}, {{dtype}}>({{dtype}}& e, const float& c, const {{dtype}}& d0, const {{dtype}}& d1) const
     {
-        const ck::half_t x = c + bias;
-        e = x * d0;
+        const float x = (c + type_convert<float>(d0)) * type_convert<float>(d1);
+        e = type_convert<{{dtype}}>(x);
+    };
+
+    template <>
+    __host__ __device__ void operator()<{{dtype}}, {{dtype}}, {{dtype}}, {{dtype}}>({{dtype}}& e, const {{dtype}}& c, const {{dtype}}& d0, const {{dtype}}& d1) const
+    {
+        const {{dtype}} x = c + d0;
+        e = x * d1;
     };
 };
 } // namespace
@@ -89,13 +101,17 @@ def gen_profiler(func_attrs, workdir, profiler_name, dim_info_dict):
         Generated from gemm._extract_dims().
         Used to store mapping between dim_names to input / output tensor dims.
     """
+    x = func_attrs["inputs"][0]
+    spec = ROCMSpec()
+    lib_dtype = spec.dtype_to_lib_type(x._attrs["dtype"])
+
     return common.gen_profiler(
         func_attrs=func_attrs,
         workdir=workdir,
         dim_info_dict=dim_info_dict,
         args_parse=RCR.args_parse,
         gemm_flag="bias_mul",
-        extra_code=EXTRA_CODE.render(),
+        extra_code=EXTRA_CODE.render(dtype=lib_dtype),
         profiler_name=profiler_name,
     )
 
@@ -123,12 +139,16 @@ def gen_function(
     str
         The rendered template of generated function body.
     """
+    x = func_attrs["inputs"][0]
+    spec = ROCMSpec()
+    lib_dtype = spec.dtype_to_lib_type(x._attrs["dtype"])
+
     return common.gen_function(
         func_attrs,
         exec_cond_template,
         dim_info_dict,
         "bias_mul",
-        extra_code=EXTRA_CODE.render(),
+        extra_code=EXTRA_CODE.render(dtype=lib_dtype),
         input_addr_calculator=common.INPUT_ADDR_CALCULATOR.render(
             accessor_a=func_attrs["input_accessors"][0],
             accessor_b=func_attrs["input_accessors"][1],
@@ -155,7 +175,7 @@ def gen_function_decl(func_attrs):
     """
     func_name = func_attrs["name"]
     return common.gen_function_decl(
-        func_name=func_name,
+        func_attrs,
         gemm_flag="bias_mul",
         has_d0=common.has_d0(func_attrs),
         has_d1=common.has_d1(func_attrs),

--- a/src/dinoml/backend/rocm/gemm/gemm_rcr_bias_mul_add.py
+++ b/src/dinoml/backend/rocm/gemm/gemm_rcr_bias_mul_add.py
@@ -22,6 +22,7 @@ bias[RowMajor][N], D0[RowMajor][M, N], D1[RowMajor][M, N]
 import jinja2
 
 from dinoml.backend import registry
+from dinoml.backend.backend_spec import ROCMSpec
 from dinoml.backend.rocm.gemm import common
 from dinoml.backend.rocm.gemm.layout import RCR
 
@@ -37,9 +38,9 @@ struct AddMulAdd
 {
     AddMulAdd(){};
 
-    __host__ __device__ void operator()(ck::half_t& e, const ck::half_t& c, const ck::half_t& bias, const ck::half_t& d0, const ck::half_t& d1) const
+    __host__ __device__ void operator()({{dtype}}& e, const {{dtype}}& c, const {{dtype}}& bias, const {{dtype}}& d0, const {{dtype}}& d1) const
     {
-        const ck::half_t x = c + bias;
+        const {{dtype}} x = c + bias;
         e = x * d0 + d1;
     };
 
@@ -77,13 +78,17 @@ def gemm_rcr_config(func_attrs, dtype="float16"):
 
 @registry.reg("rocm.gemm_rcr_bias_mul_add.gen_profiler")
 def gen_profiler(func_attrs, workdir, profiler_name, dim_info_dict):
+    x = func_attrs["inputs"][0]
+    spec = ROCMSpec()
+    lib_dtype = spec.dtype_to_lib_type(x._attrs["dtype"])
+
     return common.gen_profiler(
         func_attrs=func_attrs,
         workdir=workdir,
         dim_info_dict=dim_info_dict,
         args_parse=RCR.args_parse,
         gemm_flag="bias_mul_add",
-        extra_code=EXTRA_CODE.render(),
+        extra_code=EXTRA_CODE.render(dtype=lib_dtype),
         profiler_name=profiler_name,
     )
 
@@ -94,12 +99,16 @@ def gen_function(
     exec_cond_template,
     dim_info_dict,
 ):
+    x = func_attrs["inputs"][0]
+    spec = ROCMSpec()
+    lib_dtype = spec.dtype_to_lib_type(x._attrs["dtype"])
+
     return common.gen_function(
         func_attrs,
         exec_cond_template,
         dim_info_dict,
         "bias_mul_add",
-        extra_code=EXTRA_CODE.render(),
+        extra_code=EXTRA_CODE.render(dtype=lib_dtype),
         input_addr_calculator=common.INPUT_ADDR_CALCULATOR.render(
             accessor_a=func_attrs["input_accessors"][0],
             accessor_b=func_attrs["input_accessors"][1],
@@ -126,7 +135,7 @@ def gen_function_decl(func_attrs):
     """
     func_name = func_attrs["name"]
     return common.gen_function_decl(
-        func_name=func_name,
+        func_attrs,
         gemm_flag="bias_mul_add",
         has_d0=common.has_d0(func_attrs),
         has_d1=common.has_d1(func_attrs),

--- a/src/dinoml/backend/rocm/gemm/gemm_rcr_bias_mul_tanh.py
+++ b/src/dinoml/backend/rocm/gemm/gemm_rcr_bias_mul_tanh.py
@@ -22,6 +22,7 @@ bias[RowMajor][N], D0[RowMajor][M, N]
 import jinja2
 
 from dinoml.backend import registry
+from dinoml.backend.backend_spec import ROCMSpec
 from dinoml.backend.rocm.gemm import common
 from dinoml.backend.rocm.gemm.layout import RCR
 
@@ -38,10 +39,10 @@ struct AddMulTanh
 {
     AddMulTanh(){};
 
-    __host__ __device__ void operator()(ck::half_t& e, const ck::half_t& c, const ck::half_t& bias, const ck::half_t& d0) const
+    __host__ __device__ void operator()({{dtype}}& e, const {{dtype}}& c, const {{dtype}}& bias, const {{dtype}}& d0) const
     {
-        const ck::half_t x = c + bias;
-        const ck::half_t x2 = x * d0;
+        const {{dtype}} x = c + bias;
+        const {{dtype}} x2 = x * d0;
         // 1-2/(e^(2x)+1)
         e = type_convert<half_t>(1.0) - type_convert<half_t>(2.0) /
                     (type_convert<half_t>(1.0) + type_convert<half_t>(exp(ck::type_convert<float>(2*x2))));
@@ -92,13 +93,17 @@ def gen_profiler(func_attrs, workdir, profiler_name, dim_info_dict):
         Generated from gemm._extract_dims().
         Used to store mapping between dim_names to input / output tensor dims.
     """
+    x = func_attrs["inputs"][0]
+    spec = ROCMSpec()
+    lib_dtype = spec.dtype_to_lib_type(x._attrs["dtype"])
+
     return common.gen_profiler(
         func_attrs=func_attrs,
         workdir=workdir,
         dim_info_dict=dim_info_dict,
         args_parse=RCR.args_parse,
         gemm_flag="bias_mul_tanh",
-        extra_code=EXTRA_CODE.render(),
+        extra_code=EXTRA_CODE.render(dtype=lib_dtype),
         profiler_name=profiler_name,
     )
 
@@ -126,12 +131,16 @@ def gen_function(
     str
         The rendered template of generated function body.
     """
+    x = func_attrs["inputs"][0]
+    spec = ROCMSpec()
+    lib_dtype = spec.dtype_to_lib_type(x._attrs["dtype"])
+
     return common.gen_function(
         func_attrs,
         exec_cond_template,
         dim_info_dict,
         "bias_mul_tanh",
-        extra_code=EXTRA_CODE.render(),
+        extra_code=EXTRA_CODE.render(dtype=lib_dtype),
         input_addr_calculator=common.INPUT_ADDR_CALCULATOR.render(
             accessor_a=func_attrs["input_accessors"][0],
             accessor_b=func_attrs["input_accessors"][1],
@@ -158,7 +167,7 @@ def gen_function_decl(func_attrs):
     """
     func_name = func_attrs["name"]
     return common.gen_function_decl(
-        func_name=func_name,
+        func_attrs,
         gemm_flag="bias_mul_tanh",
         has_d0=common.has_d0(func_attrs),
         has_d1=common.has_d1(func_attrs),

--- a/src/dinoml/backend/rocm/gemm/gemm_rcr_bias_permute.py
+++ b/src/dinoml/backend/rocm/gemm/gemm_rcr_bias_permute.py
@@ -149,7 +149,7 @@ def gemm_gen_function_decl(func_attrs):
         The rentered template of function declaration.
     """
     func_name = func_attrs["name"]
-    return common.gen_function_decl(func_name=func_name, gemm_flag="bias")
+    return common.gen_function_decl(func_attrs, gemm_flag="bias")
 
 
 @registry.reg("rocm.gemm_rcr_bias_permute.func_call")

--- a/src/dinoml/backend/rocm/gemm/gemm_rcr_bias_permute_m2n3.py
+++ b/src/dinoml/backend/rocm/gemm/gemm_rcr_bias_permute_m2n3.py
@@ -141,7 +141,7 @@ def gemm_gen_function_decl(func_attrs):
     """
     func_name = func_attrs["name"]
     return common.gen_function_decl(
-        func_name=func_name, gemm_flag="bias", pdims=len(func_attrs["shape"])
+        func_attrs, gemm_flag="bias", pdims=len(func_attrs["shape"])
     )
 
 

--- a/src/dinoml/backend/rocm/gemm/gemm_rcr_bias_permute_m3n2.py
+++ b/src/dinoml/backend/rocm/gemm/gemm_rcr_bias_permute_m3n2.py
@@ -141,7 +141,7 @@ def gemm_gen_function_decl(func_attrs):
     """
     func_name = func_attrs["name"]
     return common.gen_function_decl(
-        func_name=func_name, gemm_flag="bias", pdims=len(func_attrs["shape"])
+        func_attrs, gemm_flag="bias", pdims=len(func_attrs["shape"])
     )
 
 

--- a/src/dinoml/backend/rocm/gemm/gemm_rcr_bias_relu.py
+++ b/src/dinoml/backend/rocm/gemm/gemm_rcr_bias_relu.py
@@ -122,7 +122,7 @@ def gemm_gen_function_decl(func_attrs):
         The rentered template of function declaration.
     """
     func_name = func_attrs["name"]
-    return common.gen_function_decl(func_name=func_name, gemm_flag="bias_relu")
+    return common.gen_function_decl(func_attrs, gemm_flag="bias_relu")
 
 
 @registry.reg("rocm.gemm_rcr_bias_relu.func_call")

--- a/src/dinoml/backend/rocm/gemm/gemm_rcr_bias_sigmoid.py
+++ b/src/dinoml/backend/rocm/gemm/gemm_rcr_bias_sigmoid.py
@@ -22,6 +22,7 @@ When used for `linear`, need to set A->Data, B->Weight, C->Bias
 import jinja2
 
 from dinoml.backend import registry
+from dinoml.backend.backend_spec import ROCMSpec
 from dinoml.backend.rocm.gemm import common
 from dinoml.backend.rocm.gemm.layout import RCR
 
@@ -109,13 +110,17 @@ def gemm_gen_profiler(func_attrs, workdir, profiler_name, dim_info_dict):
         Generated from gemm._extract_dims().
         Used to store mapping between dim_names to input / output tensor dims.
     """
+    x = func_attrs["inputs"][0]
+    spec = ROCMSpec()
+    lib_dtype = spec.dtype_to_lib_type(x._attrs["dtype"])
+
     return common.gen_profiler(
         func_attrs=func_attrs,
         workdir=workdir,
         dim_info_dict=dim_info_dict,
         args_parse=RCR.args_parse,
         gemm_flag="bias_sigmoid",
-        extra_code=EXTRA_CODE.render(),
+        extra_code=EXTRA_CODE.render(dtype=lib_dtype),
         profiler_name=profiler_name,
     )
 
@@ -139,12 +144,16 @@ def gemm_gen_function(func_attrs, exec_cond_template, dim_info_dict):
     str
         The rendered template of generated function body.
     """
+    x = func_attrs["inputs"][0]
+    spec = ROCMSpec()
+    lib_dtype = spec.dtype_to_lib_type(x._attrs["dtype"])
+
     return common.gen_function(
         func_attrs,
         exec_cond_template,
         dim_info_dict,
         "bias_sigmoid",
-        extra_code=EXTRA_CODE.render(),
+        extra_code=EXTRA_CODE.render(dtype=lib_dtype),
         input_addr_calculator=common.INPUT_ADDR_CALCULATOR.render(
             accessor_a=func_attrs["input_accessors"][0],
             accessor_b=func_attrs["input_accessors"][1],
@@ -170,7 +179,7 @@ def gemm_gen_function_decl(func_attrs):
         The rentered template of function declaration.
     """
     func_name = func_attrs["name"]
-    return common.gen_function_decl(func_name=func_name, gemm_flag="bias_sigmoid")
+    return common.gen_function_decl(func_attrs, gemm_flag="bias_sigmoid")
 
 
 @registry.reg("rocm.gemm_rcr_bias_sigmoid.func_call")

--- a/src/dinoml/backend/rocm/gemm/gemm_rcr_bias_sigmoid_mul.py
+++ b/src/dinoml/backend/rocm/gemm/gemm_rcr_bias_sigmoid_mul.py
@@ -22,6 +22,7 @@ bias[RowMajor][N], D0[RowMajor][M, N].
 import jinja2
 
 from dinoml.backend import registry
+from dinoml.backend.backend_spec import ROCMSpec
 from dinoml.backend.rocm.gemm import common
 from dinoml.backend.rocm.gemm.layout import RCR
 
@@ -38,11 +39,11 @@ struct AddSigmoidMul
 {
     AddSigmoidMul(){};
 
-    __host__ __device__ void operator()(ck::half_t& e, const ck::half_t& c, const ck::half_t& bias, const ck::half_t& d0) const
+    __host__ __device__ void operator()({{dtype}}& e, const {{dtype}}& c, const {{dtype}}& bias, const {{dtype}}& d0) const
     {
-        const ck::half_t x = c + bias;
+        const {{dtype}} x = c + bias;
         // 1/(1+e^(-x))
-        const ck::half_t x2 = type_convert<half_t>(1.0) / (type_convert<half_t>(1.0) + type_convert<half_t>(exp(ck::type_convert<float>(-x))));
+        const {{dtype}} x2 = type_convert<{{dtype}}>(1.0) / (type_convert<{{dtype}}>(1.0) + type_convert<{{dtype}}>(exp(ck::type_convert<float>(-x))));
         e = x2 * d0;
     };
 };
@@ -91,13 +92,17 @@ def gen_profiler(func_attrs, workdir, profiler_name, dim_info_dict):
         Generated from gemm._extract_dims().
         Used to store mapping between dim_names to input / output tensor dims.
     """
+    x = func_attrs["inputs"][0]
+    spec = ROCMSpec()
+    lib_dtype = spec.dtype_to_lib_type(x._attrs["dtype"])
+
     return common.gen_profiler(
         func_attrs=func_attrs,
         workdir=workdir,
         dim_info_dict=dim_info_dict,
         args_parse=RCR.args_parse,
         gemm_flag="bias_sigmoid_mul",
-        extra_code=EXTRA_CODE.render(),
+        extra_code=EXTRA_CODE.render(dtype=lib_dtype),
         profiler_name=profiler_name,
     )
 
@@ -125,12 +130,16 @@ def gen_function(
     str
         The rendered template of generated function body.
     """
+    x = func_attrs["inputs"][0]
+    spec = ROCMSpec()
+    lib_dtype = spec.dtype_to_lib_type(x._attrs["dtype"])
+
     return common.gen_function(
         func_attrs,
         exec_cond_template,
         dim_info_dict,
         "bias_sigmoid_mul",
-        extra_code=EXTRA_CODE.render(),
+        extra_code=EXTRA_CODE.render(dtype=lib_dtype),
         input_addr_calculator=common.INPUT_ADDR_CALCULATOR.render(
             accessor_a=func_attrs["input_accessors"][0],
             accessor_b=func_attrs["input_accessors"][1],
@@ -157,7 +166,7 @@ def gen_function_decl(func_attrs):
     """
     func_name = func_attrs["name"]
     return common.gen_function_decl(
-        func_name=func_name,
+        func_attrs,
         gemm_flag="bias_sigmoid_mul",
         has_d0=common.has_d0(func_attrs),
         has_d1=common.has_d1(func_attrs),

--- a/src/dinoml/backend/rocm/gemm/gemm_rcr_bias_sigmoid_mul_tanh.py
+++ b/src/dinoml/backend/rocm/gemm/gemm_rcr_bias_sigmoid_mul_tanh.py
@@ -22,6 +22,7 @@ bias[RowMajor][N], D0[RowMajor][M, N].
 import jinja2
 
 from dinoml.backend import registry
+from dinoml.backend.backend_spec import ROCMSpec
 from dinoml.backend.rocm.gemm import common
 from dinoml.backend.rocm.gemm.layout import RCR
 
@@ -38,15 +39,15 @@ struct AddSigmoidMulTanh
 {
     AddSigmoidMulTanh(){};
 
-    __host__ __device__ void operator()(ck::half_t& e, const ck::half_t& c, const ck::half_t& bias, const ck::half_t& d0) const
+    __host__ __device__ void operator()({{dtype}}& e, const {{dtype}}& c, const {{dtype}}& bias, const {{dtype}}& d0) const
     {
-        const ck::half_t x = c + bias;
+        const {{dtype}} x = c + bias;
         // 1/(1+e^(-x))
-        const ck::half_t x2 = type_convert<half_t>(1.0) / (type_convert<half_t>(1.0) + type_convert<half_t>(exp(ck::type_convert<float>(-x))));
-        const ck::half_t x3 = x2*d0;
+        const {{dtype}} x2 = type_convert<{{dtype}}>(1.0) / (type_convert<{{dtype}}>(1.0) + type_convert<{{dtype}}>(exp(ck::type_convert<float>(-x))));
+        const {{dtype}} x3 = x2*d0;
         // 1-2/(e^(2x)+1)
-        e = type_convert<half_t>(1.0) - type_convert<half_t>(2.0) /
-                    (type_convert<half_t>(1.0) + type_convert<half_t>(exp(ck::type_convert<float>(2*x3))));
+        e = type_convert<{{dtype}}>(1.0) - type_convert<{{dtype}}>(2.0) /
+                    (type_convert<{{dtype}}>(1.0) + type_convert<{{dtype}}>(exp(ck::type_convert<float>(2*x3))));
     };
 };
 } // namespace
@@ -94,13 +95,17 @@ def gen_profiler(func_attrs, workdir, profiler_name, dim_info_dict):
         Generated from gemm._extract_dims().
         Used to store mapping between dim_names to input / output tensor dims.
     """
+    x = func_attrs["inputs"][0]
+    spec = ROCMSpec()
+    lib_dtype = spec.dtype_to_lib_type(x._attrs["dtype"])
+
     return common.gen_profiler(
         func_attrs=func_attrs,
         workdir=workdir,
         dim_info_dict=dim_info_dict,
         args_parse=RCR.args_parse,
         gemm_flag="bias_sigmoid_mul_tanh",
-        extra_code=EXTRA_CODE.render(),
+        extra_code=EXTRA_CODE.render(dtype=lib_dtype),
         profiler_name=profiler_name,
     )
 
@@ -128,12 +133,16 @@ def gen_function(
     str
         The rendered template of generated function body.
     """
+    x = func_attrs["inputs"][0]
+    spec = ROCMSpec()
+    lib_dtype = spec.dtype_to_lib_type(x._attrs["dtype"])
+
     return common.gen_function(
         func_attrs,
         exec_cond_template,
         dim_info_dict,
         "bias_sigmoid_mul_tanh",
-        extra_code=EXTRA_CODE.render(),
+        extra_code=EXTRA_CODE.render(dtype=lib_dtype),
         input_addr_calculator=common.INPUT_ADDR_CALCULATOR.render(
             accessor_a=func_attrs["input_accessors"][0],
             accessor_b=func_attrs["input_accessors"][1],
@@ -160,7 +169,7 @@ def gen_function_decl(func_attrs):
     """
     func_name = func_attrs["name"]
     return common.gen_function_decl(
-        func_name=func_name,
+        func_attrs,
         gemm_flag="bias_sigmoid_mul_tanh",
         has_d0=common.has_d0(func_attrs),
         has_d1=common.has_d1(func_attrs),

--- a/src/dinoml/backend/rocm/gemm/gemm_rcr_bias_swish.py
+++ b/src/dinoml/backend/rocm/gemm/gemm_rcr_bias_swish.py
@@ -22,6 +22,7 @@ When used for `linear`, need to set A->Data, B->Weight, C->Bias
 import jinja2
 
 from dinoml.backend import registry
+from dinoml.backend.backend_spec import ROCMSpec
 from dinoml.backend.rocm.gemm import common
 from dinoml.backend.rocm.gemm.layout import RCR
 
@@ -54,10 +55,10 @@ struct AddSwish
     };
     template <>
     __host__ __device__ constexpr void
-    operator()<ck::half_t>(ck::half_t& y, const ck::half_t& x0, const ck::half_t& x1) const
+    operator()<{{dtype}}>({{dtype}}& y, const {{dtype}}& x0, const {{dtype}}& x1) const
     {
-        const ck::half_t a = x0 + x1;
-        y                  = a / (ck::type_convert<ck::half_t>(1.0) + ck::type_convert<ck::half_t>(exp(ck::type_convert<float>(-a))));
+        const {{dtype}} a = x0 + x1;
+        y                  = a / (ck::type_convert<{{dtype}}>(1.0) + ck::type_convert<{{dtype}}>(exp(ck::type_convert<float>(-a))));
     };
 };
 } // namespace
@@ -105,13 +106,17 @@ def gemm_gen_profiler(func_attrs, workdir, profiler_name, dim_info_dict):
         Generated from gemm._extract_dims().
         Used to store mapping between dim_names to input / output tensor dims.
     """
+    x = func_attrs["inputs"][0]
+    spec = ROCMSpec()
+    lib_dtype = spec.dtype_to_lib_type(x._attrs["dtype"])
+
     return common.gen_profiler(
         func_attrs=func_attrs,
         workdir=workdir,
         dim_info_dict=dim_info_dict,
         args_parse=RCR.args_parse,
         gemm_flag="bias_swish",
-        extra_code=EXTRA_CODE.render(),
+        extra_code=EXTRA_CODE.render(dtype=lib_dtype),
         profiler_name=profiler_name,
     )
 
@@ -135,12 +140,16 @@ def gemm_gen_function(func_attrs, exec_cond_template, dim_info_dict):
     str
         The rendered template of generated function body.
     """
+    x = func_attrs["inputs"][0]
+    spec = ROCMSpec()
+    lib_dtype = spec.dtype_to_lib_type(x._attrs["dtype"])
+
     return common.gen_function(
         func_attrs,
         exec_cond_template,
         dim_info_dict,
         "bias_swish",
-        extra_code=EXTRA_CODE.render(),
+        extra_code=EXTRA_CODE.render(dtype=lib_dtype),
         input_addr_calculator=common.INPUT_ADDR_CALCULATOR.render(
             accessor_a=func_attrs["input_accessors"][0],
             accessor_b=func_attrs["input_accessors"][1],
@@ -166,7 +175,7 @@ def gemm_gen_function_decl(func_attrs):
         The rentered template of function declaration.
     """
     func_name = func_attrs["name"]
-    return common.gen_function_decl(func_name=func_name, gemm_flag="bias_swish")
+    return common.gen_function_decl(func_attrs, gemm_flag="bias_swish")
 
 
 @registry.reg("rocm.gemm_rcr_bias_swish.func_call")

--- a/src/dinoml/backend/rocm/gemm/gemm_rcr_bias_tanh.py
+++ b/src/dinoml/backend/rocm/gemm/gemm_rcr_bias_tanh.py
@@ -22,6 +22,7 @@ When used for `linear`, need to set A->Data, B->Weight, C->Bias
 import jinja2
 
 from dinoml.backend import registry
+from dinoml.backend.backend_spec import ROCMSpec
 from dinoml.backend.rocm.gemm import common
 from dinoml.backend.rocm.gemm.layout import RCR
 
@@ -111,13 +112,17 @@ def gemm_gen_profiler(func_attrs, workdir, profiler_name, dim_info_dict):
         Generated from gemm._extract_dims().
         Used to store mapping between dim_names to input / output tensor dims.
     """
+    x = func_attrs["inputs"][0]
+    spec = ROCMSpec()
+    lib_dtype = spec.dtype_to_lib_type(x._attrs["dtype"])
+
     return common.gen_profiler(
         func_attrs=func_attrs,
         workdir=workdir,
         dim_info_dict=dim_info_dict,
         args_parse=RCR.args_parse,
         gemm_flag="bias_tanh",
-        extra_code=EXTRA_CODE.render(),
+        extra_code=EXTRA_CODE.render(dtype=lib_dtype),
         profiler_name=profiler_name,
     )
 
@@ -141,12 +146,16 @@ def gemm_gen_function(func_attrs, exec_cond_template, dim_info_dict):
     str
         The rendered template of generated function body.
     """
+    x = func_attrs["inputs"][0]
+    spec = ROCMSpec()
+    lib_dtype = spec.dtype_to_lib_type(x._attrs["dtype"])
+
     return common.gen_function(
         func_attrs,
         exec_cond_template,
         dim_info_dict,
         "bias_tanh",
-        extra_code=EXTRA_CODE.render(),
+        extra_code=EXTRA_CODE.render(dtype=lib_dtype),
         input_addr_calculator=common.INPUT_ADDR_CALCULATOR.render(
             accessor_a=func_attrs["input_accessors"][0],
             accessor_b=func_attrs["input_accessors"][1],
@@ -172,7 +181,7 @@ def gemm_gen_function_decl(func_attrs):
         The rentered template of function declaration.
     """
     func_name = func_attrs["name"]
-    return common.gen_function_decl(func_name=func_name, gemm_flag="bias_tanh")
+    return common.gen_function_decl(func_attrs, gemm_flag="bias_tanh")
 
 
 @registry.reg("rocm.gemm_rcr_bias_tanh.func_call")

--- a/src/dinoml/backend/rocm/gemm/gemm_rcr_permute_m2n3.py
+++ b/src/dinoml/backend/rocm/gemm/gemm_rcr_permute_m2n3.py
@@ -141,7 +141,7 @@ def gemm_gen_function_decl(func_attrs):
     """
     func_name = func_attrs["name"]
     return common.gen_function_decl(
-        func_name=func_name, gemm_flag="", pdims=len(func_attrs["shape"])
+        func_attrs, gemm_flag="", pdims=len(func_attrs["shape"])
     )
 
 

--- a/src/dinoml/backend/rocm/gemm/gemm_rrr.py
+++ b/src/dinoml/backend/rocm/gemm/gemm_rrr.py
@@ -122,7 +122,7 @@ def gemm_gen_function_decl(func_attrs):
         The rentered template of function declaration.
     """
     func_name = func_attrs["name"]
-    return common.gen_function_decl(func_name=func_name, gemm_flag="")
+    return common.gen_function_decl(func_attrs, gemm_flag="")
 
 
 @registry.reg("rocm.gemm_rrr.func_call")

--- a/src/dinoml/backend/rocm/gemm/gemm_rrr_bias.py
+++ b/src/dinoml/backend/rocm/gemm/gemm_rrr_bias.py
@@ -122,7 +122,7 @@ def gemm_gen_function_decl(func_attrs):
         The rentered template of function declaration.
     """
     func_name = func_attrs["name"]
-    return common.gen_function_decl(func_name=func_name, gemm_flag="bias")
+    return common.gen_function_decl(func_attrs, gemm_flag="bias")
 
 
 @registry.reg("rocm.gemm_rrr_bias.func_call")

--- a/src/dinoml/backend/rocm/gemm/gemm_rrr_bias_permute.py
+++ b/src/dinoml/backend/rocm/gemm/gemm_rrr_bias_permute.py
@@ -125,7 +125,7 @@ def gemm_gen_function_decl(func_attrs):
         The rentered template of function declaration.
     """
     func_name = func_attrs["name"]
-    return common.gen_function_decl(func_name=func_name, gemm_flag="bias")
+    return common.gen_function_decl(func_attrs, gemm_flag="bias")
 
 
 @registry.reg("rocm.gemm_rrr_bias_permute.func_call")

--- a/src/dinoml/backend/rocm/lib_template.py
+++ b/src/dinoml/backend/rocm/lib_template.py
@@ -39,6 +39,8 @@ def void_ptr_decl(name, dtype="float16", indent="  "):
     # return PTR_TEMPLATE.render(name=name, dtype="void*", indent=indent)
     if dtype == "float16":
         type_string = "ck::half_t*"
+    elif dtype == "bfloat16":
+        type_string = "ck::bhalf_t*"
     elif dtype == "int64":
         type_string = "int64_t*"
     elif dtype == "bool":

--- a/src/dinoml/backend/rocm/normalization/groupnorm.py
+++ b/src/dinoml/backend/rocm/normalization/groupnorm.py
@@ -18,19 +18,22 @@ Groupnorm codegen for ROCM.
 
 from collections import OrderedDict
 from hashlib import sha1
+import os
 from typing import Any, Dict
 
 import jinja2
 
 from dinoml.backend import registry
+from dinoml.backend.backend_spec import ROCMSpec
 from dinoml.backend.rocm.normalization import norm_common
 from dinoml.backend.target import Target
 
 from dinoml.compiler.base import IntImm
+from dinoml.utils.shape_utils import get_shape
 
 EXTRA_HEADERS = jinja2.Template(
     """
-#include "ck/tensor_operation/gpu/device/impl/device_normalization_impl.hpp"
+#include "ck/tensor_operation/gpu/device/impl/device_normalization_fwd_impl.hpp"
 """
 )
 
@@ -39,20 +42,25 @@ EXTRA_CODE_TEMPLATE = jinja2.Template(
 {%if use_swish %}
 struct YElementOp
 {
-    template <typename T>
-    __host__ __device__ void operator()(T& y, const T& x) const
+    template <typename Y, typename X>
+    __host__ __device__ void operator()(Y& y, const X& x) const
     {
-        static_assert(ck::is_same<T, float>::value || ck::is_same<T, double>::value ||
-                          ck::is_same<T, ck::half_t>::value,
+        static_assert(ck::is_same<X, float>::value || ck::is_same<X, double>::value ||
+                          ck::is_same<X, {{dtype}}>::value,
                       "Data type is not supported by this operation!");
 
-        T a;
+        static_assert(ck::is_same<Y, float>::value || ck::is_same<Y, double>::value ||
+                          ck::is_same<Y, {{dtype}}>::value,
+                      "Data type is not supported by this operation!");
+
+        X a;
 
         ck::tensor_operation::element_wise::Sigmoid{}(a, x);
 
-        y = x * a;
+        y = ck::type_convert<Y>(x * a);
     };
 };
+
 
 {% else %}
 
@@ -63,7 +71,7 @@ using YElementOp   = ck::tensor_operation::element_wise::PassThrough;
 )
 
 FUNC_CALL_FP16_PARAM_TEMPLATE = jinja2.Template(
-    "reinterpret_cast<ck::half_t*>(({{name}}))"
+    "reinterpret_cast<{{dtype}}*>(({{name}}))"
 )
 
 TENSOR_DECL_TEMPLATE = jinja2.Template(
@@ -122,12 +130,14 @@ EXEC_TEMPLATE = jinja2.Template(
         gamma_beta_Strides,
         gamma_beta_Strides,
         i_inStrides, // y stride
+        std::vector<ck::index_t>{0, 0},
+        std::vector<ck::index_t>{0, 0},
         {1, 2, 4}, // reduction dimension: [H, W, C]
         1e-5,
-        static_cast<ck::half_t *>(input),
-        static_cast<ck::half_t *>(gamma),
-        static_cast<ck::half_t *>(beta),
-        static_cast<ck::half_t *>(output),
+        static_cast<{{dtype}} *>(input),
+        static_cast<{{dtype}} *>(gamma),
+        static_cast<{{dtype}} *>(beta),
+        static_cast<{{dtype}} *>(output),
         nullptr,
         nullptr,
         YElementOp{}
@@ -223,12 +233,42 @@ def groupnorm_extract_config(func_attrs):
     """
     import dinoml.utils.ck_lib as ck_lib
 
+    x = func_attrs["inputs"][0]
+    spec = ROCMSpec()
+    lib_dtype = spec.dtype_to_lib_type(x._attrs["dtype"])
+
+    if lib_dtype == "float":
+        data_type = ck_lib.library.DataType.f32
+        acc_type = ck_lib.library.DataType.f32
+    elif lib_dtype == "ck::half_t":
+        data_type = ck_lib.library.DataType.f16
+        acc_type = ck_lib.library.DataType.f32
+        # check target use fp16 acc
+        if (
+            "use_fp16_acc" in Target.current()._kwargs
+            and Target.current().name() != "rocm"
+        ):
+            if Target.current()._kwargs["use_fp16_acc"]:
+                acc_type = ck_lib.library.DataType.f16
+    elif lib_dtype == "ck::bhalf_t":
+        data_type = ck_lib.library.DataType.bf16
+        acc_type = ck_lib.library.DataType.f32
+    else:
+        raise RuntimeError(f"Unsupported dtype {lib_dtype}")
+
+    def f_proc_op(op: ck_lib.groupnorm_operation.GroupNormOperation):
+        if op.In == data_type and op.Out == data_type and op.acc_dtype == acc_type:
+            return op
+        return None
+
     op_kind = ck_lib.library.OperationKind.GroupNorm
     extra_kind = 5
     extract_ops = list(Target.current()._operators[op_kind][extra_kind].items())
     groupnorm_ops = OrderedDict()
     for key, value in extract_ops:
-        groupnorm_ops[key] = value[0]
+        op = value[0]
+        if f_proc_op(op) is not None:
+            groupnorm_ops[key] = op
     func_attrs["op_instance"] = groupnorm_ops
 
 
@@ -240,12 +280,218 @@ def get_func_signature_profiler(func_attrs: Dict[str, Any]) -> str:
     ).strip()
 
 
+PROFILER_TEMPLATE = jinja2.Template(
+    """
+#include <iostream>
+#include <numeric>
+#include <initializer_list>
+#include <cstdlib>
+#include <stdlib.h>
+#include <random>
+#include <rocrand/rocrand.h>
+#include "logging.h"
+//include "ck/utility/print.hpp"
+#include "ck/library/utility/device_memory.hpp"
+#include "ck/library/utility/host_tensor.hpp"
+#include "ck/library/utility/host_tensor_generator.hpp"
+#include "ck/tensor_operation/gpu/device/tensor_layout.hpp"
+#include "ck/utility/reduction_operator.hpp"
+{{extra_headers}}
+
+{{extra_code}}
+
+size_t GLOBAL_WORKSPACE_SIZE = 0;
+
+{{structs_def}}
+
+{{all_instances}}
+
+template <typename Instance>
+int benchmark_norm(
+    Instance& device_instance,
+    const char* op_name,
+    ProfilerMemoryPool* memory_pool,
+    int64_t N,
+    int64_t H,
+    int64_t W,
+    int64_t G,
+    int64_t C,
+    hipStream_t stream)
+{
+    C = C / G;
+
+    std::vector<ck::index_t> i_inStrides = {
+        static_cast<int>(H * W * G * C),
+        static_cast<int>(W * G * C),
+        static_cast<int>(G * C),
+        static_cast<int>(C),
+        1
+    };
+
+    std::vector<ck::index_t> gamma_beta_Strides = {
+        0, 0, 0, static_cast<int>(C), 1
+    };
+
+    auto argument_ptr = device_instance.MakeArgumentPointer(
+        {static_cast<ck::index_t>(N),
+         static_cast<ck::index_t>(H),
+         static_cast<ck::index_t>(W),
+         static_cast<ck::index_t>(G),
+         static_cast<ck::index_t>(C)},
+        i_inStrides,
+        gamma_beta_Strides,
+        gamma_beta_Strides,
+        i_inStrides,
+        std::vector<ck::index_t>{0, 0},
+        std::vector<ck::index_t>{0, 0},
+        {1, 2, 4},
+        1e-5,
+        memory_pool->RequestHalfTensorByIdx(0),
+        memory_pool->RequestHalfTensorByIdx(2),
+        memory_pool->RequestHalfTensorByIdx(3),
+        memory_pool->RequestHalfTensorByIdx(1),
+        nullptr,
+        nullptr,
+        YElementOp{}
+    );
+
+    if(!device_instance.IsSupportedArgument(argument_ptr.get()))
+    {
+        return -1;
+    }
+
+    // warmup
+    auto invoker = device_instance.MakeInvokerPointer();
+    for(int i = 0; i < 3; ++i)
+    {
+        invoker->Run(argument_ptr.get(), StreamConfig{stream, false});
+    }
+
+    KernelTimerImpl timer;
+    timer.Start();
+    for(int i = 0; i < 5; ++i)
+    {
+        invoker->Run(argument_ptr.get(), StreamConfig{stream, false});
+    }
+    timer.End();
+
+    std::cout << "OP:" << op_name
+              << ",TIME:" << timer.GetElapsedTime()
+              << ",WS:" << GLOBAL_WORKSPACE_SIZE
+              << std::endl
+              << std::flush;
+
+    return 0;
+}
+
+int main(int argc, char** argv) {
+  {{args_parse}}
+  auto memory_pool = std::make_unique<ProfilerMemoryPool>();
+  hipStream_t stream = nullptr;
+  {{tensor_decl}}
+  {% for op_name, inst_name in instances %}
+{
+    {{inst_name}} device_instance;
+    benchmark_norm(
+        device_instance,
+        "{{op_name}}",
+        memory_pool.get(),
+        in_0, in_1, in_2, in_3, in_4,
+        stream);
+}
+{% endfor %}
+}
+"""
+)
+
+
+def gen_profiler(
+    func_attrs: Dict[str, Any],
+    workdir: str,
+    rank: int,
+    extra_header_template: jinja2.Template,
+    extra_code: str = "",
+    profile_filename=None,
+    indent: str = "  ",
+) -> str:
+    """Generates standalone executables for profiler.
+
+    Parameters
+    ----------
+    func_attrs : Dict
+        Operation attributes.
+    workdir : str
+        Directory to store the generated outputs.
+    rank: int
+        Rank of the input tensor. If using [M, N] in exec_key, the rank here
+        must be 2 because if implies that the inputs are reshaped for profiling.
+        For code gen, the real shapes are used.
+    exec_template : jinja2.Template
+        Execution block template.
+    tensor_decl_template: jinja2.Template
+        Tensor declaration template.
+    extra_header_template : jinja2.Template
+        Extra header template.
+    indent : str, optional
+        Indent for codegen, target dependent e.g. C++, python, etc., by default "  ".
+    """
+    x = func_attrs["inputs"][0]
+    spec = ROCMSpec()
+    lib_dtype = spec.dtype_to_lib_type(x._attrs["dtype"])
+
+    op_type = func_attrs["op"]
+    op_instance = func_attrs["op_instance"]
+
+    all_instances_decl = ""
+    instance_names = []
+
+    for idx, (op_name, op) in enumerate(op_instance.items()):
+        config = norm_common.emit_instance(op)
+        config_name = norm_common.extract_config_name(config)
+        inst_name = f"DeviceInstance_{idx}"
+
+        all_instances_decl += norm_common.INSTANCE_TEMPLATE.render(
+            name=inst_name,
+            config_name=config_name,
+            config=config,
+        )
+        instance_names.append((op_name, inst_name))
+
+    structs_def = norm_common.STRUCTS_DEF_TEMPLATE.render(dtype=lib_dtype)
+    args_parse = norm_common.ARGS_PARSE_TEMPLATE.render(rank=rank)
+    tensor_decl = TENSOR_DECL_TEMPLATE.render(rank=rank)
+
+    file_pairs = []
+    code = PROFILER_TEMPLATE.render(
+        structs_def=structs_def,
+        args_parse=args_parse,
+        tensor_decl=tensor_decl,
+        instances=instance_names,
+        all_instances=all_instances_decl,
+        extra_headers=extra_header_template.render(),
+        extra_code=extra_code,
+    )
+
+    prefix = os.path.join(workdir, "profiler", op_type)
+    if not os.path.exists(prefix):
+        os.makedirs(prefix)
+    src_path = os.path.join(prefix, profile_filename + ".cpp")
+    obj_path = os.path.join(prefix, profile_filename)
+    if os.path.exists(obj_path):
+        return
+    with open(src_path, "w") as fo:
+        fo.write(code)
+    file_pairs.append((src_path, obj_path))
+    return file_pairs
+
+
 @registry.reg("rocm.groupnorm.gen_profiler")
 def groupnorm_gen_profiler(
     func_attrs: Dict[str, Any],
     workdir: str,
     indent: str = "  ",
     use_swish: bool = False,
+    profile_filename=None,
 ) -> str:
     """Generates standalone executables for profiler.
 
@@ -261,25 +507,24 @@ def groupnorm_gen_profiler(
         Use swish if True
     """
     # N, H, W, C
-    shapes = func_attrs["inputs"][0]._attrs["shape"]
+    x = func_attrs["inputs"][0]
+    spec = ROCMSpec()
+    lib_dtype = spec.dtype_to_lib_type(x._attrs["dtype"])
 
-    for dim_idx in (1, 2, 3):
-        assert isinstance(shapes[dim_idx], IntImm), (
-            f"groupnorm requires reduction dim {dim_idx=} to be static"
-        )
-
-    return norm_common.gen_profiler(
+    shapes = []
+    for dim in func_attrs["inputs"][0]._attrs["shape"]:
+        if isinstance(dim, IntImm):
+            shapes.append(dim.value())
+        else:
+            shapes.append(dim.upper_bound())
+    return gen_profiler(
         func_attrs,
         workdir,
-        5,  # rank
-        SHAPE_EVAL_TEMPLATE,
-        EXEC_TEMPLATE,
-        TENSOR_DECL_TEMPLATE,
-        EXTRA_HEADERS,
-        get_func_signature_profiler,
-        EXTRA_CODE_TEMPLATE.render(use_swish=use_swish),
-        PROFILER_FUNC_CALL_TEMPLATE,
-        indent,
+        rank=5,
+        extra_header_template=EXTRA_HEADERS,
+        extra_code=EXTRA_CODE_TEMPLATE.render(use_swish=use_swish, dtype=lib_dtype),
+        profile_filename=profile_filename,
+        indent=indent,
     )
 
 
@@ -313,6 +558,10 @@ def gen_function(
     str
         The rendered template of generated function body.
     """
+    x = func_attrs["inputs"][0]
+    spec = ROCMSpec()
+    lib_dtype = spec.dtype_to_lib_type(x._attrs["dtype"])
+
     exec_path = func_attrs["exec_path"]
     op_instance = func_attrs["op_instance"]
 
@@ -339,7 +588,7 @@ def gen_function(
     exec_paths = ""
     for key, _ in instances.items():
         fname = "f" + sha1(key.encode()).hexdigest()
-        program = exec_template.render(instance=fname, dtype="void")
+        program = exec_template.render(instance=fname, dtype=lib_dtype)
         exec_inst = exec_cond_template.render(indent="  ", cond=key, program=program)
         exec_paths += exec_inst
 
@@ -349,7 +598,7 @@ def gen_function(
         shape_eval="",
         exec_paths=exec_paths,
         extra_headers=extra_header_template.render(),
-        extra_code=extra_code_template.render(use_swish=use_swish),
+        extra_code=extra_code_template.render(use_swish=use_swish, dtype=lib_dtype),
     )
 
 
@@ -369,11 +618,6 @@ def groupnorm_gen_function(func_attrs: Dict[str, Any], use_swish: bool = False) 
     """
     # N, H, W, C
     shapes = func_attrs["inputs"][0]._attrs["shape"]
-
-    for dim_idx in (1, 2, 3):
-        assert isinstance(shapes[dim_idx], IntImm), (
-            f"groupnorm requires reduction dim {dim_idx=} to be static"
-        )
 
     return gen_function(
         func_attrs,
@@ -405,17 +649,21 @@ def groupnorm_gen_func_call(func_attrs, indent="  "):
     assert len(func_attrs["outputs"]) == 1
     assert len(func_attrs["inputs"]) == 3
 
+    x = func_attrs["inputs"][0]
+    spec = ROCMSpec()
+    lib_dtype = spec.dtype_to_lib_type(x._attrs["dtype"])
+
     input_name = FUNC_CALL_FP16_PARAM_TEMPLATE.render(
-        name=func_attrs["inputs"][0]._attrs["name"]
+        name=func_attrs["inputs"][0]._attrs["name"], dtype=lib_dtype
     )
     gamma_name = FUNC_CALL_FP16_PARAM_TEMPLATE.render(
-        name=func_attrs["inputs"][1]._attrs["name"]
+        name=func_attrs["inputs"][1]._attrs["name"], dtype=lib_dtype
     )
     beta_name = FUNC_CALL_FP16_PARAM_TEMPLATE.render(
-        name=func_attrs["inputs"][2]._attrs["name"]
+        name=func_attrs["inputs"][2]._attrs["name"], dtype=lib_dtype
     )
     output_name = FUNC_CALL_FP16_PARAM_TEMPLATE.render(
-        name=func_attrs["outputs"][0]._attrs["name"]
+        name=func_attrs["outputs"][0]._attrs["name"], dtype=lib_dtype
     )
 
     shapes = func_attrs["inputs"][0]._attrs["shape"]

--- a/src/dinoml/backend/rocm/normalization/groupnorm_swish.py
+++ b/src/dinoml/backend/rocm/normalization/groupnorm_swish.py
@@ -31,8 +31,15 @@ def extract_config(func_attrs):
 
 
 @registry.reg("rocm.groupnorm_swish.gen_profiler")
-def gen_profiler(func_attrs: Dict[str, Any], workdir: str, indent: str = "  ") -> str:
-    return groupnorm_gen_profiler(func_attrs, workdir, indent, use_swish=True)
+def gen_profiler(
+    func_attrs: Dict[str, Any],
+    workdir: str,
+    indent: str = "  ",
+    profile_filename=None,
+) -> str:
+    return groupnorm_gen_profiler(
+        func_attrs, workdir, indent, use_swish=True, profile_filename=profile_filename
+    )
 
 
 @registry.reg("rocm.groupnorm_swish.gen_function")

--- a/src/dinoml/backend/rocm/normalization/layernorm.py
+++ b/src/dinoml/backend/rocm/normalization/layernorm.py
@@ -18,11 +18,13 @@ Layernorm codegen for ROCM.
 
 from collections import OrderedDict
 from hashlib import sha1
+import os
 from typing import Any, Dict
 
 import jinja2
 
 from dinoml.backend import registry
+from dinoml.backend.backend_spec import ROCMSpec
 from dinoml.backend.rocm.normalization import norm_common
 from dinoml.backend.target import Target
 
@@ -30,12 +32,12 @@ from dinoml.compiler.base import IntImm
 
 EXTRA_HEADERS = jinja2.Template(
     """
-#include "ck/tensor_operation/gpu/device/impl/device_normalization_impl.hpp"
+#include "ck/tensor_operation/gpu/device/impl/device_normalization_fwd_impl.hpp"
 """
 )
 
 FUNC_CALL_FP16_PARAM_TEMPLATE = jinja2.Template(
-    "reinterpret_cast<ck::half_t*>(({{name}}))"
+    "reinterpret_cast<{{dtype}}*>(({{name}}))"
 )
 
 TENSOR_DECL_TEMPLATE = jinja2.Template(
@@ -90,12 +92,14 @@ EXEC_TEMPLATE = jinja2.Template(
         std::vector<ck::index_t>{0, 1},
         std::vector<ck::index_t>{0, 1},
         i_outStrides,
+        std::vector<ck::index_t>{0},
+        std::vector<ck::index_t>{0},
         {1},
         {{eps}},
-        static_cast<ck::half_t *>(input) + {{ input_offset if input_offset is defined else 0 }},
-        static_cast<ck::half_t *>(gamma),
-        static_cast<ck::half_t *>(beta),
-        static_cast<ck::half_t *>(output) + {{ output_offset if output_offset is defined else 0 }},
+        static_cast<{{dtype}} *>(input) + {{ input_offset if input_offset is defined else 0 }},
+        static_cast<{{dtype}} *>(gamma),
+        static_cast<{{dtype}} *>(beta),
+        static_cast<{{dtype}} *>(output) + {{ output_offset if output_offset is defined else 0 }},
         nullptr,
         nullptr,
         ck::tensor_operation::element_wise::PassThrough{}
@@ -168,12 +172,42 @@ def extract_config(func_attrs):
     """
     import dinoml.utils.ck_lib as ck_lib
 
+    x = func_attrs["inputs"][0]
+    spec = ROCMSpec()
+    lib_dtype = spec.dtype_to_lib_type(x._attrs["dtype"])
+
+    if lib_dtype == "float":
+        data_type = ck_lib.library.DataType.f32
+        acc_type = ck_lib.library.DataType.f32
+    elif lib_dtype == "ck::half_t":
+        data_type = ck_lib.library.DataType.f16
+        acc_type = ck_lib.library.DataType.f32
+        # check target use fp16 acc
+        if (
+            "use_fp16_acc" in Target.current()._kwargs
+            and Target.current().name() != "rocm"
+        ):
+            if Target.current()._kwargs["use_fp16_acc"]:
+                acc_type = ck_lib.library.DataType.f16
+    elif lib_dtype == "ck::bhalf_t":
+        data_type = ck_lib.library.DataType.bf16
+        acc_type = ck_lib.library.DataType.f32
+    else:
+        raise RuntimeError(f"Unsupported dtype {lib_dtype}")
+
+    def f_proc_op(op: ck_lib.layernorm_operation.LayerNormOperation):
+        if op.In == data_type and op.Out == data_type and op.acc_dtype == acc_type:
+            return op
+        return None
+
     op_kind = ck_lib.library.OperationKind.LayerNorm
     extra_kind = 2
     extract_ops = list(Target.current()._operators[op_kind][extra_kind].items())
     layernorm_ops = OrderedDict()
     for key, value in extract_ops:
-        layernorm_ops[key] = value[0]
+        op = value[0]
+        if f_proc_op(op) is not None:
+            layernorm_ops[key] = op
     func_attrs["op_instance"] = layernorm_ops
 
 
@@ -185,9 +219,208 @@ def get_func_signature_profiler(func_attrs: Dict[str, Any]) -> str:
     ).strip()
 
 
+PROFILER_TEMPLATE = jinja2.Template(
+    """
+#include <iostream>
+#include <numeric>
+#include <initializer_list>
+#include <cstdlib>
+#include <stdlib.h>
+#include <random>
+#include <rocrand/rocrand.h>
+#include "logging.h"
+//include "ck/utility/print.hpp"
+#include "ck/library/utility/device_memory.hpp"
+#include "ck/library/utility/host_tensor.hpp"
+#include "ck/library/utility/host_tensor_generator.hpp"
+#include "ck/tensor_operation/gpu/device/tensor_layout.hpp"
+#include "ck/utility/reduction_operator.hpp"
+{{extra_headers}}
+
+{{extra_code}}
+
+size_t GLOBAL_WORKSPACE_SIZE = 0;
+
+{{structs_def}}
+
+{{all_instances}}
+
+template <typename Instance>
+int benchmark_norm(
+    Instance& device_instance,
+    const char* op_name,
+    ProfilerMemoryPool* memory_pool,
+    int64_t in_0,
+    int64_t in_1,
+    float eps,
+    hipStream_t stream)
+{
+    // in_0 = M, in_1 = N (reduction dim)
+    int M = static_cast<int>(in_0);
+    int N = static_cast<int>(in_1);
+
+    std::vector<ck::index_t> i_inStrides = {static_cast<ck::index_t>(N), 1};
+    std::vector<ck::index_t> i_outStrides = {static_cast<ck::index_t>(N), 1};
+
+    auto argument_ptr = device_instance.MakeArgumentPointer(
+        {M, N},
+        i_inStrides,
+        std::vector<ck::index_t>{0, 1},
+        std::vector<ck::index_t>{0, 1},
+        i_outStrides,
+        std::vector<ck::index_t>{0},
+        std::vector<ck::index_t>{0},
+        {1},
+        eps,
+        memory_pool->RequestHalfTensorByIdx(0), // input
+        memory_pool->RequestHalfTensorByIdx(2), // gamma
+        memory_pool->RequestHalfTensorByIdx(3), // beta
+        memory_pool->RequestHalfTensorByIdx(1), // output
+        nullptr,
+        nullptr,
+        ck::tensor_operation::element_wise::PassThrough{}
+    );
+
+    if(!device_instance.IsSupportedArgument(argument_ptr.get()))
+    {
+        return -1;
+    }
+
+    auto invoker = device_instance.MakeInvokerPointer();
+
+    // warmup
+    for(int i = 0; i < 3; ++i)
+    {
+        invoker->Run(argument_ptr.get(), StreamConfig{stream, false});
+    }
+
+    KernelTimerImpl timer;
+    timer.Start();
+    for(int i = 0; i < 5; ++i)
+    {
+        invoker->Run(argument_ptr.get(), StreamConfig{stream, false});
+    }
+    timer.End();
+
+    std::cout << "OP:" << op_name
+              << ",TIME:" << timer.GetElapsedTime()
+              << ",WS:" << GLOBAL_WORKSPACE_SIZE
+              << std::endl
+              << std::flush;
+
+    return 0;
+}
+
+int main(int argc, char** argv) {
+  {{args_parse}}
+  auto memory_pool = std::make_unique<ProfilerMemoryPool>();
+  hipStream_t stream = nullptr;
+  {{tensor_decl}}
+  {% for op_name, inst_name in instances %}
+{
+    {{inst_name}} device_instance;
+    benchmark_norm(
+        device_instance,
+        "{{op_name}}",
+        memory_pool.get(),
+        in_0, in_1,
+        {{eps}},
+        stream);
+}
+{% endfor %}
+}
+"""
+)
+
+
+def gen_profiler(
+    func_attrs: Dict[str, Any],
+    workdir: str,
+    rank: int,
+    extra_header_template: jinja2.Template,
+    extra_code: str = "",
+    profile_filename=None,
+    indent: str = "  ",
+) -> str:
+    """Generates standalone executables for profiler.
+
+    Parameters
+    ----------
+    func_attrs : Dict
+        Operation attributes.
+    workdir : str
+        Directory to store the generated outputs.
+    rank: int
+        Rank of the input tensor. If using [M, N] in exec_key, the rank here
+        must be 2 because if implies that the inputs are reshaped for profiling.
+        For code gen, the real shapes are used.
+    exec_template : jinja2.Template
+        Execution block template.
+    tensor_decl_template: jinja2.Template
+        Tensor declaration template.
+    extra_header_template : jinja2.Template
+        Extra header template.
+    indent : str, optional
+        Indent for codegen, target dependent e.g. C++, python, etc., by default "  ".
+    """
+    x = func_attrs["inputs"][0]
+    spec = ROCMSpec()
+    lib_dtype = spec.dtype_to_lib_type(x._attrs["dtype"])
+
+    op_type = func_attrs["op"]
+    op_instance = func_attrs["op_instance"]
+    eps = func_attrs.get("eps", "1e-5")
+
+    all_instances_decl = ""
+    instance_names = []
+
+    for idx, (op_name, op) in enumerate(op_instance.items()):
+        config = norm_common.emit_instance(op)
+        config_name = norm_common.extract_config_name(config)
+        inst_name = f"DeviceInstance_{idx}"
+
+        all_instances_decl += norm_common.INSTANCE_TEMPLATE.render(
+            name=inst_name,
+            config_name=config_name,
+            config=config,
+        )
+        instance_names.append((op_name, inst_name))
+
+    structs_def = norm_common.STRUCTS_DEF_TEMPLATE.render(dtype=lib_dtype)
+    args_parse = norm_common.ARGS_PARSE_TEMPLATE.render(rank=rank)
+    tensor_decl = TENSOR_DECL_TEMPLATE.render(rank=rank)
+
+    file_pairs = []
+    code = PROFILER_TEMPLATE.render(
+        structs_def=structs_def,
+        args_parse=args_parse,
+        tensor_decl=tensor_decl,
+        instances=instance_names,
+        all_instances=all_instances_decl,
+        extra_headers=extra_header_template.render(),
+        extra_code=extra_code,
+        eps=eps,
+    )
+
+    prefix = os.path.join(workdir, "profiler", op_type)
+    if not os.path.exists(prefix):
+        os.makedirs(prefix)
+    src_path = os.path.join(prefix, profile_filename + ".cpp")
+    obj_path = os.path.join(prefix, profile_filename)
+    if os.path.exists(obj_path):
+        return
+    with open(src_path, "w") as fo:
+        fo.write(code)
+    file_pairs.append((src_path, obj_path))
+    return file_pairs
+
+
 @registry.reg("rocm.layernorm.gen_profiler")
 def layernorm_gen_profiler(
-    func_attrs: Dict[str, Any], workdir: str, indent: str = "  "
+    func_attrs: Dict[str, Any],
+    workdir: str,
+    indent: str = "  ",
+    profile_filename=None,
 ) -> str:
     """Generates standalone executables for profiler.
 
@@ -206,19 +439,14 @@ def layernorm_gen_profiler(
     assert isinstance(shapes[dim], IntImm), (
         "layernorm requires reduction dim to be static"
     )
-
-    return norm_common.gen_profiler(
+    return gen_profiler(
         func_attrs,
         workdir,
-        2,  # rank
-        SHAPE_EVAL_TEMPLATE,
-        EXEC_TEMPLATE,
-        TENSOR_DECL_TEMPLATE,
-        EXTRA_HEADERS,
-        get_func_signature_profiler,
-        "",  # extra_code
-        FUNC_CALL_TEMPLATE,
-        indent,
+        rank=2,
+        extra_header_template=EXTRA_HEADERS,
+        extra_code="",
+        profile_filename=profile_filename,
+        indent=indent,
     )
 
 
@@ -248,18 +476,12 @@ def gen_function(
     str
         The rendered template of generated function body.
     """
+    x = func_attrs["inputs"][0]
+    spec = ROCMSpec()
+    lib_dtype = spec.dtype_to_lib_type(x._attrs["dtype"])
+
     rank = func_attrs["inputs"][0]._rank()
     eps = func_attrs.get("eps", "1e-5")
-    input_accessor = func_attrs["input_accessors"][0]
-    output_accessor = func_attrs["output_accessors"][0]
-    input_strides = []
-    output_strides = []
-    for i, _ in enumerate(input_accessor.original_shapes):
-        input_strides.append(input_accessor.stride(i))
-        output_strides.append(output_accessor.stride(i))
-
-    input_offset = input_accessor.offset
-    output_offset = output_accessor.offset
 
     exec_path = func_attrs["exec_path"]
     op_instance = func_attrs["op_instance"]
@@ -290,13 +512,9 @@ def gen_function(
         fname = "f" + sha1(key.encode()).hexdigest()
         program = exec_template.render(
             instance=fname,
-            dtype="void",
+            dtype=lib_dtype,
             reduce_dims=rank - 1,
             eps=eps,
-            input_strides=input_strides,
-            output_strides=output_strides,
-            input_offset=input_offset,
-            output_offset=output_offset,
         )
         exec_inst = exec_cond_template.render(indent="  ", cond=key, program=program)
         exec_paths += exec_inst
@@ -359,17 +577,21 @@ def layernorm_gen_function_call(func_attrs, indent="  "):
     assert len(func_attrs["outputs"]) == 1
     assert len(func_attrs["inputs"]) == 3
 
+    x = func_attrs["inputs"][0]
+    spec = ROCMSpec()
+    lib_dtype = spec.dtype_to_lib_type(x._attrs["dtype"])
+
     input_name = FUNC_CALL_FP16_PARAM_TEMPLATE.render(
-        name=func_attrs["inputs"][0]._attrs["name"]
+        name=func_attrs["inputs"][0]._attrs["name"], dtype=lib_dtype
     )
     gamma_name = FUNC_CALL_FP16_PARAM_TEMPLATE.render(
-        name=func_attrs["inputs"][1]._attrs["name"]
+        name=func_attrs["inputs"][1]._attrs["name"], dtype=lib_dtype
     )
     beta_name = FUNC_CALL_FP16_PARAM_TEMPLATE.render(
-        name=func_attrs["inputs"][2]._attrs["name"]
+        name=func_attrs["inputs"][2]._attrs["name"], dtype=lib_dtype
     )
     output_name = FUNC_CALL_FP16_PARAM_TEMPLATE.render(
-        name=func_attrs["outputs"][0]._attrs["name"]
+        name=func_attrs["outputs"][0]._attrs["name"], dtype=lib_dtype
     )
 
     shapes = func_attrs["inputs"][0]._attrs["shape"]

--- a/src/dinoml/backend/rocm/normalization/norm_common.py
+++ b/src/dinoml/backend/rocm/normalization/norm_common.py
@@ -56,11 +56,16 @@ struct ProfilerMemoryPool {
     strides.reserve(512);
     copies.reserve(512);
     ptrs.reserve(512);
+    rocrand_status st = rocrand_create_generator(&generator, ROCRAND_RNG_PSEUDO_DEFAULT);
+    if(st != ROCRAND_STATUS_SUCCESS) {
+      throw std::runtime_error("rocrand_create_generator failed");
+    }
   }
   ~ProfilerMemoryPool() {
     for(int i = 0; i < ptrs.size(); i++){
       hipFree(ptrs[i]);
     }
+    if(generator) rocrand_destroy_generator(generator);
   }
 
   template <typename DType>
@@ -77,9 +82,9 @@ struct ProfilerMemoryPool {
     return d_x;
   }
 
-  ck::half_t* AllocateHalfGaussianTensor(int64_t size) {
-    return reinterpret_cast<ck::half_t*>(
-        AllocateGaussianTensor<ck::half_t>(size));
+  {{dtype}}* AllocateHalfGaussianTensor(int64_t size) {
+    return reinterpret_cast<{{dtype}}*>(
+        AllocateGaussianTensor<float>(size));
   }
 
   int AllocateHalfTensor(int64_t size, int64_t copy) {
@@ -91,11 +96,11 @@ struct ProfilerMemoryPool {
     return ptrs.size() - 1;
   }
 
-  ck::half_t* RequestHalfTensorByIdx(int idx) {
+  {{dtype}}* RequestHalfTensorByIdx(int idx) {
     auto copy = copies.at(idx);
     auto offset = offsets.at(idx);
     auto stride = strides.at(idx);
-    ck::half_t* ptr = reinterpret_cast<ck::half_t*>(ptrs.at(idx));
+    {{dtype}}* ptr = reinterpret_cast<{{dtype}}*>(ptrs.at(idx));
     ptr += offset;
     offset += stride;
     if (offset == copy * stride) {
@@ -113,36 +118,32 @@ struct ProfilerMemoryPool {
   rocrand_generator generator;
 };
 
-"""
-)
-
-PROFILER_TEMPLATE = jinja2.Template(
-    """
-size_t GLOBAL_WORKSPACE_SIZE = 0;
-{{op_func}}
-
-{{structs_def}}
-
-int main(int argc, char** argv) {
-  {{args_parse}}
-  auto memory_pool = std::make_unique<ProfilerMemoryPool>();
-  hipStream_t stream = nullptr;
-  {{tensor_decl}}
-  // warmup
-  for(int i = 0; i < 3; ++i) {
-    {{func_call}}
+struct KernelTimerImpl
+{
+  KernelTimerImpl() {
+    hipGetErrorString(hipEventCreateWithFlags(&mStart, hipEventDisableSystemFence));
+    hipGetErrorString(hipEventCreateWithFlags(&mEnd, hipEventDisableSystemFence));
   }
-  // run
-  KernelTimerImpl timer;
-  timer.Start();
-  for(int i = 0; i < 5; ++i) {
-    {{func_call}}
+  ~KernelTimerImpl() {
+    hipGetErrorString(hipEventDestroy(mStart));
+    hipGetErrorString(hipEventDestroy(mEnd));
   }
-  timer.End();
-  std::cout << "OP:" << "{{op_name}}" << ",";
-  std::cout << "TIME:" << timer.GetElapsedTime() << ",";
-  std::cout << "WS:" << GLOBAL_WORKSPACE_SIZE << std::endl;
-}
+  void Start() {
+    hipGetErrorString(hipDeviceSynchronize());
+    hipGetErrorString(hipEventRecord(mStart, nullptr));
+  }
+  void End() {
+    hipGetErrorString(hipEventRecord(mEnd, nullptr));
+    hipGetErrorString(hipEventSynchronize(mEnd));
+  }
+  float GetElapsedTime() const {
+    float time;
+    hipGetErrorString(hipEventElapsedTime(&time, mStart, mEnd));
+    return time;
+  }
+  hipEvent_t mStart, mEnd;
+};
+
 """
 )
 
@@ -253,104 +254,6 @@ def extract_config_name(config):
     if match is None:
         raise RuntimeError("Invalid config: \n" + config)
     return match.groups()[0]
-
-
-def gen_profiler(
-    func_attrs: Dict[str, Any],
-    workdir: str,
-    rank: int,
-    shape_eval_template: jinja2.Template,
-    exec_template: jinja2.Template,
-    tensor_decl_template: jinja2.Template,
-    extra_header_template: jinja2.Template,
-    get_func_signature: Any,
-    extra_code: str = "",
-    func_call_template: jinja2.Template = FUNC_CALL_TEMPLATE,
-    indent: str = "  ",
-) -> str:
-    """Generates standalone executables for profiler.
-
-    Parameters
-    ----------
-    func_attrs : Dict
-        Operation attributes.
-    workdir : str
-        Directory to store the generated outputs.
-    rank: int
-        Rank of the input tensor. If using [M, N] in exec_key, the rank here
-        must be 2 because if implies that the inputs are reshaped for profiling.
-        For code gen, the real shapes are used.
-    exec_template : jinja2.Template
-        Execution block template.
-    tensor_decl_template: jinja2.Template
-        Tensor declaration template.
-    extra_header_template : jinja2.Template
-        Extra header template.
-    indent : str, optional
-        Indent for codegen, target dependent e.g. C++, python, etc., by default "  ".
-    """
-    op_type = func_attrs["op"]
-    shape_eval = shape_eval_template.render(rank=rank) if shape_eval_template else ""
-    eps = func_attrs.get("eps", "1e-5")
-
-    op_instance = func_attrs["op_instance"]
-    file_pairs = []
-    for op_name, op in op_instance.items():
-        config = emit_instance(op)
-        config_name = extract_config_name(config)
-        instances = INSTANCE_TEMPLATE.render(
-            name="DeviceInstance", config_name=config_name, config=config
-        )
-        exe_path = exec_template.render(
-            instance="DeviceInstance",
-            dtype="void",
-            reduce_dims=rank - 1,
-            rank=rank,
-            eps=eps,
-        )
-
-        op_func = FUNC_TEMPLATE.render(
-            instances_decl=instances,
-            func_signature=get_func_signature(func_attrs),
-            shape_eval=shape_eval,
-            exec_paths=exe_path,
-            extra_headers=extra_header_template.render(),
-            extra_code=extra_code,
-        )
-        structs_def = STRUCTS_DEF_TEMPLATE.render()
-        args_parse = ARGS_PARSE_TEMPLATE.render(rank=rank)
-        tensor_decl = tensor_decl_template.render(rank=rank)
-
-        input_dim_names = [f"in_{i}" for i in range(rank)]
-        func_call = func_call_template.render(
-            func_name=func_attrs["name"],
-            input="(void *) memory_pool->RequestHalfTensorByIdx(0)",
-            gamma="(void *) memory_pool->RequestHalfTensorByIdx(2)",
-            beta="(void *) memory_pool->RequestHalfTensorByIdx(3)",
-            output="(void *) memory_pool->RequestHalfTensorByIdx(1)",
-            input_dim_names=input_dim_names,
-            indent=indent,
-        )
-        code = PROFILER_TEMPLATE.render(
-            op_func=op_func,
-            structs_def=structs_def,
-            args_parse=args_parse,
-            tensor_decl=tensor_decl,
-            func_call=func_call,
-            op_name=op_name,
-        )
-
-        prefix = os.path.join(workdir, "profiler", op_type)
-        if not os.path.exists(prefix):
-            os.makedirs(prefix)
-        src_path = os.path.join(prefix, op_name + ".cpp")
-        obj_path = os.path.join(prefix, op_name)
-        if os.path.exists(obj_path):
-            continue
-        with open(src_path, "w") as fo:
-            fo.write(code)
-        file_pairs.append((src_path, obj_path))
-    return file_pairs
 
 
 # no longer used by layernorm

--- a/src/dinoml/backend/rocm/target_def.py
+++ b/src/dinoml/backend/rocm/target_def.py
@@ -30,6 +30,7 @@ from dinoml.backend import registry
 from dinoml.backend.target import (
     DINOML_STATIC_FILES_PATH,
     COMPOSABLE_KERNEL_PATH,
+    _3RDPARTY_PATH,
     Target,
 )
 
@@ -84,7 +85,9 @@ class ROCM(Target):
         str
             path to rocm compiler library
         """
-        rocm_path = os.environ.get("HIP_PATH", "/opt/rocm")
+        rocm_path = os.environ.get(
+            "HIP_PATH", "/opt/rocm" if is_linux() else "C:/TheRock"
+        )
         return rocm_path
 
     def _get_ck_paths(self) -> List[str]:
@@ -95,6 +98,7 @@ class ROCM(Target):
             os.path.join(self._template_path, "library/include/"),
             os.path.join(self._template_path, "profiler/include/"),
             os.path.join(self.static_files_path, "include"),
+            str(_3RDPARTY_PATH),
             f"{self._pkg_path()}/include",
         ]
         return ck_paths

--- a/src/dinoml/backend/rocm/tensor/__init__.py
+++ b/src/dinoml/backend/rocm/tensor/__init__.py
@@ -29,6 +29,7 @@ from dinoml.backend.rocm.tensor import (  # noqa
     identity,
     meshgrid,
     pad,
+    get_timestep_embedding,
     permute021,
     permute0213,
     permute102,

--- a/src/dinoml/backend/rocm/tensor/get_timestep_embedding.py
+++ b/src/dinoml/backend/rocm/tensor/get_timestep_embedding.py
@@ -1,0 +1,154 @@
+from typing import Any, Dict, List
+
+import jinja2
+
+from dinoml.backend import registry
+from dinoml.backend.backend_spec import ROCMSpec
+from dinoml.compiler.base import IntImm, IntVar
+
+
+SRC_TEMPLATE = jinja2.Template(
+    """
+#include <dinoml/device.h>
+#include <ops/get_timestep_embedding.h>
+
+void {{function_name}}(
+    void* out,
+    const void* timesteps,
+    int64_t n,
+    int embedding_dim,
+    bool flip_sin_to_cos,
+    float downscale_freq_shift,
+    float scale,
+    int max_period,
+    dinoml::DeviceStream stream
+) {
+    invoke_get_timestep_embedding<{{elem_output_type}}, {{elem_input_type}}>(
+        out,
+        timesteps,
+        n,
+        embedding_dim,
+        flip_sin_to_cos,
+        downscale_freq_shift,
+        scale,
+        max_period,
+        stream
+    );
+}
+"""
+)
+
+FUNC_DECL_TEMPLATE = jinja2.Template(
+    """
+void {{func_name}}(
+    void*,
+    const void*,
+    int64_t,
+    int,
+    bool,
+    float,
+    float,
+    int,
+    dinoml::DeviceStream
+);
+"""
+)
+
+FUNC_CALL_TEMPLATE = jinja2.Template(
+    """
+{{indent}}{{func_name}}(
+{{indent}}    {{output}},
+{{indent}}    {{timesteps}},
+{{indent}}    {{n}},
+{{indent}}    {{embedding_dim}},
+{{indent}}    {{flip_sin_to_cos}},
+{{indent}}    {{downscale_freq_shift}},
+{{indent}}    {{scale}},
+{{indent}}    {{max_period}},
+{{indent}}    stream
+{{indent}});
+"""
+)
+
+
+def gen_int_var_product_str(int_vars: List[IntVar]) -> str:
+    res = []
+    for int_var in int_vars:
+        if isinstance(int_var, IntImm):
+            res.append(str(int_var._attrs["values"][0]))
+        elif isinstance(int_var, IntVar):
+            res.append(int_var._attrs["name"])
+        else:
+            raise RuntimeError(
+                f"A dim must be an IntVar! Current type: {type(int_var)}"
+            )
+    return " * ".join(res) if res else "1"
+
+
+def _c_bool(v: bool) -> str:
+    return "true" if v else "false"
+
+
+def _c_float(v: float) -> str:
+    if isinstance(v, int):
+        v = float(v)
+    s = repr(float(v))
+    if "e" in s or "E" in s or "." in s:
+        return f"{s}f"
+    return f"{s}.0f"
+
+
+def gen_function_call(func_attrs: Dict[str, Any], indent="  ") -> str:
+    t = func_attrs["inputs"][0]
+    y = func_attrs["outputs"][0]
+
+    n = gen_int_var_product_str(t._attrs["shape"])
+
+    return FUNC_CALL_TEMPLATE.render(
+        func_name=func_attrs["name"],
+        output=y._attrs["name"],
+        timesteps=t._attrs["name"],
+        n=n,
+        embedding_dim=str(func_attrs["embedding_dim"]),
+        flip_sin_to_cos=_c_bool(func_attrs["flip_sin_to_cos"]),
+        downscale_freq_shift=_c_float(func_attrs["downscale_freq_shift"]),
+        scale=_c_float(func_attrs["scale"]),
+        max_period=str(func_attrs["max_period"]),
+        indent=indent,
+    )
+
+
+def gen_function(func_attrs, backend_spec: ROCMSpec):
+    func_name = func_attrs["name"]
+
+    out_type = backend_spec.dtype_to_backend_type(
+        func_attrs["outputs"][0]._attrs["dtype"]
+    )
+    in_type = backend_spec.dtype_to_backend_type(
+        func_attrs["inputs"][0]._attrs["dtype"]
+    )
+
+    return SRC_TEMPLATE.render(
+        function_name=func_name,
+        elem_output_type=out_type,
+        elem_input_type=in_type,
+    )
+
+
+def gen_function_decl(func_attrs: Dict[str, Any], backend_spec) -> str:
+    return FUNC_DECL_TEMPLATE.render(func_name=func_attrs["name"])
+
+
+@registry.reg("rocm.get_timestep_embedding.gen_function")
+def rocm_get_timestep_embedding_gen_function(func_attrs):
+    return gen_function(func_attrs, ROCMSpec())
+
+
+@registry.reg("rocm.get_timestep_embedding.func_decl")
+def rocm_get_timestep_embedding_gen_function_decl(func_attrs: Dict[str, Any]) -> str:
+    return gen_function_decl(func_attrs, ROCMSpec())
+
+
+@registry.reg("rocm.get_timestep_embedding.func_call")
+def rocm_get_timestep_embedding_func_call(func_attrs, indent="  "):
+    return gen_function_call(func_attrs, indent)

--- a/src/dinoml/backend/rocm/view_ops/view_ops.py
+++ b/src/dinoml/backend/rocm/view_ops/view_ops.py
@@ -13,7 +13,7 @@
 #  limitations under the License.
 #
 """
-ROCM codegen functions for view ops.
+Codegen functions for view ops.
 """
 
 import jinja2
@@ -84,15 +84,19 @@ FUNC_CALL_TEMPLATE = jinja2.Template(
 )
 
 
+def _is_intvar(func_attrs):
+    return func_attrs["is_intvar"] if "is_intvar" in func_attrs else False
+
+
 @registry.reg("rocm.reshape.gen_function")
 @registry.reg("rocm.flatten.gen_function")
 def reshape_gen_function(func_attrs, shape_eval_template):
-    func_name = func_attrs["name"]
-
-    input_ndim = len(func_attrs["inputs"][0]._attrs["shape"])
-    output_ndim = len(func_attrs["outputs"][0]._attrs["shape"])
+    func_name = "dinoml_" + func_attrs["name"]
     unknown_idx = func_attrs["unknown_idx"]
-
+    input_ndim = len(func_attrs["inputs"][0]._attrs["shape"])
+    if _is_intvar(func_attrs):
+        input_ndim = len(func_attrs["inputs"]) - 1
+    output_ndim = len(func_attrs["outputs"][0]._attrs["shape"])
     input_args = INPUT_ARGS_TEMPLATE.render(input_ndim=input_ndim)
     output_args = OUTPUT_ARGS_TEMPLATE.render(output_ndim=output_ndim)
 
@@ -115,8 +119,10 @@ def reshape_gen_function(func_attrs, shape_eval_template):
 @registry.reg("rocm.reshape.func_decl")
 @registry.reg("rocm.flatten.func_decl")
 def reshape_gen_function_decl(func_attrs):
-    func_name = func_attrs["name"]
+    func_name = "dinoml_" + func_attrs["name"]
     input_ndim = len(func_attrs["inputs"][0]._attrs["shape"])
+    if _is_intvar(func_attrs):
+        input_ndim = len(func_attrs["inputs"]) - 1
     output_ndim = len(func_attrs["outputs"][0]._attrs["shape"])
 
     return FUNC_DECL_TEMPLATE.render(
@@ -127,10 +133,18 @@ def reshape_gen_function_decl(func_attrs):
 @registry.reg("rocm.reshape.func_call")
 @registry.reg("rocm.flatten.func_call")
 def reshape_gen_function_call(func_attrs, indent="  "):
-    func_name = func_attrs["name"]
-    input_names = [
-        shape._attrs["name"] for shape in func_attrs["inputs"][0]._attrs["shape"]
-    ]
+    func_name = "dinoml_" + func_attrs["name"]
+    input_names = []
+    if _is_intvar(func_attrs):
+        for i, inp in enumerate(func_attrs["inputs"]):
+            if i == 0:
+                continue
+            input_names.append(inp._attrs["int_var"]._attrs["name"])
+    else:
+        input_names = [
+            shape._attrs["name"] for shape in func_attrs["inputs"][0]._attrs["shape"]
+        ]
+
     output_names = [
         shape._attrs["name"] for shape in func_attrs["outputs"][0]._attrs["shape"]
     ]
@@ -156,7 +170,7 @@ def squeeze_gen_function(func_attrs, shape_eval_template):
     shape_eval_template : jinja2.Template
         The template that implements the logic for writing to dynamic shapes.
     """
-    func_name = func_attrs["name"]
+    func_name = "dinoml_" + func_attrs["name"]
     out_dim_to_in = func_attrs["out_dim_to_in"]
 
     input_ndim = len(func_attrs["inputs"][0]._attrs["shape"])
@@ -191,7 +205,7 @@ def squeeze_gen_function_decl(func_attrs):
     func_attrs : Dict[str, Any]
         The _attrs dict from the original op.
     """
-    func_name = func_attrs["name"]
+    func_name = "dinoml_" + func_attrs["name"]
     input_ndim = len(func_attrs["inputs"][0]._attrs["shape"])
     output_ndim = len(func_attrs["outputs"][0]._attrs["shape"])
 
@@ -210,9 +224,9 @@ def squeeze_gen_function_call(func_attrs, indent="  "):
     func_attrs : Dict[str, Any]
         The _attrs dict from the original op.
     ident : str
-        Sequence to use to generate the indentations in the ROCM code
+        Sequence to use to generate the indentations in the rocm code
     """
-    func_name = func_attrs["name"]
+    func_name = "dinoml_" + func_attrs["name"]
     input_names = [
         shape._attrs["name"] for shape in func_attrs["inputs"][0]._attrs["shape"]
     ]

--- a/src/dinoml/backend/task_runner.py
+++ b/src/dinoml/backend/task_runner.py
@@ -80,7 +80,8 @@ class Task:
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
             env=env,
-            shell=use_shell,
+            text=True,
+            shell=False,
         )
         self._timestamp = time.time()
 
@@ -141,8 +142,11 @@ class Task:
             self._failed = True
             return True
         # handle finished job
-        if self._proc.poll() is not None:
+        self._stdout = self._proc.stdout.read()
+        if self._proc.poll() is not None or self._stdout != "":
             self._finished = True
+            if self._proc:
+                self._proc.kill()
         return self._finished
 
     def pull(self, fproc: typing.Callable) -> None:
@@ -156,8 +160,9 @@ class Task:
         """
         if self._failed:
             return None
-        self._stdout = self._proc.stdout.read().decode("utf-8")
-        self._stderr = self._proc.stderr.read().decode("utf-8")
+        if self._stdout == "":
+            self._stdout = self._proc.stdout.read()
+        self._stderr = self._proc.stderr.read()
         fproc(self)
 
     def is_failed(self) -> bool:

--- a/src/dinoml/builder/autoencoder_kl.py
+++ b/src/dinoml/builder/autoencoder_kl.py
@@ -26,7 +26,7 @@ class AutoencoderKLDecodeBuilder(Build):
 
     """
 
-    model_name = "autoencoder_kl.{model_type}.{label}.{resolution}.{device_name}.sm{sm}"
+    model_name = "autoencoder_kl.{model_type}.{label}.{resolution}.{device_name}.{sm}"
     model_type = "decode"
     map_function = map_autoencoder_kl
     map_function_skip_keys = (
@@ -63,7 +63,7 @@ class AutoencoderKLEncodeBuilder(Build):
 
     """
 
-    model_name = "autoencoder_kl.{model_type}.{label}.{resolution}.{device_name}.sm{sm}"
+    model_name = "autoencoder_kl.{model_type}.{label}.{resolution}.{device_name}.{sm}"
     model_type = "encode"
     map_function = map_autoencoder_kl
     map_function_skip_keys = (

--- a/src/dinoml/builder/base.py
+++ b/src/dinoml/builder/base.py
@@ -21,7 +21,7 @@ from dinoml.builder.config import load_config, mark_output
 
 
 class Build:
-    model_name: str = "model.{label}.{device_name}.sm{sm}"
+    model_name: str = "model.{label}.{device_name}.{sm}"
     model_type: Optional[str] = None
 
     model_forward: str = "forward"
@@ -114,10 +114,10 @@ class Build:
             if isinstance(tensor, dict):
                 for sub_name, sub_tensor in tensor.items():
                     sub_tensor._attrs["shape"][0] = batch
-                    print(f"{sub_name=}: {get_shape(sub_tensor)}")
+                    print(f"{sub_name=}: {get_shape(sub_tensor)} {sub_tensor.dtype()}")
             else:
                 # TODO
-                print(f"{name=}: {get_shape(tensor)}")
+                print(f"{name=}: {get_shape(tensor)} {tensor.dtype()}")
                 tensor._attrs["shape"][0] = batch
 
     def create_output_tensors(self):
@@ -149,6 +149,7 @@ class Build:
             )
 
     def compile(self):
+        # , optimize_for_compilation_time=False
         target = detect_target(use_fp16_acc=self.use_fp16_acc)
         if self.debug:
             debug = DinoMLDebugSettings(check_all_outputs=True, elements_to_check=10)

--- a/src/dinoml/builder/esrgan.py
+++ b/src/dinoml/builder/esrgan.py
@@ -23,7 +23,7 @@ class ESRGANBuilder(Build):
 
     """
 
-    model_name = "ESRGAN.{label}.{resolution}.{device_name}.sm{sm}"
+    model_name = "ESRGAN.{label}.{resolution}.{device_name}.{sm}"
     map_function = map_esrgan
     model_output_names = ["Y"]
     model_output = None

--- a/src/dinoml/builder/pixart_transformer_2d.py
+++ b/src/dinoml/builder/pixart_transformer_2d.py
@@ -20,7 +20,7 @@ def build(
     label: str,
     dtype: Union[str, torch.dtype],
     device: Union[str, torch.device],
-    model_name: str = "pixart_transformer_2d.{label}.{resolution}.{device_name}.sm{sm}",
+    model_name: str = "pixart_transformer_2d.{label}.{resolution}.{device_name}.{sm}",
     vae_scale_factor: int = 8,
     benchmark_after_compile: bool = True,
     store_constants_in_module: bool = True,

--- a/src/dinoml/builder/t5.py
+++ b/src/dinoml/builder/t5.py
@@ -28,7 +28,7 @@ class T5EncoderBuilder(Build):
 
     """
 
-    model_name = "t5.{model_type}.{label}.{device_name}.sm{sm}"
+    model_name = "t5.{model_type}.{label}.{device_name}.{sm}"
     model_type = "encoder"
     map_function = map_t5
     model_output_names = ["last_hidden_state"]

--- a/src/dinoml/builder/transformer_flux.py
+++ b/src/dinoml/builder/transformer_flux.py
@@ -26,7 +26,7 @@ class FluxTransformer2DBuilder(Build):
 
     """
 
-    model_name = "transformer_flux.{label}.{resolution}.{device_name}.sm{sm}"
+    model_name = "transformer_flux.{label}.{resolution}.{device_name}.{sm}"
     map_function = map_transformer_flux
     model_output_names = ["Y"]
 

--- a/src/dinoml/builder/unet2d_condition.py
+++ b/src/dinoml/builder/unet2d_condition.py
@@ -25,7 +25,7 @@ class UNet2DConditionBuilder(Build):
 
     """
 
-    model_name = "unet2d_condition.{label}.{resolution}.{device_name}.sm{sm}"
+    model_name = "unet2d_condition.{label}.{resolution}.{device_name}.{sm}"
     map_function = map_unet2d_condition
     model_output_names = ["Y"]
 

--- a/src/dinoml/compiler/compiler.py
+++ b/src/dinoml/compiler/compiler.py
@@ -162,7 +162,7 @@ def compile_model(
     debug_settings: DinoMLDebugSettings = _DEBUG_SETTINGS,
     do_optimize_graph: bool = True,
     do_constant_folding: bool = True,
-    profile_timeout: int = 3600,
+    profile_timeout: int = 360,
     n_cpus: int = -1,
     do_compile: bool = True,
     do_build: bool = True,

--- a/src/dinoml/compiler/model.py
+++ b/src/dinoml/compiler/model.py
@@ -16,6 +16,7 @@
 Python bindings to the DinoML runtime.
 """
 
+import torch
 import ctypes
 import enum
 import logging
@@ -598,7 +599,9 @@ class Model:
         of torch.Tensors ordered according to GetInputNameToIndexMap. Outputs
         can also be a dictionary, or a list ordered according to GetOutputNameToIndexMap.
         """
-
+        torch.cuda.synchronize()
+        if stream_ptr is None:
+            stream_ptr = torch.cuda.current_stream().cuda_stream
         _check_tensors_contiguous_and_on_gpu(
             inputs,
             name="inputs",
@@ -614,7 +617,7 @@ class Model:
             sync=sync,
             graph_mode=graph_mode,
         )
-
+        torch.cuda.synchronize()
         return self._interpret_tensors_as_shapes(outputs, outputs_dinoml)
 
     def _run_with_outputs_on_host(
@@ -738,6 +741,9 @@ class Model:
             outputs,
             name="outputs",
         )
+        torch.cuda.synchronize()
+        if stream_ptr is None:
+            stream_ptr = torch.cuda.current_stream().cuda_stream
 
         mean, std, dinoml_outputs = self.benchmark(
             _convert_tensor_args(inputs),

--- a/src/dinoml/compiler/ops/attention/__init__.py
+++ b/src/dinoml/compiler/ops/attention/__init__.py
@@ -17,7 +17,8 @@ flash attention module init
 """
 
 from dinoml.compiler.ops.attention.flash_attention import flash_attention
+from dinoml.compiler.ops.attention.flash_attn import flash_attn
 from dinoml.compiler.ops.attention.mem_eff_attention import mem_eff_attention
 
 
-__all__ = ["flash_attention", "mem_eff_attention"]
+__all__ = ["flash_attention", "mem_eff_attention", "flash_attn"]

--- a/src/dinoml/compiler/ops/attention/flash_attn.py
+++ b/src/dinoml/compiler/ops/attention/flash_attn.py
@@ -1,0 +1,52 @@
+import math
+from dinoml import backend
+from dinoml.backend import registry
+from dinoml.compiler.base import Operator, Tensor
+from dinoml.testing import detect_target
+
+
+def workspace_size(q: Tensor) -> int:
+    size = 4 * math.prod(q.shape()[i].upper_bound() for i in range(len(q.shape()) - 1))
+    return (size + 16 - 1) // 16 * 16
+
+
+class flash_attn(Operator):
+    def __init__(
+        self,
+        mask_type: str = "none",
+        window_size_left: int = -1,
+        window_size_right: int = -1,
+    ):
+        super().__init__()
+        self._attrs["op"] = "flash_attn"
+        self._attrs["has_profiler"] = False
+        self._attrs["nop"] = False
+
+        self._attrs["mask_type"] = mask_type
+        self._attrs["window_size_left"] = int(window_size_left)
+        self._attrs["window_size_right"] = int(window_size_right)
+        self._attrs["workspace"] = 0
+
+    def __call__(self, q: Tensor, k: Tensor, v: Tensor):
+        self._attrs["inputs"] = [q, k, v]
+        self._attrs["dtype"] = q._attrs["dtype"]
+        target = detect_target()
+        if target.name() == "cuda":
+            self._attrs["workspace"] = workspace_size(q)
+
+        self._set_depth()
+
+        out = Tensor(
+            q.shape(),
+            src_ops={self},
+            dtype=self._attrs["dtype"],
+        )
+
+        self._attrs["outputs"] = [out]
+        return out
+
+    def gen_function(self) -> str:
+        target = backend.target.Target.current()
+        func_key = f"{target.name()}.{self._attrs['op']}.gen_function"
+        func = registry.get(func_key)
+        return func(self._attrs)

--- a/src/dinoml/compiler/ops/conv/conv2d.py
+++ b/src/dinoml/compiler/ops/conv/conv2d.py
@@ -23,6 +23,7 @@ import re
 from collections import OrderedDict
 from hashlib import sha1
 from operator import itemgetter
+import time
 from typing import Any, Dict, List, Tuple, Union, Optional
 
 import jinja2
@@ -473,7 +474,7 @@ class conv2d(Operator):
 
         return attr
 
-    def _should_build_profiler(self) -> bool:
+    def _should_build_profiler(self, workdir=None) -> bool:
         """
         Check if we should build profilers. If we have a cached
         entry for this conv instance, we update this conv op's
@@ -488,6 +489,12 @@ class conv2d(Operator):
                 )
             # If there are dynamic dims, we'll have to generate and build the
             # profilers, as the binaries will be needed for dynamic profiling.
+            if workdir is not None:
+                profiler_filename = get_profiler_filename(self._attrs, "conv")
+                profiler_prefix = os.path.join(workdir, "profiler", self._attrs["op"])
+                profiler_path = os.path.join(profiler_prefix, profiler_filename)
+                if os.path.exists(profiler_path):
+                    return False
             return True
         # We are forced to use the cache so we skip building profilers.
         if force_cache:
@@ -557,10 +564,11 @@ class conv2d(Operator):
         target = backend.target.Target.current()
 
         op = self._attrs["op"]
-        if op.startswith("conv2d"):
-            op = "conv2d"
-        if op.startswith("transposed_conv2d"):
-            op = "transposed_conv2d"
+        if target.name() == "cuda":
+            if op.startswith("conv2d"):
+                op = "conv2d"
+            if op.startswith("transposed_conv2d"):
+                op = "transposed_conv2d"
         func_key = "{target}.{op}.config".format(
             target=target.name(),
             op=op,
@@ -568,7 +576,7 @@ class conv2d(Operator):
         func = registry.get(func_key)
         func(self._attrs, dtype=self._attrs["inputs"][0]._attrs["dtype"])
 
-        if self._should_build_profiler():
+        if self._should_build_profiler(workdir):
             x_shapes = [
                 self._invert_exec_key(exec_key) for exec_key in self._attrs["exec_path"]
             ]
@@ -730,10 +738,11 @@ class conv2d(Operator):
         if "op_instance" not in self._attrs:
             # init candidate ops
             op = self._attrs["op"]
-            if op.startswith("conv2d"):
-                op = "conv2d"
-            if op.startswith("transposed_conv2d"):
-                op = "transposed_conv2d"
+            if target.name() == "cuda":
+                if op.startswith("conv2d"):
+                    op = "conv2d"
+                if op.startswith("transposed_conv2d"):
+                    op = "transposed_conv2d"
             func_key = "{target}.{op}.config".format(
                 target=target.name(),
                 op=op,
@@ -905,10 +914,11 @@ class conv2d(Operator):
     def gen_function(self) -> str:
         target = backend.target.Target.current()
         op = self._attrs["op"]
-        if op.startswith("conv2d"):
-            op = "conv2d"
-        if op.startswith("transposed_conv2d"):
-            op = "transposed_conv2d"
+        if target.name() == "cuda":
+            if op.startswith("conv2d"):
+                op = "conv2d"
+            if op.startswith("transposed_conv2d"):
+                op = "transposed_conv2d"
         func_key = "{target}.{op}.gen_function".format(
             target=target.name(),
             op=op,

--- a/src/dinoml/compiler/ops/conv/conv_common.py
+++ b/src/dinoml/compiler/ops/conv/conv_common.py
@@ -47,10 +47,11 @@ def filter_op_instances(func_attrs, x_shapes):
     """
     target = backend.target.Target.current()
     op = func_attrs["op"]
-    if op.startswith("conv2d"):
-        op = "conv2d"
-    if op.startswith("transposed_conv2d"):
-        op = "transposed_conv2d"
+    if target.name() == "cuda":
+        if op.startswith("conv2d"):
+            op = "conv2d"
+        if op.startswith("transposed_conv2d"):
+            op = "transposed_conv2d"
     func_key = "{target}.{op}.filter".format(
         target=target.name(),
         op=op,
@@ -76,10 +77,11 @@ def generate_profiler_sources(func_attrs, op_class, workdir, shape_template):
     """
     target = backend.target.Target.current()
     op = func_attrs["op"]
-    if op.startswith("conv2d"):
-        op = "conv2d"
-    if op.startswith("transposed_conv2d"):
-        op = "transposed_conv2d"
+    if target.name() == "cuda":
+        if op.startswith("conv2d"):
+            op = "conv2d"
+        if op.startswith("transposed_conv2d"):
+            op = "transposed_conv2d"
     func_key = "{target}.{op}.gen_profiler".format(
         target=target.name(),
         op=op,

--- a/src/dinoml/compiler/ops/groupnorm/groupnorm.py
+++ b/src/dinoml/compiler/ops/groupnorm/groupnorm.py
@@ -292,9 +292,11 @@ class group_norm(Operator):
         content = list(self._attrs["op_instance"].keys())
         runner = backend.profiler_runner.Runner(devices, self._attrs["name"])
         x_shape_dict = self._invert_exec_key(exec_key)
-        for cfg in content:
-            command = self._gen_profile_cmd(profiler_prefix, cfg, x_shape_dict)
-            runner.push(cfg, command)
+        profiler_filename = self._get_profiler_filename()
+        command = self._gen_profile_cmd(
+            profiler_prefix, profiler_filename, x_shape_dict
+        )
+        runner.push(profiler_filename, command)
 
         runner.join()
         result = runner.pull()
@@ -305,7 +307,7 @@ class group_norm(Operator):
             )
 
         out = min(result, key=itemgetter(1))
-        best_algo = out[0]
+        best_algo = out[1].op_config
         workspace = out[1].workspace
         ## cache
         cache_record = NormRecordEntry(
@@ -395,11 +397,16 @@ class group_norm(Operator):
         )
         func = registry.get(func_key)
         func(self._attrs)
+        profiler_filename = self._get_profiler_filename()
         func_key = "{target}.{op}.gen_profiler".format(
             target=target.name(), op=self._attrs["op"]
         )
         func = registry.get(func_key)
-        func(self._attrs, workdir)
+        return func(
+            self._attrs,
+            workdir,
+            profile_filename=profiler_filename,
+        )
 
     def _extract_exec_path(self, dynamic_profiling_strategy=DynamicProfileStrategy.MAX):
         """Extract execution key, i.e. input arguments for the profiler.
@@ -415,19 +422,22 @@ class group_norm(Operator):
         n_min = min(n_dim._attrs["values"])
 
         h_dim = self._attrs["inputs"][0]._attrs["shape"][-3]
-        assert isinstance(h_dim, IntImm), "groupnorm requires h_dim to be static"
         w_dim = self._attrs["inputs"][0]._attrs["shape"][-2]
-        assert isinstance(w_dim, IntImm), "groupnorm requires w_dim to be static"
         c_dim = self._attrs["inputs"][0]._attrs["shape"][-1]
-        assert isinstance(c_dim, IntImm), "groupnorm requires c_dim to be static"
 
         # N, H, W, G, C
         shape_values_dict = {
             "N": [n_min, n_max],
-            "H": [h_dim.value()],
-            "W": [w_dim.value()],
+            "H": [h_dim.lower_bound(), h_dim.upper_bound()]
+            if isinstance(h_dim, IntVar)
+            else [c_dim.value()],
+            "W": [w_dim.lower_bound(), w_dim.upper_bound()]
+            if isinstance(w_dim, IntVar)
+            else [c_dim.value()],
             "G": [self._attrs["num_groups"]],
-            "C": [c_dim.value()],
+            "C": [c_dim.lower_bound(), c_dim.upper_bound()]
+            if isinstance(c_dim, IntVar)
+            else [c_dim.value()],
         }
 
         self._attrs["exec_path"] = OrderedDict()
@@ -453,6 +463,23 @@ class group_norm(Operator):
                 algo="",
             )
             self._attrs["exec_path"][exec_item.profiling_key] = exec_item
+
+    def _get_profiler_filename(self):
+        """
+        generate a filename for a profiler that benchmarks multiple GEMM instances
+        """
+        target = backend.target.Target.current()
+
+        op_type = self._attrs["op"]
+        all_op_names = list(self._attrs["op_instance"].keys())
+        encoded_str = sha1((";".join(all_op_names)).encode("utf-8")).hexdigest()
+
+        if target.use_dummy_profiling_results():
+            # we don't use cache
+            return f"{op_type}_{encoded_str}"
+        else:
+            cache_ver = target.get_profile_cache_version("gemm")
+            return f"{op_type}_{encoded_str}_{cache_ver}"
 
     def _get_op_attributes(self):
         return {

--- a/src/dinoml/compiler/ops/layernorm/layernorm.py
+++ b/src/dinoml/compiler/ops/layernorm/layernorm.py
@@ -339,9 +339,9 @@ class layernorm(Operator):
         content = list(self._attrs["op_instance"].keys())
         runner = backend.profiler_runner.Runner(devices, self._attrs["name"])
         x_shape = self._invert_exec_key(exec_key)
-        for cfg in content:
-            command = self._gen_profile_cmd(profiler_prefix, cfg, x_shape)
-            runner.push(cfg, command)
+        profiler_filename = self._get_profiler_filename()
+        command = self._gen_profile_cmd(profiler_prefix, profiler_filename, x_shape)
+        runner.push(profiler_filename, command)
 
         runner.join()
         result = runner.pull()
@@ -352,7 +352,7 @@ class layernorm(Operator):
             )
 
         out = min(result, key=itemgetter(1))
-        best_algo = out[0]
+        best_algo = out[1].op_config
         workspace = out[1].workspace
         ## cache
         cache_record = NormRecordEntry(
@@ -442,11 +442,33 @@ class layernorm(Operator):
         )
         func = registry.get(func_key)
         func(self._attrs)
+        profiler_filename = self._get_profiler_filename()
         func_key = "{target}.{op}.gen_profiler".format(
             target=target.name(), op=self._attrs["op"]
         )
         func = registry.get(func_key)
-        return func(self._attrs, workdir)
+        return func(
+            self._attrs,
+            workdir,
+            profile_filename=profiler_filename,
+        )
+
+    def _get_profiler_filename(self):
+        """
+        generate a filename for a profiler that benchmarks multiple GEMM instances
+        """
+        target = backend.target.Target.current()
+
+        op_type = self._attrs["op"]
+        all_op_names = list(self._attrs["op_instance"].keys())
+        encoded_str = sha1((";".join(all_op_names)).encode("utf-8")).hexdigest()
+
+        if target.use_dummy_profiling_results():
+            # we don't use cache
+            return f"{op_type}_{encoded_str}"
+        else:
+            cache_ver = target.get_profile_cache_version("gemm")
+            return f"{op_type}_{encoded_str}_{cache_ver}"
 
     def _get_op_attributes(self):
         return {"normalized_shape": self._attrs["default_normalized_shape"]}

--- a/src/dinoml/compiler/ops/tensor/get_timestep_embedding.py
+++ b/src/dinoml/compiler/ops/tensor/get_timestep_embedding.py
@@ -22,22 +22,18 @@ class get_timestep_embedding(Operator):
         scale: float = 1.0,
         max_period: int = 10000,
     ) -> Tensor:
-        # Store inputs
         self._attrs["inputs"] = [timesteps]
 
-        # Store op attributes (use the same argument names as requested)
         self._attrs["embedding_dim"] = int(embedding_dim)
         self._attrs["flip_sin_to_cos"] = bool(flip_sin_to_cos)
         self._attrs["downscale_freq_shift"] = float(downscale_freq_shift)
         self._attrs["scale"] = float(scale)
         self._attrs["max_period"] = int(max_period)
 
-        # Output is float32 (matches the reference implementation behavior)
-        self._attrs["dtype"] = normalize_dtype("float32")
+        self._attrs["dtype"] = timesteps._attrs["dtype"]
 
         self._set_depth()
 
-        # timesteps is 1-D: [N] -> output [N, embedding_dim]
         out_shape = [timesteps._attrs["shape"][0], IntImm(int(embedding_dim))]
 
         y = Tensor(

--- a/src/dinoml/frontend/nn/linear.py
+++ b/src/dinoml/frontend/nn/linear.py
@@ -86,13 +86,17 @@ class Linear(Module):
         self.op = op_func(**kwargs)
         self.use_bias = bias
         self.in_channels = in_channels
+        self.out_channels = out_channels
 
     def forward(self, *args):
         assert len(args) >= 1
         x = args[0]
         dtype = x.dtype()
-        if not self.USE_CUDA and len(x._attrs["shape"]) != 2:
-            x = ops.reshape()(x, [-1, self.in_channels])
+        batch_size = None
+        # if not self.USE_CUDA and len(x._attrs["shape"]) != 2:
+        #     batch_size, s, h = ops.size()(x)
+        #     out_c, in_c = ops.size()(self.weight.tensor())
+        #     x = ops.reshape()(x, [batch_size * s, in_c])
         inputs = [
             x,
             (
@@ -110,4 +114,6 @@ class Linear(Module):
         if len(args) == 2:
             inputs.append(args[1])
         output = self.op(*inputs)
+        # if not self.USE_CUDA and batch_size is not None:
+        #     output = ops.reshape()(output, [batch_size, s, out_c])
         return output

--- a/src/dinoml/mapping/unet2d_condition.py
+++ b/src/dinoml/mapping/unet2d_condition.py
@@ -31,12 +31,12 @@ def conv2d_pad(
 def geglu_split(key: str, tensor: torch.Tensor, state_dict: Dict[str, torch.Tensor]):
     if key.endswith("ff_net_0_proj_weight"):
         proj, gate = tensor.chunk(2, dim=0)
-        state_dict[key.replace("proj", "gate")] = gate
-        return proj
+        state_dict[key.replace("proj", "gate")] = gate.contiguous().to("cuda")
+        return proj.contiguous()
     elif key.endswith("ff_net_0_proj_bias"):
         proj, gate = tensor.chunk(2, dim=0)
-        state_dict[key.replace("proj", "gate")] = gate
-        return proj
+        state_dict[key.replace("proj", "gate")] = gate.contiguous().to("cuda")
+        return proj.contiguous()
     else:
         return tensor
 

--- a/src/dinoml/modeling/diffusers/activations.py
+++ b/src/dinoml/modeling/diffusers/activations.py
@@ -1,6 +1,8 @@
+from dinoml.backend.target import Target
 from dinoml.compiler import ops
 
 from dinoml.frontend import nn, Tensor
+from dinoml.testing import detect_target
 
 
 def mish(x: Tensor) -> Tensor:
@@ -108,17 +110,25 @@ class GEGLU(nn.Module):
         self, dim_in: int, dim_out: int, bias: bool = True, dtype: str = "float16"
     ):
         super().__init__()
-        self.proj = nn.Linear(dim_in, dim_out, bias=bias, dtype=dtype)
-        self.gate = nn.Linear(dim_in, dim_out, bias=bias, dtype=dtype)
+        self.proj = nn.Linear(
+            dim_in, dim_out, bias=bias, dtype=dtype, specialization="mul"
+        )
+        self.gate = nn.Linear(
+            dim_in, dim_out, bias=bias, dtype=dtype, specialization="fast_gelu"
+        )
 
     def forward(self, hidden_states, *args, **kwargs):
-        return ops.dual_gemm_rcr_bias_fast_gelu()(
-            hidden_states,
-            self.gate.weight.tensor(),
-            self.proj.weight.tensor(),
-            self.gate.bias.tensor(),
-            self.proj.bias.tensor(),
-        )
+        use_dual_gemm = detect_target().name() == "cuda"
+        if use_dual_gemm:
+            return ops.dual_gemm_rcr_bias_fast_gelu()(
+                hidden_states,
+                self.gate.weight.tensor(),
+                self.proj.weight.tensor(),
+                self.gate.bias.tensor(),
+                self.proj.bias.tensor(),
+            )
+        else:
+            return self.proj(hidden_states, self.gate(hidden_states))
 
 
 class ApproximateGELU(nn.Module):

--- a/src/dinoml/modeling/diffusers/attention.py
+++ b/src/dinoml/modeling/diffusers/attention.py
@@ -3,6 +3,7 @@ from typing import Any, Dict, Optional
 from dinoml.compiler import ops
 
 from dinoml.frontend import IntVar, nn, Tensor
+from dinoml.utils.shape_utils import get_shape
 
 from .activations import ApproximateGELU, GEGLU, GELU
 from .attention_processor import Attention, JointAttnProcessor2_0
@@ -13,14 +14,6 @@ from .normalization import (
     AdaLayerNormZero,
     RMSNorm,
 )
-
-
-def get_shape(x):
-    shape = [
-        it.value() if not isinstance(it, IntVar) else it.symbolic_value()
-        for it in x._attrs["shape"]
-    ]
-    return shape
 
 
 class GatedSelfAttentionDense(nn.Module):

--- a/src/dinoml/modeling/diffusers/attention_processor.py
+++ b/src/dinoml/modeling/diffusers/attention_processor.py
@@ -3,21 +3,9 @@ from typing import Optional, Union
 from dinoml.compiler import ops
 
 from dinoml.frontend import IntVar, nn, Tensor
+from dinoml.utils.shape_utils import get_shape
 
 from .normalization import FP32LayerNorm, RMSNorm
-
-
-# TODO: other processors
-def get_shape(x):
-    shape = [
-        (
-            it.value()
-            if not isinstance(it, IntVar)
-            else [it.lower_bound(), it.upper_bound()]
-        )
-        for it in x._attrs["shape"]
-    ]
-    return shape
 
 
 class Attention(nn.Module):
@@ -591,21 +579,13 @@ class AttnProcessor2_0:
         key = attn.to_k(encoder_hidden_states)
         value = attn.to_v(encoder_hidden_states)
 
-        inner_dim = ops.size()(key, dim=-1)._attrs["int_var"]
-        head_dim = inner_dim / attn.heads
+        inner_dim = attn.inner_dim
+        head_dim = inner_dim // attn.heads
 
-        query = ops.permute()(
-            ops.reshape()(query, [batch_size, -1, attn.heads, head_dim]), [0, 2, 1, 3]
-        )
-
-        key = ops.permute()(
-            ops.reshape()(key, [batch_size, -1, attn.heads, head_dim]), [0, 2, 1, 3]
-        )
-        value = ops.permute()(
-            ops.reshape()(value, [batch_size, -1, attn.heads, head_dim]), [0, 2, 1, 3]
-        )
-
-        attn_op = ops.mem_eff_attention(causal=False)
+        query = ops.reshape()(query, [batch_size, -1, attn.heads, head_dim])
+        key = ops.reshape()(key, [batch_size, -1, attn.heads, head_dim])
+        value = ops.reshape()(value, [batch_size, -1, attn.heads, head_dim])
+        attn_op = ops.flash_attn()
         hidden_states = attn_op(query, key, value)
 
         hidden_states = ops.reshape()(
@@ -626,8 +606,8 @@ class AttnProcessor2_0:
         if attn.residual_connection:
             hidden_states = hidden_states + residual
 
-        # if attn.rescale_output_factor != 1.0:
-        hidden_states = hidden_states / attn.rescale_output_factor
+        if float(attn.rescale_output_factor) != 1.0:
+            hidden_states = hidden_states / attn.rescale_output_factor
 
         return hidden_states
 

--- a/src/dinoml/modeling/diffusers/unets/unet_2d_blocks.py
+++ b/src/dinoml/modeling/diffusers/unets/unet_2d_blocks.py
@@ -171,6 +171,7 @@ def get_down_block(
             resnet_act_fn=resnet_act_fn,
             downsample_padding=downsample_padding,
             resnet_time_scale_shift=resnet_time_scale_shift,
+            dtype=dtype,
         )
     elif down_block_type == "AttnSkipDownBlock2D":
         return AttnSkipDownBlock2D(

--- a/src/dinoml/modeling/diffusers/unets/unet_2d_condition.py
+++ b/src/dinoml/modeling/diffusers/unets/unet_2d_condition.py
@@ -285,6 +285,7 @@ class UNet2DConditionModel(nn.Module):
             projection_class_embeddings_input_dim=projection_class_embeddings_input_dim,
             time_embed_dim=time_embed_dim,
             timestep_input_dim=timestep_input_dim,
+            dtype=dtype,
         )
 
         self._set_add_embedding(
@@ -297,6 +298,7 @@ class UNet2DConditionModel(nn.Module):
             freq_shift=freq_shift,
             projection_class_embeddings_input_dim=projection_class_embeddings_input_dim,
             time_embed_dim=time_embed_dim,
+            dtype=dtype,
         )
 
         if time_embedding_act_fn is None:
@@ -377,6 +379,7 @@ class UNet2DConditionModel(nn.Module):
                     else output_channel
                 ),
                 dropout=dropout,
+                dtype=dtype,
             )
             self.down_blocks.append(down_block)
 
@@ -402,6 +405,7 @@ class UNet2DConditionModel(nn.Module):
             cross_attention_norm=cross_attention_norm,
             attention_head_dim=attention_head_dim[-1],
             dropout=dropout,
+            dtype=dtype,
         )
 
         # count how many layers upsample the images
@@ -466,6 +470,7 @@ class UNet2DConditionModel(nn.Module):
                     else output_channel
                 ),
                 dropout=dropout,
+                dtype=dtype,
             )
             self.up_blocks.append(up_block)
             prev_output_channel = output_channel
@@ -476,6 +481,7 @@ class UNet2DConditionModel(nn.Module):
                 num_channels=block_out_channels[0],
                 num_groups=norm_num_groups,
                 eps=norm_eps,
+                dtype=dtype,
             )
 
             self.conv_act = get_activation(act_fn)
@@ -490,6 +496,7 @@ class UNet2DConditionModel(nn.Module):
             out_channels,
             kernel_size=conv_out_kernel,
             padding=conv_out_padding,
+            dtype=dtype,
         )
 
         self._set_pos_net_if_use_gligen(
@@ -817,10 +824,6 @@ class UNet2DConditionModel(nn.Module):
         timesteps = ops.expand()(timesteps, shape=[ops.size()(sample, dim=0)])
 
         t_emb = self.time_proj(timesteps)
-        # `Timesteps` does not contain any weights and will always return f32 tensors
-        # but time_embedding might actually be running in fp16. so we need to cast here.
-        # there might be better ways to encapsulate this.
-        t_emb = ops.cast()(t_emb, dtype=sample.dtype())
         return t_emb
 
     def get_class_embed(

--- a/src/dinoml/modeling/diffusers/unets/unet_spatio_temporal_condition.py
+++ b/src/dinoml/modeling/diffusers/unets/unet_spatio_temporal_condition.py
@@ -344,7 +344,6 @@ class UNetSpatioTemporalConditionModel(nn.Module):
         # `Timesteps` does not contain any weights and will always return f32 tensors
         # but time_embedding might actually be running in fp16. so we need to cast here.
         # there might be better ways to encapsulate this.
-        t_emb = ops.cast()(t_emb, dtype=sample.dtype())
 
         emb = self.time_embedding(t_emb)
 

--- a/src/dinoml/testing/benchmark_dinoml.py
+++ b/src/dinoml/testing/benchmark_dinoml.py
@@ -60,6 +60,8 @@ def benchmark_module(
         outputs = module.run_with_tensors(inputs, outputs)
         for name, tensor in outputs.items():
             print(f"{name=} {tensor=}")
+        if count == 0:
+            return
     inputs, outputs = prepare_inputs_outputs(module, device)
     mean, std, _ = module.benchmark_with_tensors(
         inputs, outputs, count=count, repeat=repeat, graph_mode=graph_mode

--- a/src/dinoml/testing/benchmark_pt.py
+++ b/src/dinoml/testing/benchmark_pt.py
@@ -15,9 +15,12 @@
 """
 helper function to benchmark eager pytorch
 """
+
 # pylint: disable=C0415
+import torch
 
 
+@torch.no_grad
 def benchmark_torch_function(iters: int, function, *args, **kwargs) -> float:
     """
     function for benchmarking a pytorch function.
@@ -36,20 +39,19 @@ def benchmark_torch_function(iters: int, function, *args, **kwargs) -> float:
     float
         Runtime per iteration in ms.
     """
-    import torch
-
     # Warm up
     for _ in range(5):
         function(*args, **kwargs)
 
     # Start benchmark.
     torch.cuda.synchronize()
-    start_event = torch.cuda.Event(enable_timing=True)
-    end_event = torch.cuda.Event(enable_timing=True)
-    start_event.record()
-    for _ in range(iters):
-        function(*args, **kwargs)
-    end_event.record()
+    with torch.cuda.Stream() as stream:
+        start_event = torch.cuda.Event(enable_timing=True)
+        end_event = torch.cuda.Event(enable_timing=True)
+        start_event.record(stream)
+        for _ in range(iters):
+            function(*args, **kwargs)
+        end_event.record(stream)
     torch.cuda.synchronize()
     # in ms
     return (start_event.elapsed_time(end_event)) / iters

--- a/src/dinoml/utils/build_utils.py
+++ b/src/dinoml/utils/build_utils.py
@@ -27,25 +27,28 @@ def get_device_name():
         "geforce ": "",
         "tesla ": "",
         "quadro ": "",
-        " ": "_",
+        "amd ": "",
+        "radeon ": "",
     }
     split_by = {
         ",": 0,
         "(": 0,
     }
-
     device_name = torch.cuda.get_device_name().lower()
     for target, replacement in cleanup.items():
         device_name = device_name.replace(target, replacement).strip()
-
+    device_name = device_name.replace(" ", "_")
     for target, index in split_by.items():
         device_name = device_name.split(target)[index].strip()
-
     return device_name
 
 
 def get_sm():
-    sm = "".join(str(i) for i in torch.cuda.get_device_capability())
+    properties = torch.cuda.get_device_properties()
+    if properties.name == properties.gcnArchName:
+        sm = "sm" + "".join(str(i) for i in torch.cuda.get_device_capability())
+    else:
+        sm = properties.gcnArchName
     return sm
 
 

--- a/src/dinoml/utils/ck_lib/__init__.py
+++ b/src/dinoml/utils/ck_lib/__init__.py
@@ -15,4 +15,4 @@
 
 # flake8: noqa
 
-from . import conv2d_operation, gemm_operation, generator, library, manifest
+from . import conv2d_operation, gemm_operation, generator, library, manifest, layernorm_operation, groupnorm_operation, softmax_operation

--- a/src/dinoml/utils/ck_lib/conv2d_operation.py
+++ b/src/dinoml/utils/ck_lib/conv2d_operation.py
@@ -60,7 +60,7 @@ XdlOpTag = {
     XdlOpType.DeviceConv2d_Xdl_CShuffle_Bias_Relu: "ck::tensor_operation::device::DeviceConv2dFwdXdl_C_Shuffle_Bias_Activation_Input_N_Hi_Wi_C_Weight_K_Y_X_C_Output_N_Ho_Wo_K",
     XdlOpType.DeviceConv2d_Xdl_CShuffle_Bias_Relu_Add: "ck::tensor_operation::device::DeviceConv2dFwdXdl_C_Shuffle_Bias_Activation_Add_Input_N_Hi_Wi_C_Weight_K_Y_X_C_Output_N_Ho_Wo_K",
     XdlOpType.DeviceConv2d_Xdl_CShuffle_Bias_Sigmoid: "ck::tensor_operation::device::DeviceConv2dFwdXdl_C_Shuffle_Bias_Activation_Input_N_Hi_Wi_C_Weight_K_Y_X_C_Output_N_Ho_Wo_K",
-    XdlOpType.DeviceGroupedConv2D_Xdl_CShuffle_Bias_Relu: "ck::tensor_operation::device::DeviceGroupedConvFwdMultipleD_Xdl_CShuffle",
+    XdlOpType.DeviceGroupedConv2D_Xdl_CShuffle_Bias_Relu: "ck::tensor_operation::device::DeviceGroupedConvFwdMultipleABD_Xdl_CShuffle",
     XdlOpType.DeviceConvNdBwdDataNwcKxcNwk_Xdl: "ck::tensor_operation::device::DeviceConvNdBwdDataNwcKxcNwk_Xdl",
     XdlOpType.DeviceGroupedConvBwdDataMultipleD_Xdl_CShuffle_v1: "ck::tensor_operation::device::DeviceGroupedConvBwdDataMultipleD_Xdl_CShuffle_v1",
 }
@@ -239,9 +239,10 @@ class Conv2DOperation:
     a_block_transfer: BlockTransferDesc
     b_block_transfer: BlockTransferDesc
     c_block_transfer: CBlockTransferDesc
+    acc_dtype: library.DataType = library.DataType.f32
 
     def __str__(self) -> str:
-        io_name = "{conv2d_kind}_{conv2d_specialization}_{gemm_specialization}_{a_dtype}{b_dtype}{c_dtype}_{a_layout}_{b_layout}_{c_layout}".format(
+        io_name = "{conv2d_kind}_{conv2d_specialization}_{gemm_specialization}_{a_dtype}{b_dtype}{c_dtype}_{acc_dtype}_{a_layout}_{b_layout}_{c_layout}".format(
             conv2d_kind=library.Conv2dKindNames[self.operation_kind],
             conv2d_specialization=self.conv2d_specialization.value,
             gemm_specialization=self.gemm_specialization.value,
@@ -251,6 +252,7 @@ class Conv2DOperation:
             a_layout=library.ShortLayoutTypeNames[self.A.layout],
             b_layout=library.ShortLayoutTypeNames[self.B.layout],
             c_layout=library.ShortLayoutTypeNames[self.C.layout],
+            acc_dtype=library.ShortDataTypeNames[self.acc_dtype],
         )
         tile_name = str(self.tile_desc)
         return "{io_name}_{tile_name}_{epilogue_functor}".format(
@@ -260,7 +262,7 @@ class Conv2DOperation:
         )
 
     def accumulator_type(self):
-        return library.DataType.f32
+        return self.acc_dtype
 
     def emit(self) -> str:
         template = jinja2.Template(
@@ -338,7 +340,7 @@ using {{name}} = {{xdl_op_type}}<
             ADType=library.DataTypeTag[self.A.element],
             BDType=library.DataTypeTag[self.B.element],
             CDType=library.DataTypeTag[self.C.element],
-            AccDType=library.DataTypeTag[library.DataType.f32],
+            AccDType=library.DataTypeTag[self.acc_dtype],
             CShuffleDType=library.DataTypeTag[self.C.element],
             A_elem_op=library.TensorOperationTag[self.a_elem_op],
             B_elem_op=library.TensorOperationTag[self.b_elem_op],

--- a/src/dinoml/utils/ck_lib/gemm_operation.py
+++ b/src/dinoml/utils/ck_lib/gemm_operation.py
@@ -297,6 +297,7 @@ class GemmOperation:
     tile_desc: TileDesc
     a_block_transfer: BlockTransferDesc
     b_block_transfer: BlockTransferDesc
+    acc_dtype: library.DataType = library.DataType.f32
     b1_block_transfer: BlockTransferDesc = None
     c_block_transfer: CBlockTransferDesc = None
     ds_dtype: List[library.DataType] = None
@@ -304,7 +305,7 @@ class GemmOperation:
     e_dtype: library.DataType = None
 
     def __str__(self) -> str:
-        io_name = "{gemm_kind}_{gemm_specialization}_{a_dtype}{b_dtype}{c_dtype}_{a_layout}{b_layout}{c_layout}".format(
+        io_name = "{gemm_kind}_{gemm_specialization}_{a_dtype}{b_dtype}{c_dtype}_{acc_dtype}_{a_layout}{b_layout}{c_layout}".format(
             gemm_kind=library.GemmKindNames[self.operation_kind],
             gemm_specialization=self.gemm_specialization.value,
             a_dtype=library.ShortDataTypeNames[self.A.element],
@@ -313,6 +314,7 @@ class GemmOperation:
             a_layout=library.ShortLayoutTypeNames[self.A.layout],
             b_layout=library.ShortLayoutTypeNames[self.B.layout],
             c_layout=library.ShortLayoutTypeNames[self.C.layout],
+            acc_dtype=library.ShortDataTypeNames[self.acc_dtype],
         )
         extra_tile = ""
         if self.c_block_transfer is not None:
@@ -333,7 +335,7 @@ class GemmOperation:
         )
 
     def accumulator_type(self):
-        return library.DataType.f32
+        return self.acc_dtype
 
     def emit(self) -> str:
         template = jinja2.Template(
@@ -484,8 +486,8 @@ using {{name}} = {{xdl_op_type}}<
             ADType=library.DataTypeTag[self.A.element],
             BDType=library.DataTypeTag[self.B.element],
             CDType=library.DataTypeTag[self.C.element],
-            AccDType=library.DataTypeTag[library.DataType.f32],
-            CShuffleDType=library.DataTypeTag[self.C.element],
+            AccDType=library.DataTypeTag[self.acc_dtype],
+            CShuffleDType=library.DataTypeTag[self.C.element] if self.A.element != library.DataType.bf16 else library.DataTypeTag[library.DataType.f32],
             A_elem_op=library.TensorOperationTag[self.a_elem_op],
             B_elem_op=library.TensorOperationTag[self.b_elem_op],
             C_elem_op=library.TensorOperationTag[self.epilogue_functor],

--- a/src/dinoml/utils/ck_lib/generator.py
+++ b/src/dinoml/utils/ck_lib/generator.py
@@ -22,264 +22,221 @@ from . import layernorm_operation as layernorm
 from . import library
 from . import softmax_operation as softmax
 
+# dtype, accumulator dtype
+# float16 -> float32
+# float16 -> float16 (disabled for now)
+# bfloat16 -> float32
+dtype_acc_types = [
+    (library.DataType.f16, library.DataType.f32),
+    # (library.DataType.f16, library.DataType.f16),
+    (library.DataType.bf16, library.DataType.f32),
+]
 
 ###########################################################################################################
 # Convolution for 2D Fwd operations
 def CreateConv2dFwdOperator(manifest, operation_kind, out_element_op, out_data_op=""):
-    a_element_desc = library.TensorDesc(
-        library.DataType.f16, library.LayoutType.G_NHW_C
-    )
-    b_element_desc = library.TensorDesc(
-        library.DataType.f16, library.LayoutType.G_K_YX_C
-    )
-    c_element_desc = library.TensorDesc(
-        library.DataType.f16, library.LayoutType.G_NHW_K
-    )
-
-    in_element_op = library.TensorOperation.PassThrough
-
-    tile_descriptions = [
-        conv.GroupTileDesc(1, 256, 256, 128, 32, 8, 8, 32, 32, 4, 2),
-        conv.GroupTileDesc(1, 256, 128, 256, 32, 8, 8, 32, 32, 2, 4),
-        conv.GroupTileDesc(1, 128, 128, 128, 32, 8, 8, 32, 32, 4, 2),
-        conv.GroupTileDesc(1, 256, 128, 128, 32, 8, 8, 32, 32, 2, 2),
-        conv.GroupTileDesc(1, 128, 128, 64, 32, 8, 8, 32, 32, 2, 2),
-        conv.GroupTileDesc(1, 128, 64, 128, 32, 8, 8, 32, 32, 2, 2),
-        conv.GroupTileDesc(1, 64, 64, 64, 32, 8, 8, 32, 32, 2, 2),
-        conv.GroupTileDesc(1, 256, 128, 64, 32, 8, 8, 32, 32, 2, 1),
-        conv.GroupTileDesc(1, 256, 64, 128, 32, 8, 8, 32, 32, 1, 2),
-        conv.GroupTileDesc(1, 128, 32, 128, 32, 8, 8, 32, 32, 1, 2),
-        conv.GroupTileDesc(1, 64, 64, 32, 32, 8, 8, 32, 32, 2, 1),
-        conv.GroupTileDesc(1, 64, 32, 64, 32, 8, 8, 32, 32, 1, 2),
-    ]
-
-    c_block_descriptions = [
-        conv.CBlockTransferDesc(1, 1, [1, 32, 1, 8], 8),
-        conv.CBlockTransferDesc(1, 1, [1, 32, 1, 8], 8),
-        conv.CBlockTransferDesc(1, 1, [1, 16, 1, 8], 8),
-        conv.CBlockTransferDesc(1, 1, [1, 32, 1, 8], 8),
-        conv.CBlockTransferDesc(1, 1, [1, 32, 1, 4], 8),
-        conv.CBlockTransferDesc(1, 1, [1, 16, 1, 8], 8),
-        conv.CBlockTransferDesc(1, 1, [1, 16, 1, 4], 8),
-        conv.CBlockTransferDesc(1, 1, [1, 32, 1, 8], 8),
-        conv.CBlockTransferDesc(1, 1, [1, 32, 1, 8], 8),
-        conv.CBlockTransferDesc(1, 1, [1, 16, 1, 8], 8),
-        conv.CBlockTransferDesc(1, 1, [1, 16, 1, 4], 8),
-        conv.CBlockTransferDesc(1, 1, [1, 16, 1, 4], 8),
-    ]
-
-    block_descriptions = []
-    for t in tile_descriptions:
-        block_transfer = -1
-        if t.block_size == 256:
-            block_transfer = [4, 64, 1]
-        if t.block_size == 128:
-            block_transfer = [4, 32, 1]
-        if t.block_size == 64:
-            block_transfer = [4, 16, 1]
-        assert block_transfer != -1, f"Cannot determine block_transfer_size with block_size {str(t.block_size)}"
-        block_descriptions.append(
-            conv.BlockTransferDesc(block_transfer, [1, 0, 2], [1, 0, 2], 2, 8, 8, 1)
+    for dtype, acc_dtype in dtype_acc_types:
+        a_element_desc = library.TensorDesc(
+            dtype, library.LayoutType.G_NHW_C
+        )
+        b_element_desc = library.TensorDesc(
+            dtype, library.LayoutType.G_K_YX_C
+        )
+        c_element_desc = library.TensorDesc(
+            dtype, library.LayoutType.G_NHW_K
         )
 
-    conv2d_specialization = [
-        conv.Conv2DSpecialization.ConvFwdDefault,
-        conv.Conv2DSpecialization.ConvFwd1x1P0,
-        conv.Conv2DSpecialization.ConvFwd1x1S1P0,
-    ]
+        in_element_op = library.TensorOperation.PassThrough
 
-    gemm_specialization = [
-        conv.Conv2DSpecialization.GemmDefault,
-        conv.Conv2DSpecialization.MNKPadding,
-    ]
+        tile_descriptions = [
+            conv.GroupTileDesc(1, 64,     64,   32,     32,   8,   8,   16,   16,    4,    2),
+            conv.GroupTileDesc(1, 256,   128,   256,    32,   8,   8,   16,   16,    8,    4),
+            conv.GroupTileDesc(1, 256,   128,   128,    32,   8,   8,   16,   16,    4,    4),
+            conv.GroupTileDesc(1, 64,     64,   64,     32,   8,   8,   16,   16,    4,    4),
+            conv.GroupTileDesc(1, 256,   256,   128,    32,   8,   8,   16,   16,    8,    4),
+            conv.GroupTileDesc(1, 128,   128,   128,    32,   8,   8,   16,   16,    8,    4),
+        ]
+        block_descriptions = [
+            conv.BlockTransferDesc([4, 16, 1],     [1, 0, 2],     [1, 0, 2],              2,              8,              8,         1),
+            conv.BlockTransferDesc([4, 64, 1],     [1, 0, 2],     [1, 0, 2],              2,              8,              8,         1),
+            conv.BlockTransferDesc([4, 64, 1],     [1, 0, 2],     [1, 0, 2],              2,              1,              8,         1),
+            conv.BlockTransferDesc([4, 16, 1],     [1, 0, 2],     [1, 0, 2],              2,              1,              8,         1),
+            conv.BlockTransferDesc([4, 64, 1],     [1, 0, 2],     [1, 0, 2],              2,              8,              8,         1),
+            conv.BlockTransferDesc([4, 32, 1],     [1, 0, 2],     [1, 0, 2],              2,              8,              8,         1),
+        ]
+        c_block_descriptions = [
+            conv.CBlockTransferDesc(1, 1, [1, 16, 1, 4],               1),
+            conv.CBlockTransferDesc(1, 1, [1, 16, 1, 16],              4),
+            conv.CBlockTransferDesc(1, 1, [1, 32, 1, 8],               4),
+            conv.CBlockTransferDesc(1, 1, [1, 16, 1, 4],               1),
+            conv.CBlockTransferDesc(1, 1, [1, 32, 1, 8],               4),
+            conv.CBlockTransferDesc(1, 1, [1, 16, 1, 8],               4),
+        ]
 
-    operations = []
-    for conv2d_spec in conv2d_specialization:
-        for gemm_spec in gemm_specialization:
-            for tile_desc, block_desc, c_block_desc in zip(
-                tile_descriptions, block_descriptions, c_block_descriptions
-            ):
-                new_operation = conv.Conv2DOperation(
-                    operation_kind=operation_kind,
-                    extra_kind=out_element_op,
-                    xdl_op_type=conv.XdlOpType(operation_kind.value),
-                    A=a_element_desc,
-                    B=b_element_desc,
-                    C=c_element_desc,
-                    a_elem_op=in_element_op,
-                    b_elem_op=in_element_op,
-                    epilogue_functor=out_element_op,
-                    c_data_op=out_data_op,
-                    conv2d_specialization=conv2d_spec,
-                    gemm_specialization=gemm_spec,
-                    tile_desc=tile_desc,
-                    a_block_transfer=block_desc,
-                    b_block_transfer=block_desc,
-                    c_block_transfer=c_block_desc,
-                )
-                manifest.append(new_operation)
-                operations.append(new_operation)
+        conv2d_specialization = [
+            conv.Conv2DSpecialization.ConvFwdDefault,
+            conv.Conv2DSpecialization.ConvFwd1x1P0,
+            conv.Conv2DSpecialization.ConvFwd1x1S1P0,
+        ]
 
-    conv2d_specialization = [conv.Conv2DSpecialization.ConvFwdOddC]
+        gemm_specialization = [
+            conv.Conv2DSpecialization.GemmDefault,
+            conv.Conv2DSpecialization.MNKPadding,
+        ]
 
-    tile_descriptions += [
-        conv.GroupTileDesc(1, 256, 128, 64, 32, 8, 8, 32, 32, 2, 1),
-        conv.GroupTileDesc(1, 256, 128, 64, 32, 8, 8, 32, 32, 2, 1),
-        conv.GroupTileDesc(1, 256, 256, 64, 32, 8, 8, 32, 32, 4, 1),
-        conv.GroupTileDesc(1, 128, 128, 64, 32, 8, 8, 32, 32, 2, 2),
-        conv.GroupTileDesc(1, 128, 64, 64, 32, 8, 8, 32, 32, 1, 2),
-        conv.GroupTileDesc(1, 256, 256, 16, 32, 8, 8, 16, 16, 4, 1),  # c_out=1
-    ]
+        operations = []
+        for conv2d_spec in conv2d_specialization:
+            for gemm_spec in gemm_specialization:
+                for tile_desc, block_desc, c_block_desc in zip(
+                    tile_descriptions, block_descriptions, c_block_descriptions
+                ):
+                    new_operation = conv.Conv2DOperation(
+                        operation_kind=operation_kind,
+                        extra_kind=out_element_op,
+                        xdl_op_type=conv.XdlOpType(operation_kind.value),
+                        A=a_element_desc,
+                        B=b_element_desc,
+                        C=c_element_desc,
+                        a_elem_op=in_element_op,
+                        b_elem_op=in_element_op,
+                        epilogue_functor=out_element_op,
+                        c_data_op=out_data_op,
+                        conv2d_specialization=conv2d_spec,
+                        gemm_specialization=gemm_spec,
+                        tile_desc=tile_desc,
+                        a_block_transfer=block_desc,
+                        b_block_transfer=block_desc,
+                        c_block_transfer=c_block_desc,
+                        acc_dtype=acc_dtype,
+                    )
+                    manifest.append(new_operation)
+                    operations.append(new_operation)
 
-    block_descriptions = [
-        conv.BlockTransferDesc([4, 8, 8], [1, 0, 2], [1, 0, 2], 2, 1, 1, 1),
-        conv.BlockTransferDesc([4, 8, 8], [1, 0, 2], [1, 0, 2], 2, 1, 1, 1),
-        conv.BlockTransferDesc([4, 4, 8], [1, 0, 2], [1, 0, 2], 2, 1, 1, 1),
-        conv.BlockTransferDesc([4, 8, 8], [1, 0, 2], [1, 0, 2], 2, 1, 1, 1),
-        conv.BlockTransferDesc([4, 4, 8], [1, 0, 2], [1, 0, 2], 2, 1, 1, 1),
-        conv.BlockTransferDesc([4, 4, 8], [1, 0, 2], [1, 0, 2], 2, 1, 1, 1),
-        conv.BlockTransferDesc([4, 2, 8], [1, 0, 2], [1, 0, 2], 2, 1, 1, 1),
-        conv.BlockTransferDesc([4, 8, 8], [1, 0, 2], [1, 0, 2], 2, 1, 1, 1),
-        conv.BlockTransferDesc([4, 8, 8], [1, 0, 2], [1, 0, 2], 2, 1, 1, 1),
-        conv.BlockTransferDesc([4, 4, 8], [1, 0, 2], [1, 0, 2], 2, 1, 1, 1),
-        conv.BlockTransferDesc([4, 2, 8], [1, 0, 2], [1, 0, 2], 2, 1, 1, 1),
-        conv.BlockTransferDesc([4, 2, 8], [1, 0, 2], [1, 0, 2], 2, 1, 1, 1),
-        conv.BlockTransferDesc([2, 32, 4], [1, 0, 2], [1, 0, 2], 2, 1, 1, 1),
-        conv.BlockTransferDesc([2, 32, 4], [1, 0, 2], [1, 0, 2], 2, 1, 1, 1),
-        conv.BlockTransferDesc([2, 32, 4], [1, 0, 2], [1, 0, 2], 2, 1, 1, 1),
-        conv.BlockTransferDesc([2, 16, 4], [1, 0, 2], [1, 0, 2], 2, 1, 1, 1),
-        conv.BlockTransferDesc([2, 16, 4], [1, 0, 2], [1, 0, 2], 2, 1, 1, 1),
-        conv.BlockTransferDesc([4, 16, 4], [1, 0, 2], [1, 0, 2], 2, 2, 2, 1),  # c_out=1
-    ]
+        conv2d_specialization = [conv.Conv2DSpecialization.ConvFwdOddC]
 
-    c_block_descriptions += [
-        conv.CBlockTransferDesc(1, 1, [1, 32, 1, 8], 8),
-        conv.CBlockTransferDesc(1, 1, [1, 32, 1, 8], 8),
-        conv.CBlockTransferDesc(1, 1, [1, 32, 1, 8], 8),
-        conv.CBlockTransferDesc(1, 1, [1, 32, 1, 4], 8),
-        conv.CBlockTransferDesc(1, 1, [1, 16, 1, 4], 8),
-        conv.CBlockTransferDesc(4, 1, [1, 256, 1, 1], 1),  # c_out=1
-    ]
-    for conv2d_spec in conv2d_specialization:
-        for gemm_spec in gemm_specialization:
-            for tile_desc, block_desc, c_block_desc in zip(
-                tile_descriptions, block_descriptions, c_block_descriptions
-            ):
-                new_operation = conv.Conv2DOperation(
-                    operation_kind=operation_kind,
-                    extra_kind=out_element_op,
-                    xdl_op_type=conv.XdlOpType(operation_kind.value),
-                    A=a_element_desc,
-                    B=b_element_desc,
-                    C=c_element_desc,
-                    a_elem_op=in_element_op,
-                    b_elem_op=in_element_op,
-                    epilogue_functor=out_element_op,
-                    c_data_op=out_data_op,
-                    conv2d_specialization=conv2d_spec,
-                    gemm_specialization=gemm_spec,
-                    tile_desc=tile_desc,
-                    a_block_transfer=block_desc,
-                    b_block_transfer=block_desc,
-                    c_block_transfer=c_block_desc,
-                )
-                manifest.append(new_operation)
-                operations.append(new_operation)
+        for conv2d_spec in conv2d_specialization:
+            for gemm_spec in gemm_specialization:
+                for tile_desc, block_desc, c_block_desc in zip(
+                    tile_descriptions, block_descriptions, c_block_descriptions
+                ):
+                    new_operation = conv.Conv2DOperation(
+                        operation_kind=operation_kind,
+                        extra_kind=out_element_op,
+                        xdl_op_type=conv.XdlOpType(operation_kind.value),
+                        A=a_element_desc,
+                        B=b_element_desc,
+                        C=c_element_desc,
+                        a_elem_op=in_element_op,
+                        b_elem_op=in_element_op,
+                        epilogue_functor=out_element_op,
+                        c_data_op=out_data_op,
+                        conv2d_specialization=conv2d_spec,
+                        gemm_specialization=gemm_spec,
+                        tile_desc=tile_desc,
+                        a_block_transfer=block_desc,
+                        b_block_transfer=block_desc,
+                        c_block_transfer=c_block_desc,
+                        acc_dtype=acc_dtype,
+                    )
+                    manifest.append(new_operation)
+                    operations.append(new_operation)
     return operations
 
 
 # Convolution for 2D Bwd operations
 def CreateConv2dBwdOperator(manifest, operation_kind, out_element_op, out_data_op=""):
-    a_element_desc = library.TensorDesc(library.DataType.f16, library.LayoutType.GNWC)
-    b_element_desc = library.TensorDesc(library.DataType.f16, library.LayoutType.GKXC)
-    c_element_desc = library.TensorDesc(library.DataType.f16, library.LayoutType.GNWK)
+    for dtype, acc_dtype in dtype_acc_types:
+        a_element_desc = library.TensorDesc(dtype, library.LayoutType.GNWC)
+        b_element_desc = library.TensorDesc(dtype, library.LayoutType.GKXC)
+        c_element_desc = library.TensorDesc(dtype, library.LayoutType.GNWK)
 
-    in_element_op = library.TensorOperation.PassThrough
+        in_element_op = library.TensorOperation.PassThrough
 
-    tile_descriptions = [
-        conv.TileDesc(256, 256, 128, 4, 8, 32, 32, 4, 2),
-        conv.TileDesc(256, 128, 256, 4, 8, 32, 32, 2, 4),
-        conv.TileDesc(128, 128, 128, 4, 8, 32, 32, 4, 2),
-        conv.TileDesc(256, 128, 128, 4, 8, 32, 32, 2, 2),
-        conv.TileDesc(256, 64, 128, 4, 8, 32, 32, 1, 2),
-        conv.TileDesc(128, 32, 128, 4, 8, 32, 32, 1, 2),
-        conv.TileDesc(128, 64, 128, 4, 8, 32, 32, 2, 2),
-        conv.TileDesc(256, 128, 64, 4, 8, 32, 32, 2, 1),
-        conv.TileDesc(128, 128, 64, 4, 8, 32, 32, 2, 2),
-        conv.TileDesc(64, 64, 64, 4, 8, 32, 32, 2, 2),
-        conv.TileDesc(128, 128, 32, 4, 8, 32, 32, 2, 1),
-        conv.TileDesc(64, 64, 32, 4, 8, 32, 32, 2, 1),
-        conv.TileDesc(64, 32, 64, 4, 8, 32, 32, 1, 2),
-    ]
+        tile_descriptions = [
+            conv.TileDesc(256, 256, 128, 4, 8, 32, 32, 4, 2),
+            conv.TileDesc(256, 128, 256, 4, 8, 32, 32, 2, 4),
+            conv.TileDesc(128, 128, 128, 4, 8, 32, 32, 4, 2),
+            conv.TileDesc(256, 128, 128, 4, 8, 32, 32, 2, 2),
+            conv.TileDesc(256, 64, 128, 4, 8, 32, 32, 1, 2),
+            conv.TileDesc(128, 32, 128, 4, 8, 32, 32, 1, 2),
+            conv.TileDesc(128, 64, 128, 4, 8, 32, 32, 2, 2),
+            conv.TileDesc(256, 128, 64, 4, 8, 32, 32, 2, 1),
+            conv.TileDesc(128, 128, 64, 4, 8, 32, 32, 2, 2),
+            conv.TileDesc(64, 64, 64, 4, 8, 32, 32, 2, 2),
+            conv.TileDesc(128, 128, 32, 4, 8, 32, 32, 2, 1),
+            conv.TileDesc(64, 64, 32, 4, 8, 32, 32, 2, 1),
+            conv.TileDesc(64, 32, 64, 4, 8, 32, 32, 1, 2),
+        ]
 
-    c_block_descriptions = [
-        conv.CBlockTransferDesc(1, 1, [1, 32, 1, 8], 8),
-        conv.CBlockTransferDesc(1, 1, [1, 32, 1, 8], 8),
-        conv.CBlockTransferDesc(1, 1, [1, 16, 1, 8], 8),
-        conv.CBlockTransferDesc(1, 1, [1, 32, 1, 8], 8),
-        conv.CBlockTransferDesc(1, 1, [1, 32, 1, 4], 8),
-        conv.CBlockTransferDesc(1, 1, [1, 16, 1, 8], 8),
-        conv.CBlockTransferDesc(1, 1, [1, 16, 1, 4], 8),
-        conv.CBlockTransferDesc(1, 1, [1, 32, 1, 8], 8),
-        conv.CBlockTransferDesc(1, 1, [1, 32, 1, 8], 8),
-        conv.CBlockTransferDesc(1, 1, [1, 16, 1, 8], 8),
-        conv.CBlockTransferDesc(1, 1, [1, 16, 1, 4], 8),
-        conv.CBlockTransferDesc(1, 1, [1, 16, 1, 4], 8),
-        conv.CBlockTransferDesc(1, 1, [1, 16, 1, 4], 8),
-    ]
+        c_block_descriptions = [
+            conv.CBlockTransferDesc(1, 1, [1, 32, 1, 8], 8),
+            conv.CBlockTransferDesc(1, 1, [1, 32, 1, 8], 8),
+            conv.CBlockTransferDesc(1, 1, [1, 16, 1, 8], 8),
+            conv.CBlockTransferDesc(1, 1, [1, 32, 1, 8], 8),
+            conv.CBlockTransferDesc(1, 1, [1, 32, 1, 4], 8),
+            conv.CBlockTransferDesc(1, 1, [1, 16, 1, 8], 8),
+            conv.CBlockTransferDesc(1, 1, [1, 16, 1, 4], 8),
+            conv.CBlockTransferDesc(1, 1, [1, 32, 1, 8], 8),
+            conv.CBlockTransferDesc(1, 1, [1, 32, 1, 8], 8),
+            conv.CBlockTransferDesc(1, 1, [1, 16, 1, 8], 8),
+            conv.CBlockTransferDesc(1, 1, [1, 16, 1, 4], 8),
+            conv.CBlockTransferDesc(1, 1, [1, 16, 1, 4], 8),
+            conv.CBlockTransferDesc(1, 1, [1, 16, 1, 4], 8),
+        ]
 
-    block_descriptions = []
-    for t in tile_descriptions:
-        block_transfer = -1
-        if t.block_size == 256:
-            block_transfer = [4, 64, 1]
-        if t.block_size == 128:
-            block_transfer = [4, 32, 1]
-        if t.block_size == 64:
-            block_transfer = [4, 16, 1]
-        assert block_transfer != -1, f"Cannot determine block_transfer_size with block_size {str(t.block_size)}"
-        block_descriptions.append(
-            conv.BlockTransferDesc(block_transfer, [1, 0, 2], [1, 0, 2], 2, 8, 8, 1)
-        )
-    b_block_scalars = [2, 4, 4, 2, 2, 4, 4, 1, 2, 4, 1, 2, 2]
-
-    conv2d_specialization = [
-        conv.Conv2DSpecialization.ConvBwdDataDefault,
-        conv.Conv2DSpecialization.ConvBwd1x1S1P0,
-    ]
-    gemm_spec = conv.Conv2DSpecialization.GemmDefault
-
-    operations = []
-    for conv2d_spec in conv2d_specialization:
-        for tile_desc, block_desc, b_scalar, c_block_desc in zip(
-            tile_descriptions,
-            block_descriptions,
-            b_block_scalars,
-            c_block_descriptions,
-        ):
-            b_block_desc = copy.deepcopy(block_desc)
-            b_block_desc.src_vector_dim = 1
-            b_block_desc.src_scalar_per_vector = b_scalar
-            new_operation = conv.Conv2DOperation(
-                operation_kind=operation_kind,
-                extra_kind=out_element_op,
-                xdl_op_type=conv.XdlOpType(operation_kind.value),
-                A=a_element_desc,
-                B=b_element_desc,
-                C=c_element_desc,
-                a_elem_op=in_element_op,
-                b_elem_op=in_element_op,
-                epilogue_functor=out_element_op,
-                c_data_op=out_data_op,
-                conv2d_specialization=conv2d_spec,
-                gemm_specialization=gemm_spec,
-                tile_desc=tile_desc,
-                a_block_transfer=block_desc,
-                b_block_transfer=b_block_desc,
-                c_block_transfer=c_block_desc,
+        block_descriptions = []
+        for t in tile_descriptions:
+            block_transfer = -1
+            if t.block_size == 256:
+                block_transfer = [4, 64, 1]
+            if t.block_size == 128:
+                block_transfer = [4, 32, 1]
+            if t.block_size == 64:
+                block_transfer = [4, 16, 1]
+            assert block_transfer != -1, f"Cannot determine block_transfer_size with block_size {str(t.block_size)}"
+            block_descriptions.append(
+                conv.BlockTransferDesc(block_transfer, [1, 0, 2], [1, 0, 2], 2, 8, 8, 1)
             )
-            manifest.append(new_operation)
-            operations.append(new_operation)
+        b_block_scalars = [2, 4, 4, 2, 2, 4, 4, 1, 2, 4, 1, 2, 2]
+
+        conv2d_specialization = [
+            conv.Conv2DSpecialization.ConvBwdDataDefault,
+            conv.Conv2DSpecialization.ConvBwd1x1S1P0,
+        ]
+        gemm_spec = conv.Conv2DSpecialization.GemmDefault
+
+        operations = []
+        for conv2d_spec in conv2d_specialization:
+            for tile_desc, block_desc, b_scalar, c_block_desc in zip(
+                tile_descriptions,
+                block_descriptions,
+                b_block_scalars,
+                c_block_descriptions,
+            ):
+                b_block_desc = copy.deepcopy(block_desc)
+                b_block_desc.src_vector_dim = 1
+                b_block_desc.src_scalar_per_vector = b_scalar
+                new_operation = conv.Conv2DOperation(
+                    operation_kind=operation_kind,
+                    extra_kind=out_element_op,
+                    xdl_op_type=conv.XdlOpType(operation_kind.value),
+                    A=a_element_desc,
+                    B=b_element_desc,
+                    C=c_element_desc,
+                    a_elem_op=in_element_op,
+                    b_elem_op=in_element_op,
+                    epilogue_functor=out_element_op,
+                    c_data_op=out_data_op,
+                    conv2d_specialization=conv2d_spec,
+                    gemm_specialization=gemm_spec,
+                    tile_desc=tile_desc,
+                    a_block_transfer=block_desc,
+                    b_block_transfer=b_block_desc,
+                    c_block_transfer=c_block_desc,
+                    acc_dtype=acc_dtype,
+                )
+                manifest.append(new_operation)
+                operations.append(new_operation)
     return operations
 
 
@@ -287,104 +244,106 @@ def CreateConv2dBwdOperator(manifest, operation_kind, out_element_op, out_data_o
 def CreateConv2dBwdBiasOperator(
     manifest, operation_kind, out_element_op, out_data_op=""
 ):
-    a_element_desc = library.TensorDesc(library.DataType.f16, library.LayoutType.GNHWK)
-    b_element_desc = library.TensorDesc(library.DataType.f16, library.LayoutType.GKYXC)
-    c_element_desc = library.TensorDesc(library.DataType.f16, library.LayoutType.GNHWC)
+    for dtype, acc_dtype in dtype_acc_types:
+        a_element_desc = library.TensorDesc(dtype, library.LayoutType.GNHWK)
+        b_element_desc = library.TensorDesc(dtype, library.LayoutType.GKYXC)
+        c_element_desc = library.TensorDesc(dtype, library.LayoutType.GNHWC)
 
-    in_element_op = library.TensorOperation.PassThrough
+        in_element_op = library.TensorOperation.PassThrough
 
-    tile_descriptions = [
-        gemm.TileDesc(256, 256, 128, 32, 8, 2, 32, 32, 4, 2),
-        gemm.TileDesc(256, 256, 128, 32, 8, 8, 32, 32, 4, 2),
-        gemm.TileDesc(256, 128, 256, 32, 8, 2, 32, 32, 2, 4),
-        gemm.TileDesc(256, 128, 256, 32, 8, 8, 32, 32, 2, 4),
-        gemm.TileDesc(128, 128, 128, 32, 8, 2, 32, 32, 4, 2),
-        gemm.TileDesc(128, 128, 128, 32, 8, 8, 32, 32, 4, 2),
-        gemm.TileDesc(256, 128, 128, 32, 8, 2, 32, 32, 2, 2),
-        gemm.TileDesc(256, 128, 128, 32, 8, 8, 32, 32, 2, 2),
-        gemm.TileDesc(128, 128, 64, 32, 8, 2, 32, 32, 2, 2),
-        gemm.TileDesc(128, 128, 64, 32, 8, 8, 32, 32, 2, 2),
-        gemm.TileDesc(128, 64, 128, 32, 8, 2, 32, 32, 2, 2),
-        gemm.TileDesc(128, 64, 128, 32, 8, 8, 32, 32, 2, 2),
-        gemm.TileDesc(256, 128, 64, 32, 8, 2, 32, 32, 2, 1),
-        gemm.TileDesc(256, 128, 64, 32, 8, 8, 32, 32, 2, 1),
-        gemm.TileDesc(256, 64, 128, 32, 8, 2, 32, 32, 1, 2),
-        gemm.TileDesc(256, 64, 128, 32, 8, 8, 32, 32, 1, 2),
-    ]
+        tile_descriptions = [
+            gemm.TileDesc(256, 256, 128, 32, 8, 2, 32, 32, 4, 2),
+            gemm.TileDesc(256, 256, 128, 32, 8, 8, 32, 32, 4, 2),
+            gemm.TileDesc(256, 128, 256, 32, 8, 2, 32, 32, 2, 4),
+            gemm.TileDesc(256, 128, 256, 32, 8, 8, 32, 32, 2, 4),
+            gemm.TileDesc(128, 128, 128, 32, 8, 2, 32, 32, 4, 2),
+            gemm.TileDesc(128, 128, 128, 32, 8, 8, 32, 32, 4, 2),
+            gemm.TileDesc(256, 128, 128, 32, 8, 2, 32, 32, 2, 2),
+            gemm.TileDesc(256, 128, 128, 32, 8, 8, 32, 32, 2, 2),
+            gemm.TileDesc(128, 128, 64, 32, 8, 2, 32, 32, 2, 2),
+            gemm.TileDesc(128, 128, 64, 32, 8, 8, 32, 32, 2, 2),
+            gemm.TileDesc(128, 64, 128, 32, 8, 2, 32, 32, 2, 2),
+            gemm.TileDesc(128, 64, 128, 32, 8, 8, 32, 32, 2, 2),
+            gemm.TileDesc(256, 128, 64, 32, 8, 2, 32, 32, 2, 1),
+            gemm.TileDesc(256, 128, 64, 32, 8, 8, 32, 32, 2, 1),
+            gemm.TileDesc(256, 64, 128, 32, 8, 2, 32, 32, 1, 2),
+            gemm.TileDesc(256, 64, 128, 32, 8, 8, 32, 32, 1, 2),
+        ]
 
-    b_block_descriptions = [
-        gemm.BlockTransferDesc([8, 32, 1], [0, 2, 1], [0, 2, 1], 1, 4, 2, 0),
-        gemm.BlockTransferDesc([4, 64, 1], [0, 2, 1], [0, 2, 1], 1, 2, 8, 1),
-        gemm.BlockTransferDesc([4, 64, 1], [0, 2, 1], [0, 2, 1], 1, 4, 2, 0),
-        gemm.BlockTransferDesc([4, 64, 1], [0, 2, 1], [0, 2, 1], 1, 4, 8, 1),
-        gemm.BlockTransferDesc([4, 32, 1], [0, 2, 1], [0, 2, 1], 1, 4, 2, 0),
-        gemm.BlockTransferDesc([4, 32, 1], [0, 2, 1], [0, 2, 1], 1, 4, 8, 1),
-        gemm.BlockTransferDesc([8, 32, 1], [0, 2, 1], [0, 2, 1], 1, 4, 2, 0),
-        gemm.BlockTransferDesc([4, 64, 1], [0, 2, 1], [0, 2, 1], 1, 2, 8, 1),
-        gemm.BlockTransferDesc([8, 16, 1], [0, 2, 1], [0, 2, 1], 1, 4, 2, 0),
-        gemm.BlockTransferDesc([4, 32, 1], [0, 2, 1], [0, 2, 1], 1, 2, 8, 1),
-        gemm.BlockTransferDesc([4, 32, 1], [0, 2, 1], [0, 2, 1], 1, 4, 2, 0),
-        gemm.BlockTransferDesc([4, 32, 1], [0, 2, 1], [0, 2, 1], 1, 4, 8, 1),
-        gemm.BlockTransferDesc([16, 16, 1], [0, 2, 1], [0, 2, 1], 1, 4, 2, 0),
-        gemm.BlockTransferDesc([4, 64, 1], [0, 2, 1], [0, 2, 1], 1, 1, 8, 1),
-        gemm.BlockTransferDesc([8, 32, 1], [0, 2, 1], [0, 2, 1], 1, 4, 2, 0),
-        gemm.BlockTransferDesc([4, 64, 1], [0, 2, 1], [0, 2, 1], 1, 2, 8, 1),
-    ]
-    a_block_descriptions = []
-    c_block_descriptions = []
-    for t in tile_descriptions:
-        a_block_transfer = -1
-        c_block_transfer = -1
-        if t.block_size == 256:
-            a_block_transfer = [4, 64, 1]
-            c_block_transfer = gemm.CBlockTransferDesc(1, 1, [1, 32, 1, 8], 8)
-        if t.block_size == 128:
-            a_block_transfer = [4, 32, 1]
-            if t.n_per_block == 128:
-                c_block_transfer = gemm.CBlockTransferDesc(1, 1, [1, 16, 1, 8], 8)
-            if t.n_per_block == 64:
-                c_block_transfer = gemm.CBlockTransferDesc(1, 1, [1, 32, 1, 4], 8)
+        b_block_descriptions = [
+            gemm.BlockTransferDesc([8, 32, 1], [0, 2, 1], [0, 2, 1], 1, 4, 2, 0),
+            gemm.BlockTransferDesc([4, 64, 1], [0, 2, 1], [0, 2, 1], 1, 2, 8, 1),
+            gemm.BlockTransferDesc([4, 64, 1], [0, 2, 1], [0, 2, 1], 1, 4, 2, 0),
+            gemm.BlockTransferDesc([4, 64, 1], [0, 2, 1], [0, 2, 1], 1, 4, 8, 1),
+            gemm.BlockTransferDesc([4, 32, 1], [0, 2, 1], [0, 2, 1], 1, 4, 2, 0),
+            gemm.BlockTransferDesc([4, 32, 1], [0, 2, 1], [0, 2, 1], 1, 4, 8, 1),
+            gemm.BlockTransferDesc([8, 32, 1], [0, 2, 1], [0, 2, 1], 1, 4, 2, 0),
+            gemm.BlockTransferDesc([4, 64, 1], [0, 2, 1], [0, 2, 1], 1, 2, 8, 1),
+            gemm.BlockTransferDesc([8, 16, 1], [0, 2, 1], [0, 2, 1], 1, 4, 2, 0),
+            gemm.BlockTransferDesc([4, 32, 1], [0, 2, 1], [0, 2, 1], 1, 2, 8, 1),
+            gemm.BlockTransferDesc([4, 32, 1], [0, 2, 1], [0, 2, 1], 1, 4, 2, 0),
+            gemm.BlockTransferDesc([4, 32, 1], [0, 2, 1], [0, 2, 1], 1, 4, 8, 1),
+            gemm.BlockTransferDesc([16, 16, 1], [0, 2, 1], [0, 2, 1], 1, 4, 2, 0),
+            gemm.BlockTransferDesc([4, 64, 1], [0, 2, 1], [0, 2, 1], 1, 1, 8, 1),
+            gemm.BlockTransferDesc([8, 32, 1], [0, 2, 1], [0, 2, 1], 1, 4, 2, 0),
+            gemm.BlockTransferDesc([4, 64, 1], [0, 2, 1], [0, 2, 1], 1, 2, 8, 1),
+        ]
+        a_block_descriptions = []
+        c_block_descriptions = []
+        for t in tile_descriptions:
+            a_block_transfer = -1
+            c_block_transfer = -1
+            if t.block_size == 256:
+                a_block_transfer = [4, 64, 1]
+                c_block_transfer = gemm.CBlockTransferDesc(1, 1, [1, 32, 1, 8], 8)
+            if t.block_size == 128:
+                a_block_transfer = [4, 32, 1]
+                if t.n_per_block == 128:
+                    c_block_transfer = gemm.CBlockTransferDesc(1, 1, [1, 16, 1, 8], 8)
+                if t.n_per_block == 64:
+                    c_block_transfer = gemm.CBlockTransferDesc(1, 1, [1, 32, 1, 4], 8)
 
-        assert a_block_transfer != -1 and c_block_transfer != -1, "Cannot determine block_transfer_size with block_size " + str(t.block_size)
-        a_block_descriptions.append(
-            gemm.BlockTransferDesc(a_block_transfer, [1, 0, 2], [1, 0, 2], 2, 8, 8, 1)
-        )
-        c_block_descriptions.append(c_block_transfer)
-
-    conv2d_specialization = [
-        conv.Conv2DSpecialization.ConvBwdDataDefault,
-        conv.Conv2DSpecialization.ConvBwd1x1S1P0,
-    ]
-    gemm_spec = conv.Conv2DSpecialization.GemmDefault
-
-    operations = []
-    for conv2d_spec in conv2d_specialization:
-        for tile_desc, a_block_desc, b_block_desc, c_block_desc in zip(
-            tile_descriptions,
-            a_block_descriptions,
-            b_block_descriptions,
-            c_block_descriptions,
-        ):
-            new_operation = conv.Conv2DOperation(
-                operation_kind=operation_kind,
-                extra_kind=out_element_op,
-                xdl_op_type=conv.XdlOpType(operation_kind.value),
-                A=a_element_desc,
-                B=b_element_desc,
-                C=c_element_desc,
-                a_elem_op=in_element_op,
-                b_elem_op=in_element_op,
-                epilogue_functor=out_element_op,
-                c_data_op=out_data_op,
-                conv2d_specialization=conv2d_spec,
-                gemm_specialization=gemm_spec,
-                tile_desc=tile_desc,
-                a_block_transfer=a_block_desc,
-                b_block_transfer=b_block_desc,
-                c_block_transfer=c_block_desc,
+            assert a_block_transfer != -1 and c_block_transfer != -1, "Cannot determine block_transfer_size with block_size " + str(t.block_size)
+            a_block_descriptions.append(
+                gemm.BlockTransferDesc(a_block_transfer, [1, 0, 2], [1, 0, 2], 2, 8, 8, 1)
             )
-            manifest.append(new_operation)
-            operations.append(new_operation)
+            c_block_descriptions.append(c_block_transfer)
+
+        conv2d_specialization = [
+            conv.Conv2DSpecialization.ConvBwdDataDefault,
+            conv.Conv2DSpecialization.ConvBwd1x1S1P0,
+        ]
+        gemm_spec = conv.Conv2DSpecialization.GemmDefault
+
+        operations = []
+        for conv2d_spec in conv2d_specialization:
+            for tile_desc, a_block_desc, b_block_desc, c_block_desc in zip(
+                tile_descriptions,
+                a_block_descriptions,
+                b_block_descriptions,
+                c_block_descriptions,
+            ):
+                new_operation = conv.Conv2DOperation(
+                    operation_kind=operation_kind,
+                    extra_kind=out_element_op,
+                    xdl_op_type=conv.XdlOpType(operation_kind.value),
+                    A=a_element_desc,
+                    B=b_element_desc,
+                    C=c_element_desc,
+                    a_elem_op=in_element_op,
+                    b_elem_op=in_element_op,
+                    epilogue_functor=out_element_op,
+                    c_data_op=out_data_op,
+                    conv2d_specialization=conv2d_spec,
+                    gemm_specialization=gemm_spec,
+                    tile_desc=tile_desc,
+                    a_block_transfer=a_block_desc,
+                    b_block_transfer=b_block_desc,
+                    c_block_transfer=c_block_desc,
+                    acc_dtype=acc_dtype,
+                )
+                manifest.append(new_operation)
+                operations.append(new_operation)
     return operations
 
 
@@ -392,1013 +351,1033 @@ def CreateConv2dBwdBiasOperator(
 # Gemm operations
 def CreateGemmRRROperator(manifest):
     operation_kind = library.GemmKind.Gemm
-    a_element_desc = library.TensorDesc(
-        library.DataType.f16, library.LayoutType.RowMajor
-    )
-    b_element_desc = library.TensorDesc(
-        library.DataType.f16, library.LayoutType.RowMajor
-    )
-    c_element_desc = library.TensorDesc(
-        library.DataType.f16, library.LayoutType.RowMajor
-    )
-    element_op = library.TensorOperation.PassThrough
-
-    xdl_op_type=gemm.XdlOpType.DeviceGemmXdl_CShuffle
-
-    tile_descriptions = [
-        gemm.TileDesc(256,   256,   128,    32,   8,   8,   16,   16,    8,    4),
-        gemm.TileDesc(256,   128,   256,    32,   8,   8,   16,   16,    4,    8),
-        gemm.TileDesc(128,   128,   128,    32,   8,   8,   16,   16,    8,    4),
-        gemm.TileDesc(256,   128,   128,    32,   8,   8,   16,   16,    4,    4),
-        gemm.TileDesc(128,   128,    64,    32,   8,   8,   16,   16,    4,    4),
-        gemm.TileDesc(128,    64,   128,    32,   8,   8,   16,   16,    4,    4),
-        gemm.TileDesc(256,   128,    64,    32,   8,   8,   16,   16,    4,    2),
-        gemm.TileDesc(256,    64,   128,    32,   8,   8,   16,   16,    2,    4),
-        gemm.TileDesc( 64,    32,    32,    32,   8,   8,   16,   16,    2,    2),
-    ]
-    a_block_descriptions_row_major = [
-        gemm.BlockTransferDesc([4, 64, 1], [1, 0, 2], [1, 0, 2], 2, 8, 8, 1),
-        gemm.BlockTransferDesc([4, 64, 1], [1, 0, 2], [1, 0, 2], 2, 8, 8, 1),
-        gemm.BlockTransferDesc([4, 32, 1], [1, 0, 2], [1, 0, 2], 2, 8, 8, 1),
-        gemm.BlockTransferDesc([4, 64, 1], [1, 0, 2], [1, 0, 2], 2, 8, 8, 1),
-        gemm.BlockTransferDesc([4, 32, 1], [1, 0, 2], [1, 0, 2], 2, 8, 8, 1),
-        gemm.BlockTransferDesc([4, 32, 1], [1, 0, 2], [1, 0, 2], 2, 8, 8, 1),
-        gemm.BlockTransferDesc([4, 64, 1], [1, 0, 2], [1, 0, 2], 2, 8, 8, 1),
-        gemm.BlockTransferDesc([4, 64, 1], [1, 0, 2], [1, 0, 2], 2, 8, 8, 1),
-        gemm.BlockTransferDesc([4, 16, 1], [1, 0, 2], [1, 0, 2], 2, 1, 8, 1),
-    ]
-    a_block_descriptions_col_major = [
-        gemm.BlockTransferDesc([4, 64, 1], [0, 2, 1], [0, 2, 1], 1, 4, 8, 1),
-        gemm.BlockTransferDesc([4, 64, 1], [0, 2, 1], [0, 2, 1], 1, 2, 8, 1),
-        gemm.BlockTransferDesc([4, 32, 1], [0, 2, 1], [0, 2, 1], 1, 4, 8, 1),
-        gemm.BlockTransferDesc([4, 64, 1], [0, 2, 1], [0, 2, 1], 1, 2, 8, 1),
-        gemm.BlockTransferDesc([4, 32, 1], [0, 2, 1], [0, 2, 1], 1, 4, 8, 1),
-        gemm.BlockTransferDesc([4, 32, 1], [0, 2, 1], [0, 2, 1], 1, 2, 8, 1),
-        gemm.BlockTransferDesc([4, 64, 1], [0, 2, 1], [0, 2, 1], 1, 2, 8, 1),
-        gemm.BlockTransferDesc([4, 64, 1], [0, 2, 1], [0, 2, 1], 1, 1, 8, 1),
-        gemm.BlockTransferDesc([4, 16, 1], [0, 2, 1], [0, 2, 1], 1, 1, 8, 1),
-    ]
-    b_block_descriptions_rowmajor = [
-        gemm.BlockTransferDesc([4, 64, 1], [0, 2, 1], [0, 2, 1], 1, 2, 8, 1),
-        gemm.BlockTransferDesc([4, 64, 1], [0, 2, 1], [0, 2, 1], 1, 4, 8, 1),
-        gemm.BlockTransferDesc([4, 32, 1], [0, 2, 1], [0, 2, 1], 1, 4, 8, 1),
-        gemm.BlockTransferDesc([4, 64, 1], [0, 2, 1], [0, 2, 1], 1, 2, 8, 1),
-        gemm.BlockTransferDesc([4, 32, 1], [0, 2, 1], [0, 2, 1], 1, 2, 8, 1),
-        gemm.BlockTransferDesc([4, 32, 1], [0, 2, 1], [0, 2, 1], 1, 4, 8, 1),
-        gemm.BlockTransferDesc([4, 64, 1], [0, 2, 1], [0, 2, 1], 1, 1, 8, 1),
-        gemm.BlockTransferDesc([4, 64, 1], [0, 2, 1], [0, 2, 1], 1, 2, 8, 1),
-        gemm.BlockTransferDesc([4, 16, 1], [0, 2, 1], [0, 2, 1], 1, 1, 8, 1),
-    ]
-    b_block_descriptions_colmajor = [
-        gemm.BlockTransferDesc([4, 64, 1], [1, 0, 2], [1, 0, 2], 2, 8, 8, 1),
-        gemm.BlockTransferDesc([4, 64, 1], [1, 0, 2], [1, 0, 2], 2, 8, 8, 1),
-        gemm.BlockTransferDesc([4, 32, 1], [1, 0, 2], [1, 0, 2], 2, 8, 8, 1),
-        gemm.BlockTransferDesc([4, 64, 1], [1, 0, 2], [1, 0, 2], 2, 8, 8, 1),
-        gemm.BlockTransferDesc([4, 32, 1], [1, 0, 2], [1, 0, 2], 2, 8, 8, 1),
-        gemm.BlockTransferDesc([4, 32, 1], [1, 0, 2], [1, 0, 2], 2, 8, 8, 1),
-        gemm.BlockTransferDesc([4, 64, 1], [1, 0, 2], [1, 0, 2], 2, 8, 8, 1),
-        gemm.BlockTransferDesc([4, 64, 1], [1, 0, 2], [1, 0, 2], 2, 8, 8, 1),
-        gemm.BlockTransferDesc([4, 16, 1], [1, 0, 2], [1, 0, 2], 2, 1, 8, 1),
-    ]
-    c_block_descriptions = [
-        gemm.CBlockTransferDesc(1, 1, [1, 32, 1, 8], 4),
-        gemm.CBlockTransferDesc(1, 1, [1, 32, 1, 8], 4),
-        gemm.CBlockTransferDesc(1, 1, [1, 16, 1, 8], 4),
-        gemm.CBlockTransferDesc(1, 1, [1, 32, 1, 8], 4),
-        gemm.CBlockTransferDesc(1, 1, [1, 32, 1, 4], 4),
-        gemm.CBlockTransferDesc(1, 1, [1, 16, 1, 8], 4),
-        gemm.CBlockTransferDesc(1, 1, [1, 32, 1, 8], 4),
-        gemm.CBlockTransferDesc(1, 1, [1, 32, 1, 8], 4),
-        gemm.CBlockTransferDesc(1, 1, [1, 16, 1, 4], 1),
-    ]
-    if a_element_desc.layout == library.LayoutType.RowMajor:
-        a_block_descriptions = a_block_descriptions_row_major
-    else:
-        a_block_descriptions = a_block_descriptions_col_major
-    if b_element_desc.layout == library.LayoutType.RowMajor:
-        b_block_descriptions = b_block_descriptions_rowmajor
-    else:
-        b_block_descriptions = b_block_descriptions_colmajor
-    operations = []
-    for tile_desc, a_block_desc, b_block_desc, c_block_desc in zip(
-        tile_descriptions, a_block_descriptions, b_block_descriptions, c_block_descriptions
-    ):
-        op = gemm.GemmOperation(
-            operation_kind=operation_kind,
-            extra_kind=element_op,
-            xdl_op_type=xdl_op_type,
-            A=a_element_desc,
-            B=b_element_desc,
-            C=c_element_desc,
-            a_elem_op=element_op,
-            b_elem_op=element_op,
-            epilogue_functor=element_op,
-            gemm_specialization=gemm.GemmSpecialization.MNKPadding,
-            tile_desc=copy.deepcopy(tile_desc),
-            a_block_transfer=copy.deepcopy(a_block_desc),
-            b_block_transfer=copy.deepcopy(b_block_desc),
-            c_block_transfer=copy.deepcopy(c_block_desc),
+    for dtype, acc_dtype in dtype_acc_types:
+        a_element_desc = library.TensorDesc(
+            dtype, library.LayoutType.RowMajor
         )
-        manifest.append(op)
-        operations.append(op)
+        b_element_desc = library.TensorDesc(
+            dtype, library.LayoutType.RowMajor
+        )
+        c_element_desc = library.TensorDesc(
+            dtype, library.LayoutType.RowMajor
+        )
+        element_op = library.TensorOperation.PassThrough
+
+        xdl_op_type=gemm.XdlOpType.DeviceGemmXdl_CShuffle
+
+        tile_descriptions = [
+            gemm.TileDesc(256,   256,   128,    32,   8,   8,   16,   16,    8,    4),
+            gemm.TileDesc(256,   128,   256,    32,   8,   8,   16,   16,    4,    8),
+            gemm.TileDesc(128,   128,   128,    32,   8,   8,   16,   16,    8,    4),
+            gemm.TileDesc(256,   128,   128,    32,   8,   8,   16,   16,    4,    4),
+            gemm.TileDesc(128,   128,    64,    32,   8,   8,   16,   16,    4,    4),
+            gemm.TileDesc(128,    64,   128,    32,   8,   8,   16,   16,    4,    4),
+            gemm.TileDesc(256,   128,    64,    32,   8,   8,   16,   16,    4,    2),
+            gemm.TileDesc(256,    64,   128,    32,   8,   8,   16,   16,    2,    4),
+            gemm.TileDesc( 64,    32,    32,    32,   8,   8,   16,   16,    2,    2),
+        ]
+        a_block_descriptions_row_major = [
+            gemm.BlockTransferDesc([4, 64, 1], [1, 0, 2], [1, 0, 2], 2, 8, 8, 1),
+            gemm.BlockTransferDesc([4, 64, 1], [1, 0, 2], [1, 0, 2], 2, 8, 8, 1),
+            gemm.BlockTransferDesc([4, 32, 1], [1, 0, 2], [1, 0, 2], 2, 8, 8, 1),
+            gemm.BlockTransferDesc([4, 64, 1], [1, 0, 2], [1, 0, 2], 2, 8, 8, 1),
+            gemm.BlockTransferDesc([4, 32, 1], [1, 0, 2], [1, 0, 2], 2, 8, 8, 1),
+            gemm.BlockTransferDesc([4, 32, 1], [1, 0, 2], [1, 0, 2], 2, 8, 8, 1),
+            gemm.BlockTransferDesc([4, 64, 1], [1, 0, 2], [1, 0, 2], 2, 8, 8, 1),
+            gemm.BlockTransferDesc([4, 64, 1], [1, 0, 2], [1, 0, 2], 2, 8, 8, 1),
+            gemm.BlockTransferDesc([4, 16, 1], [1, 0, 2], [1, 0, 2], 2, 1, 8, 1),
+        ]
+        a_block_descriptions_col_major = [
+            gemm.BlockTransferDesc([4, 64, 1], [0, 2, 1], [0, 2, 1], 1, 4, 8, 1),
+            gemm.BlockTransferDesc([4, 64, 1], [0, 2, 1], [0, 2, 1], 1, 2, 8, 1),
+            gemm.BlockTransferDesc([4, 32, 1], [0, 2, 1], [0, 2, 1], 1, 4, 8, 1),
+            gemm.BlockTransferDesc([4, 64, 1], [0, 2, 1], [0, 2, 1], 1, 2, 8, 1),
+            gemm.BlockTransferDesc([4, 32, 1], [0, 2, 1], [0, 2, 1], 1, 4, 8, 1),
+            gemm.BlockTransferDesc([4, 32, 1], [0, 2, 1], [0, 2, 1], 1, 2, 8, 1),
+            gemm.BlockTransferDesc([4, 64, 1], [0, 2, 1], [0, 2, 1], 1, 2, 8, 1),
+            gemm.BlockTransferDesc([4, 64, 1], [0, 2, 1], [0, 2, 1], 1, 1, 8, 1),
+            gemm.BlockTransferDesc([4, 16, 1], [0, 2, 1], [0, 2, 1], 1, 1, 8, 1),
+        ]
+        b_block_descriptions_rowmajor = [
+            gemm.BlockTransferDesc([4, 64, 1], [0, 2, 1], [0, 2, 1], 1, 2, 8, 1),
+            gemm.BlockTransferDesc([4, 64, 1], [0, 2, 1], [0, 2, 1], 1, 4, 8, 1),
+            gemm.BlockTransferDesc([4, 32, 1], [0, 2, 1], [0, 2, 1], 1, 4, 8, 1),
+            gemm.BlockTransferDesc([4, 64, 1], [0, 2, 1], [0, 2, 1], 1, 2, 8, 1),
+            gemm.BlockTransferDesc([4, 32, 1], [0, 2, 1], [0, 2, 1], 1, 2, 8, 1),
+            gemm.BlockTransferDesc([4, 32, 1], [0, 2, 1], [0, 2, 1], 1, 4, 8, 1),
+            gemm.BlockTransferDesc([4, 64, 1], [0, 2, 1], [0, 2, 1], 1, 1, 8, 1),
+            gemm.BlockTransferDesc([4, 64, 1], [0, 2, 1], [0, 2, 1], 1, 2, 8, 1),
+            gemm.BlockTransferDesc([4, 16, 1], [0, 2, 1], [0, 2, 1], 1, 1, 8, 1),
+        ]
+        b_block_descriptions_colmajor = [
+            gemm.BlockTransferDesc([4, 64, 1], [1, 0, 2], [1, 0, 2], 2, 8, 8, 1),
+            gemm.BlockTransferDesc([4, 64, 1], [1, 0, 2], [1, 0, 2], 2, 8, 8, 1),
+            gemm.BlockTransferDesc([4, 32, 1], [1, 0, 2], [1, 0, 2], 2, 8, 8, 1),
+            gemm.BlockTransferDesc([4, 64, 1], [1, 0, 2], [1, 0, 2], 2, 8, 8, 1),
+            gemm.BlockTransferDesc([4, 32, 1], [1, 0, 2], [1, 0, 2], 2, 8, 8, 1),
+            gemm.BlockTransferDesc([4, 32, 1], [1, 0, 2], [1, 0, 2], 2, 8, 8, 1),
+            gemm.BlockTransferDesc([4, 64, 1], [1, 0, 2], [1, 0, 2], 2, 8, 8, 1),
+            gemm.BlockTransferDesc([4, 64, 1], [1, 0, 2], [1, 0, 2], 2, 8, 8, 1),
+            gemm.BlockTransferDesc([4, 16, 1], [1, 0, 2], [1, 0, 2], 2, 1, 8, 1),
+        ]
+        c_block_descriptions = [
+            gemm.CBlockTransferDesc(1, 1, [1, 32, 1, 8], 4),
+            gemm.CBlockTransferDesc(1, 1, [1, 32, 1, 8], 4),
+            gemm.CBlockTransferDesc(1, 1, [1, 16, 1, 8], 4),
+            gemm.CBlockTransferDesc(1, 1, [1, 32, 1, 8], 4),
+            gemm.CBlockTransferDesc(1, 1, [1, 32, 1, 4], 4),
+            gemm.CBlockTransferDesc(1, 1, [1, 16, 1, 8], 4),
+            gemm.CBlockTransferDesc(1, 1, [1, 32, 1, 8], 4),
+            gemm.CBlockTransferDesc(1, 1, [1, 32, 1, 8], 4),
+            gemm.CBlockTransferDesc(1, 1, [1, 16, 1, 4], 1),
+        ]
+        if a_element_desc.layout == library.LayoutType.RowMajor:
+            a_block_descriptions = a_block_descriptions_row_major
+        else:
+            a_block_descriptions = a_block_descriptions_col_major
+        if b_element_desc.layout == library.LayoutType.RowMajor:
+            b_block_descriptions = b_block_descriptions_rowmajor
+        else:
+            b_block_descriptions = b_block_descriptions_colmajor
+        operations = []
+        for tile_desc, a_block_desc, b_block_desc, c_block_desc in zip(
+            tile_descriptions, a_block_descriptions, b_block_descriptions, c_block_descriptions
+        ):
+            op = gemm.GemmOperation(
+                operation_kind=operation_kind,
+                extra_kind=element_op,
+                xdl_op_type=xdl_op_type,
+                A=a_element_desc,
+                B=b_element_desc,
+                C=c_element_desc,
+                a_elem_op=element_op,
+                b_elem_op=element_op,
+                epilogue_functor=element_op,
+                gemm_specialization=gemm.GemmSpecialization.MNKPadding,
+                tile_desc=copy.deepcopy(tile_desc),
+                a_block_transfer=copy.deepcopy(a_block_desc),
+                b_block_transfer=copy.deepcopy(b_block_desc),
+                c_block_transfer=copy.deepcopy(c_block_desc),
+                acc_dtype=acc_dtype,
+            )
+            manifest.append(op)
+            operations.append(op)
     return operations
 
 def CreateGemmRCROperator(manifest):
     operation_kind = library.GemmKind.Gemm
-    a_element_desc = library.TensorDesc(
-        library.DataType.f16, library.LayoutType.RowMajor
-    )
-    b_element_desc = library.TensorDesc(
-        library.DataType.f16, library.LayoutType.ColumnMajor
-    )
-    c_element_desc = library.TensorDesc(
-        library.DataType.f16, library.LayoutType.RowMajor
-    )
-    element_op = library.TensorOperation.PassThrough
-
-    xdl_op_type=gemm.XdlOpType.DeviceGemmXdl_CShuffle
-
-    tile_descriptions = [
-        gemm.TileDesc(256,   256,   128,    32,   8,   8,   16,   16,    8,    4),
-        gemm.TileDesc(256,   128,   256,    32,   8,   8,   16,   16,    4,    8),
-        gemm.TileDesc(128,   128,   128,    32,   8,   8,   16,   16,    8,    4),
-        gemm.TileDesc(256,   128,   128,    32,   8,   8,   16,   16,    4,    4),
-        gemm.TileDesc(128,   128,    64,    32,   8,   8,   16,   16,    4,    4),
-        gemm.TileDesc(128,    64,   128,    32,   8,   8,   16,   16,    4,    4),
-        gemm.TileDesc(256,   128,    64,    32,   8,   8,   16,   16,    4,    2),
-        gemm.TileDesc(256,    64,   128,    32,   8,   8,   16,   16,    2,    4),
-        gemm.TileDesc( 64,    32,    32,    32,   8,   8,   16,   16,    2,    2),
-    ]
-    a_block_descriptions_row_major = [
-        gemm.BlockTransferDesc([4, 64, 1], [1, 0, 2], [1, 0, 2], 2, 8, 8, 1),
-        gemm.BlockTransferDesc([4, 64, 1], [1, 0, 2], [1, 0, 2], 2, 8, 8, 1),
-        gemm.BlockTransferDesc([4, 32, 1], [1, 0, 2], [1, 0, 2], 2, 8, 8, 1),
-        gemm.BlockTransferDesc([4, 64, 1], [1, 0, 2], [1, 0, 2], 2, 8, 8, 1),
-        gemm.BlockTransferDesc([4, 32, 1], [1, 0, 2], [1, 0, 2], 2, 8, 8, 1),
-        gemm.BlockTransferDesc([4, 32, 1], [1, 0, 2], [1, 0, 2], 2, 8, 8, 1),
-        gemm.BlockTransferDesc([4, 64, 1], [1, 0, 2], [1, 0, 2], 2, 8, 8, 1),
-        gemm.BlockTransferDesc([4, 64, 1], [1, 0, 2], [1, 0, 2], 2, 8, 8, 1),
-        gemm.BlockTransferDesc([4, 16, 1], [1, 0, 2], [1, 0, 2], 2, 1, 8, 1),
-    ]
-    a_block_descriptions_col_major = [
-        gemm.BlockTransferDesc([4, 64, 1], [0, 2, 1], [0, 2, 1], 1, 4, 8, 1),
-        gemm.BlockTransferDesc([4, 64, 1], [0, 2, 1], [0, 2, 1], 1, 2, 8, 1),
-        gemm.BlockTransferDesc([4, 32, 1], [0, 2, 1], [0, 2, 1], 1, 4, 8, 1),
-        gemm.BlockTransferDesc([4, 64, 1], [0, 2, 1], [0, 2, 1], 1, 2, 8, 1),
-        gemm.BlockTransferDesc([4, 32, 1], [0, 2, 1], [0, 2, 1], 1, 4, 8, 1),
-        gemm.BlockTransferDesc([4, 32, 1], [0, 2, 1], [0, 2, 1], 1, 2, 8, 1),
-        gemm.BlockTransferDesc([4, 64, 1], [0, 2, 1], [0, 2, 1], 1, 2, 8, 1),
-        gemm.BlockTransferDesc([4, 64, 1], [0, 2, 1], [0, 2, 1], 1, 1, 8, 1),
-        gemm.BlockTransferDesc([4, 16, 1], [0, 2, 1], [0, 2, 1], 1, 1, 8, 1),
-    ]
-    b_block_descriptions_rowmajor = [
-        gemm.BlockTransferDesc([4, 64, 1], [0, 2, 1], [0, 2, 1], 1, 2, 8, 1),
-        gemm.BlockTransferDesc([4, 64, 1], [0, 2, 1], [0, 2, 1], 1, 4, 8, 1),
-        gemm.BlockTransferDesc([4, 32, 1], [0, 2, 1], [0, 2, 1], 1, 4, 8, 1),
-        gemm.BlockTransferDesc([4, 64, 1], [0, 2, 1], [0, 2, 1], 1, 2, 8, 1),
-        gemm.BlockTransferDesc([4, 32, 1], [0, 2, 1], [0, 2, 1], 1, 2, 8, 1),
-        gemm.BlockTransferDesc([4, 32, 1], [0, 2, 1], [0, 2, 1], 1, 4, 8, 1),
-        gemm.BlockTransferDesc([4, 64, 1], [0, 2, 1], [0, 2, 1], 1, 1, 8, 1),
-        gemm.BlockTransferDesc([4, 64, 1], [0, 2, 1], [0, 2, 1], 1, 2, 8, 1),
-        gemm.BlockTransferDesc([4, 16, 1], [0, 2, 1], [0, 2, 1], 1, 1, 8, 1),
-    ]
-    b_block_descriptions_colmajor = [
-        gemm.BlockTransferDesc([4, 64, 1], [1, 0, 2], [1, 0, 2], 2, 8, 8, 1),
-        gemm.BlockTransferDesc([4, 64, 1], [1, 0, 2], [1, 0, 2], 2, 8, 8, 1),
-        gemm.BlockTransferDesc([4, 32, 1], [1, 0, 2], [1, 0, 2], 2, 8, 8, 1),
-        gemm.BlockTransferDesc([4, 64, 1], [1, 0, 2], [1, 0, 2], 2, 8, 8, 1),
-        gemm.BlockTransferDesc([4, 32, 1], [1, 0, 2], [1, 0, 2], 2, 8, 8, 1),
-        gemm.BlockTransferDesc([4, 32, 1], [1, 0, 2], [1, 0, 2], 2, 8, 8, 1),
-        gemm.BlockTransferDesc([4, 64, 1], [1, 0, 2], [1, 0, 2], 2, 8, 8, 1),
-        gemm.BlockTransferDesc([4, 64, 1], [1, 0, 2], [1, 0, 2], 2, 8, 8, 1),
-        gemm.BlockTransferDesc([4, 16, 1], [1, 0, 2], [1, 0, 2], 2, 1, 8, 1),
-    ]
-    c_block_descriptions = [
-        gemm.CBlockTransferDesc(1, 1, [1, 32, 1, 8], 4),
-        gemm.CBlockTransferDesc(1, 1, [1, 32, 1, 8], 4),
-        gemm.CBlockTransferDesc(1, 1, [1, 16, 1, 8], 4),
-        gemm.CBlockTransferDesc(1, 1, [1, 32, 1, 8], 4),
-        gemm.CBlockTransferDesc(1, 1, [1, 32, 1, 4], 4),
-        gemm.CBlockTransferDesc(1, 1, [1, 16, 1, 8], 4),
-        gemm.CBlockTransferDesc(1, 1, [1, 32, 1, 8], 4),
-        gemm.CBlockTransferDesc(1, 1, [1, 32, 1, 8], 4),
-        gemm.CBlockTransferDesc(1, 1, [1, 16, 1, 4], 1),
-    ]
-    if a_element_desc.layout == library.LayoutType.RowMajor:
-        a_block_descriptions = a_block_descriptions_row_major
-    else:
-        a_block_descriptions = a_block_descriptions_col_major
-    if b_element_desc.layout == library.LayoutType.RowMajor:
-        b_block_descriptions = b_block_descriptions_rowmajor
-    else:
-        b_block_descriptions = b_block_descriptions_colmajor
-    operations = []
-    for tile_desc, a_block_desc, b_block_desc, c_block_desc in zip(
-        tile_descriptions, a_block_descriptions, b_block_descriptions, c_block_descriptions
-    ):
-        op = gemm.GemmOperation(
-            operation_kind=operation_kind,
-            extra_kind=element_op,
-            xdl_op_type=xdl_op_type,
-            A=a_element_desc,
-            B=b_element_desc,
-            C=c_element_desc,
-            a_elem_op=element_op,
-            b_elem_op=element_op,
-            epilogue_functor=element_op,
-            gemm_specialization=gemm.GemmSpecialization.MNKPadding,
-            tile_desc=copy.deepcopy(tile_desc),
-            a_block_transfer=copy.deepcopy(a_block_desc),
-            b_block_transfer=copy.deepcopy(b_block_desc),
-            c_block_transfer=copy.deepcopy(c_block_desc),
+    for dtype, acc_dtype in dtype_acc_types:
+        a_element_desc = library.TensorDesc(
+            dtype, library.LayoutType.RowMajor
         )
-        manifest.append(op)
-        operations.append(op)
+        b_element_desc = library.TensorDesc(
+            dtype, library.LayoutType.ColumnMajor
+        )
+        c_element_desc = library.TensorDesc(
+            dtype, library.LayoutType.RowMajor
+        )
+        element_op = library.TensorOperation.PassThrough
+
+        xdl_op_type=gemm.XdlOpType.DeviceGemmXdl_CShuffle
+
+        tile_descriptions = [
+            gemm.TileDesc(256,   256,   128,    32,   8,   8,   16,   16,    8,    4),
+            gemm.TileDesc(256,   128,   256,    32,   8,   8,   16,   16,    4,    8),
+            gemm.TileDesc(128,   128,   128,    32,   8,   8,   16,   16,    8,    4),
+            gemm.TileDesc(256,   128,   128,    32,   8,   8,   16,   16,    4,    4),
+            gemm.TileDesc(128,   128,    64,    32,   8,   8,   16,   16,    4,    4),
+            gemm.TileDesc(128,    64,   128,    32,   8,   8,   16,   16,    4,    4),
+            gemm.TileDesc(256,   128,    64,    32,   8,   8,   16,   16,    4,    2),
+            gemm.TileDesc(256,    64,   128,    32,   8,   8,   16,   16,    2,    4),
+            gemm.TileDesc( 64,    32,    32,    32,   8,   8,   16,   16,    2,    2),
+        ]
+        a_block_descriptions_row_major = [
+            gemm.BlockTransferDesc([4, 64, 1], [1, 0, 2], [1, 0, 2], 2, 8, 8, 1),
+            gemm.BlockTransferDesc([4, 64, 1], [1, 0, 2], [1, 0, 2], 2, 8, 8, 1),
+            gemm.BlockTransferDesc([4, 32, 1], [1, 0, 2], [1, 0, 2], 2, 8, 8, 1),
+            gemm.BlockTransferDesc([4, 64, 1], [1, 0, 2], [1, 0, 2], 2, 8, 8, 1),
+            gemm.BlockTransferDesc([4, 32, 1], [1, 0, 2], [1, 0, 2], 2, 8, 8, 1),
+            gemm.BlockTransferDesc([4, 32, 1], [1, 0, 2], [1, 0, 2], 2, 8, 8, 1),
+            gemm.BlockTransferDesc([4, 64, 1], [1, 0, 2], [1, 0, 2], 2, 8, 8, 1),
+            gemm.BlockTransferDesc([4, 64, 1], [1, 0, 2], [1, 0, 2], 2, 8, 8, 1),
+            gemm.BlockTransferDesc([4, 16, 1], [1, 0, 2], [1, 0, 2], 2, 1, 8, 1),
+        ]
+        a_block_descriptions_col_major = [
+            gemm.BlockTransferDesc([4, 64, 1], [0, 2, 1], [0, 2, 1], 1, 4, 8, 1),
+            gemm.BlockTransferDesc([4, 64, 1], [0, 2, 1], [0, 2, 1], 1, 2, 8, 1),
+            gemm.BlockTransferDesc([4, 32, 1], [0, 2, 1], [0, 2, 1], 1, 4, 8, 1),
+            gemm.BlockTransferDesc([4, 64, 1], [0, 2, 1], [0, 2, 1], 1, 2, 8, 1),
+            gemm.BlockTransferDesc([4, 32, 1], [0, 2, 1], [0, 2, 1], 1, 4, 8, 1),
+            gemm.BlockTransferDesc([4, 32, 1], [0, 2, 1], [0, 2, 1], 1, 2, 8, 1),
+            gemm.BlockTransferDesc([4, 64, 1], [0, 2, 1], [0, 2, 1], 1, 2, 8, 1),
+            gemm.BlockTransferDesc([4, 64, 1], [0, 2, 1], [0, 2, 1], 1, 1, 8, 1),
+            gemm.BlockTransferDesc([4, 16, 1], [0, 2, 1], [0, 2, 1], 1, 1, 8, 1),
+        ]
+        b_block_descriptions_rowmajor = [
+            gemm.BlockTransferDesc([4, 64, 1], [0, 2, 1], [0, 2, 1], 1, 2, 8, 1),
+            gemm.BlockTransferDesc([4, 64, 1], [0, 2, 1], [0, 2, 1], 1, 4, 8, 1),
+            gemm.BlockTransferDesc([4, 32, 1], [0, 2, 1], [0, 2, 1], 1, 4, 8, 1),
+            gemm.BlockTransferDesc([4, 64, 1], [0, 2, 1], [0, 2, 1], 1, 2, 8, 1),
+            gemm.BlockTransferDesc([4, 32, 1], [0, 2, 1], [0, 2, 1], 1, 2, 8, 1),
+            gemm.BlockTransferDesc([4, 32, 1], [0, 2, 1], [0, 2, 1], 1, 4, 8, 1),
+            gemm.BlockTransferDesc([4, 64, 1], [0, 2, 1], [0, 2, 1], 1, 1, 8, 1),
+            gemm.BlockTransferDesc([4, 64, 1], [0, 2, 1], [0, 2, 1], 1, 2, 8, 1),
+            gemm.BlockTransferDesc([4, 16, 1], [0, 2, 1], [0, 2, 1], 1, 1, 8, 1),
+        ]
+        b_block_descriptions_colmajor = [
+            gemm.BlockTransferDesc([4, 64, 1], [1, 0, 2], [1, 0, 2], 2, 8, 8, 1),
+            gemm.BlockTransferDesc([4, 64, 1], [1, 0, 2], [1, 0, 2], 2, 8, 8, 1),
+            gemm.BlockTransferDesc([4, 32, 1], [1, 0, 2], [1, 0, 2], 2, 8, 8, 1),
+            gemm.BlockTransferDesc([4, 64, 1], [1, 0, 2], [1, 0, 2], 2, 8, 8, 1),
+            gemm.BlockTransferDesc([4, 32, 1], [1, 0, 2], [1, 0, 2], 2, 8, 8, 1),
+            gemm.BlockTransferDesc([4, 32, 1], [1, 0, 2], [1, 0, 2], 2, 8, 8, 1),
+            gemm.BlockTransferDesc([4, 64, 1], [1, 0, 2], [1, 0, 2], 2, 8, 8, 1),
+            gemm.BlockTransferDesc([4, 64, 1], [1, 0, 2], [1, 0, 2], 2, 8, 8, 1),
+            gemm.BlockTransferDesc([4, 16, 1], [1, 0, 2], [1, 0, 2], 2, 1, 8, 1),
+        ]
+        c_block_descriptions = [
+            gemm.CBlockTransferDesc(1, 1, [1, 32, 1, 8], 4),
+            gemm.CBlockTransferDesc(1, 1, [1, 32, 1, 8], 4),
+            gemm.CBlockTransferDesc(1, 1, [1, 16, 1, 8], 4),
+            gemm.CBlockTransferDesc(1, 1, [1, 32, 1, 8], 4),
+            gemm.CBlockTransferDesc(1, 1, [1, 32, 1, 4], 4),
+            gemm.CBlockTransferDesc(1, 1, [1, 16, 1, 8], 4),
+            gemm.CBlockTransferDesc(1, 1, [1, 32, 1, 8], 4),
+            gemm.CBlockTransferDesc(1, 1, [1, 32, 1, 8], 4),
+            gemm.CBlockTransferDesc(1, 1, [1, 16, 1, 4], 1),
+        ]
+        if a_element_desc.layout == library.LayoutType.RowMajor:
+            a_block_descriptions = a_block_descriptions_row_major
+        else:
+            a_block_descriptions = a_block_descriptions_col_major
+        if b_element_desc.layout == library.LayoutType.RowMajor:
+            b_block_descriptions = b_block_descriptions_rowmajor
+        else:
+            b_block_descriptions = b_block_descriptions_colmajor
+        operations = []
+        for tile_desc, a_block_desc, b_block_desc, c_block_desc in zip(
+            tile_descriptions, a_block_descriptions, b_block_descriptions, c_block_descriptions
+        ):
+            op = gemm.GemmOperation(
+                operation_kind=operation_kind,
+                extra_kind=element_op,
+                xdl_op_type=xdl_op_type,
+                A=a_element_desc,
+                B=b_element_desc,
+                C=c_element_desc,
+                a_elem_op=element_op,
+                b_elem_op=element_op,
+                epilogue_functor=element_op,
+                gemm_specialization=gemm.GemmSpecialization.MNKPadding,
+                tile_desc=copy.deepcopy(tile_desc),
+                a_block_transfer=copy.deepcopy(a_block_desc),
+                b_block_transfer=copy.deepcopy(b_block_desc),
+                c_block_transfer=copy.deepcopy(c_block_desc),
+                acc_dtype=acc_dtype,
+            )
+            manifest.append(op)
+            operations.append(op)
     return operations
 
 def CreateGemmRCRBilinearOperator(manifest, c_element_op):
     operation_kind = library.GemmKind.Gemm
-    a_element_desc = library.TensorDesc(
-        library.DataType.f16, library.LayoutType.RowMajor
-    )
-    b_element_desc = library.TensorDesc(
-        library.DataType.f16, library.LayoutType.ColumnMajor
-    )
-    c_element_desc = library.TensorDesc(
-        library.DataType.f16, library.LayoutType.RowMajor
-    )
-    if c_element_op in [
-        library.TensorOperation.AddMulAdd,
-        library.TensorOperation.AddAddAdd,
-        library.TensorOperation.AddAddAddRelu,
-    ]:
-        ds_dtype = [library.DataType.f16, library.DataType.f16, library.DataType.f16]
-        ds_layout = [
-            library.LayoutType.RowMajor,
-            library.LayoutType.RowMajor,
-            library.LayoutType.RowMajor,
-        ]
-    elif c_element_op in [
-        library.TensorOperation.AddSigmoidMul,
-        library.TensorOperation.AddSigmoidMulTanh,
-        library.TensorOperation.AddAdd,
-        library.TensorOperation.AddMul,
-        library.TensorOperation.AddMulTanh,
-        library.TensorOperation.AddAddRelu,
-    ]:
-        ds_dtype = [library.DataType.f16, library.DataType.f16]
-        ds_layout = [library.LayoutType.RowMajor, library.LayoutType.RowMajor]
-    else:
-        ds_dtype = [library.DataType.f16]
-        ds_layout = [library.LayoutType.RowMajor]
-    e_dtype = library.DataType.f16
-    element_op = library.TensorOperation.PassThrough
-
-    xdl_op_type=gemm.XdlOpType.DeviceGemmMultipleD_Xdl_CShuffle
-
-    tile_descriptions = [
-        gemm.TileDesc(256,   256,   128,    32,   8,   8,   16,   16,    8,    4),
-        gemm.TileDesc(256,   128,   256,    32,   8,   8,   16,   16,    4,    8),
-        gemm.TileDesc(128,   128,   128,    32,   8,   8,   16,   16,    8,    4),
-        gemm.TileDesc(256,   128,   128,    32,   8,   8,   16,   16,    4,    4),
-        gemm.TileDesc(128,   128,    64,    32,   8,   8,   16,   16,    4,    4),
-        gemm.TileDesc(128,    64,   128,    32,   8,   8,   16,   16,    4,    4),
-        gemm.TileDesc(256,   128,    64,    32,   8,   8,   16,   16,    4,    2),
-        gemm.TileDesc(256,    64,   128,    32,   8,   8,   16,   16,    2,    4),
-        gemm.TileDesc( 64,    32,    32,    32,   8,   8,   16,   16,    2,    2),
-    ]
-    a_block_descriptions_row_major = [
-        gemm.BlockTransferDesc([4, 64, 1], [1, 0, 2], [1, 0, 2], 2, 8, 8, 1),
-        gemm.BlockTransferDesc([4, 64, 1], [1, 0, 2], [1, 0, 2], 2, 8, 8, 1),
-        gemm.BlockTransferDesc([4, 32, 1], [1, 0, 2], [1, 0, 2], 2, 8, 8, 1),
-        gemm.BlockTransferDesc([4, 64, 1], [1, 0, 2], [1, 0, 2], 2, 8, 8, 1),
-        gemm.BlockTransferDesc([4, 32, 1], [1, 0, 2], [1, 0, 2], 2, 8, 8, 1),
-        gemm.BlockTransferDesc([4, 32, 1], [1, 0, 2], [1, 0, 2], 2, 8, 8, 1),
-        gemm.BlockTransferDesc([4, 64, 1], [1, 0, 2], [1, 0, 2], 2, 8, 8, 1),
-        gemm.BlockTransferDesc([4, 64, 1], [1, 0, 2], [1, 0, 2], 2, 8, 8, 1),
-        gemm.BlockTransferDesc([4, 16, 1], [1, 0, 2], [1, 0, 2], 2, 1, 8, 1),
-    ]
-    a_block_descriptions_col_major = [
-        gemm.BlockTransferDesc([4, 64, 1], [0, 2, 1], [0, 2, 1], 1, 4, 8, 1),
-        gemm.BlockTransferDesc([4, 64, 1], [0, 2, 1], [0, 2, 1], 1, 2, 8, 1),
-        gemm.BlockTransferDesc([4, 32, 1], [0, 2, 1], [0, 2, 1], 1, 4, 8, 1),
-        gemm.BlockTransferDesc([4, 64, 1], [0, 2, 1], [0, 2, 1], 1, 2, 8, 1),
-        gemm.BlockTransferDesc([4, 32, 1], [0, 2, 1], [0, 2, 1], 1, 4, 8, 1),
-        gemm.BlockTransferDesc([4, 32, 1], [0, 2, 1], [0, 2, 1], 1, 2, 8, 1),
-        gemm.BlockTransferDesc([4, 64, 1], [0, 2, 1], [0, 2, 1], 1, 2, 8, 1),
-        gemm.BlockTransferDesc([4, 64, 1], [0, 2, 1], [0, 2, 1], 1, 1, 8, 1),
-        gemm.BlockTransferDesc([4, 16, 1], [0, 2, 1], [0, 2, 1], 1, 1, 8, 1),
-    ]
-    b_block_descriptions_rowmajor = [
-        gemm.BlockTransferDesc([4, 64, 1], [0, 2, 1], [0, 2, 1], 1, 2, 8, 1),
-        gemm.BlockTransferDesc([4, 64, 1], [0, 2, 1], [0, 2, 1], 1, 4, 8, 1),
-        gemm.BlockTransferDesc([4, 32, 1], [0, 2, 1], [0, 2, 1], 1, 4, 8, 1),
-        gemm.BlockTransferDesc([4, 64, 1], [0, 2, 1], [0, 2, 1], 1, 2, 8, 1),
-        gemm.BlockTransferDesc([4, 32, 1], [0, 2, 1], [0, 2, 1], 1, 2, 8, 1),
-        gemm.BlockTransferDesc([4, 32, 1], [0, 2, 1], [0, 2, 1], 1, 4, 8, 1),
-        gemm.BlockTransferDesc([4, 64, 1], [0, 2, 1], [0, 2, 1], 1, 1, 8, 1),
-        gemm.BlockTransferDesc([4, 64, 1], [0, 2, 1], [0, 2, 1], 1, 2, 8, 1),
-        gemm.BlockTransferDesc([4, 16, 1], [0, 2, 1], [0, 2, 1], 1, 1, 8, 1),
-    ]
-    b_block_descriptions_colmajor = [
-        gemm.BlockTransferDesc([4, 64, 1], [1, 0, 2], [1, 0, 2], 2, 8, 8, 1),
-        gemm.BlockTransferDesc([4, 64, 1], [1, 0, 2], [1, 0, 2], 2, 8, 8, 1),
-        gemm.BlockTransferDesc([4, 32, 1], [1, 0, 2], [1, 0, 2], 2, 8, 8, 1),
-        gemm.BlockTransferDesc([4, 64, 1], [1, 0, 2], [1, 0, 2], 2, 8, 8, 1),
-        gemm.BlockTransferDesc([4, 32, 1], [1, 0, 2], [1, 0, 2], 2, 8, 8, 1),
-        gemm.BlockTransferDesc([4, 32, 1], [1, 0, 2], [1, 0, 2], 2, 8, 8, 1),
-        gemm.BlockTransferDesc([4, 64, 1], [1, 0, 2], [1, 0, 2], 2, 8, 8, 1),
-        gemm.BlockTransferDesc([4, 64, 1], [1, 0, 2], [1, 0, 2], 2, 8, 8, 1),
-        gemm.BlockTransferDesc([4, 16, 1], [1, 0, 2], [1, 0, 2], 2, 1, 8, 1),
-    ]
-    c_block_descriptions = [
-        gemm.CBlockTransferDesc(1, 1, [1, 32, 1, 8], 4),
-        gemm.CBlockTransferDesc(1, 1, [1, 32, 1, 8], 4),
-        gemm.CBlockTransferDesc(1, 1, [1, 16, 1, 8], 4),
-        gemm.CBlockTransferDesc(1, 1, [1, 32, 1, 8], 4),
-        gemm.CBlockTransferDesc(1, 1, [1, 32, 1, 4], 4),
-        gemm.CBlockTransferDesc(1, 1, [1, 16, 1, 8], 4),
-        gemm.CBlockTransferDesc(1, 1, [1, 32, 1, 8], 4),
-        gemm.CBlockTransferDesc(1, 1, [1, 32, 1, 8], 4),
-        gemm.CBlockTransferDesc(1, 1, [1, 16, 1, 4], 1),
-    ]
-    if a_element_desc.layout == library.LayoutType.RowMajor:
-        a_block_descriptions = a_block_descriptions_row_major
-    else:
-        a_block_descriptions = a_block_descriptions_col_major
-    if b_element_desc.layout == library.LayoutType.RowMajor:
-        b_block_descriptions = b_block_descriptions_rowmajor
-    else:
-        b_block_descriptions = b_block_descriptions_colmajor
-    operations = []
-    for tile_desc, a_block_desc, b_block_desc, c_block_desc in zip(
-        tile_descriptions, a_block_descriptions, b_block_descriptions, c_block_descriptions
-    ):
-        op = gemm.GemmOperation(
-            operation_kind=operation_kind,
-            extra_kind=c_element_op,
-            xdl_op_type=xdl_op_type,
-            A=a_element_desc,
-            B=b_element_desc,
-            C=c_element_desc,
-            a_elem_op=element_op,
-            b_elem_op=element_op,
-            epilogue_functor=c_element_op,
-            gemm_specialization=gemm.GemmSpecialization.MNKPadding,
-            tile_desc=copy.deepcopy(tile_desc),
-            a_block_transfer=copy.deepcopy(a_block_desc),
-            b_block_transfer=copy.deepcopy(b_block_desc),
-            c_block_transfer=copy.deepcopy(c_block_desc),
-            ds_dtype=ds_dtype,
-            ds_layout=ds_layout,
-            e_dtype=e_dtype,
+    for dtype, acc_dtype in dtype_acc_types:
+        a_element_desc = library.TensorDesc(
+            dtype, library.LayoutType.RowMajor
         )
-        manifest.append(op)
-        operations.append(op)
+        b_element_desc = library.TensorDesc(
+            dtype, library.LayoutType.ColumnMajor
+        )
+        c_element_desc = library.TensorDesc(
+            dtype, library.LayoutType.RowMajor
+        )
+        if c_element_op in [
+            library.TensorOperation.AddMulAdd,
+            library.TensorOperation.AddAddAdd,
+            library.TensorOperation.AddAddAddRelu,
+        ]:
+            ds_dtype = [dtype, dtype, dtype]
+            ds_layout = [
+                library.LayoutType.RowMajor,
+                library.LayoutType.RowMajor,
+                library.LayoutType.RowMajor,
+            ]
+        elif c_element_op in [
+            library.TensorOperation.AddSigmoidMul,
+            library.TensorOperation.AddSigmoidMulTanh,
+            library.TensorOperation.AddAdd,
+            library.TensorOperation.AddMul,
+            library.TensorOperation.AddMulTanh,
+            library.TensorOperation.AddAddRelu,
+        ]:
+            ds_dtype = [dtype, dtype]
+            ds_layout = [library.LayoutType.RowMajor, library.LayoutType.RowMajor]
+        else:
+            ds_dtype = [dtype]
+            ds_layout = [library.LayoutType.RowMajor]
+        e_dtype = dtype
+        element_op = library.TensorOperation.PassThrough
+
+        xdl_op_type=gemm.XdlOpType.DeviceGemmMultipleD_Xdl_CShuffle
+
+        tile_descriptions = [
+            gemm.TileDesc(256,   256,   128,    32,   8,   8,   16,   16,    8,    4),
+            gemm.TileDesc(256,   128,   256,    32,   8,   8,   16,   16,    4,    8),
+            gemm.TileDesc(128,   128,   128,    32,   8,   8,   16,   16,    8,    4),
+            gemm.TileDesc(256,   128,   128,    32,   8,   8,   16,   16,    4,    4),
+            gemm.TileDesc(128,   128,    64,    32,   8,   8,   16,   16,    4,    4),
+            gemm.TileDesc(128,    64,   128,    32,   8,   8,   16,   16,    4,    4),
+            gemm.TileDesc(256,   128,    64,    32,   8,   8,   16,   16,    4,    2),
+            gemm.TileDesc(256,    64,   128,    32,   8,   8,   16,   16,    2,    4),
+            gemm.TileDesc( 64,    32,    32,    32,   8,   8,   16,   16,    2,    2),
+        ]
+        a_block_descriptions_row_major = [
+            gemm.BlockTransferDesc([4, 64, 1], [1, 0, 2], [1, 0, 2], 2, 8, 8, 1),
+            gemm.BlockTransferDesc([4, 64, 1], [1, 0, 2], [1, 0, 2], 2, 8, 8, 1),
+            gemm.BlockTransferDesc([4, 32, 1], [1, 0, 2], [1, 0, 2], 2, 8, 8, 1),
+            gemm.BlockTransferDesc([4, 64, 1], [1, 0, 2], [1, 0, 2], 2, 8, 8, 1),
+            gemm.BlockTransferDesc([4, 32, 1], [1, 0, 2], [1, 0, 2], 2, 8, 8, 1),
+            gemm.BlockTransferDesc([4, 32, 1], [1, 0, 2], [1, 0, 2], 2, 8, 8, 1),
+            gemm.BlockTransferDesc([4, 64, 1], [1, 0, 2], [1, 0, 2], 2, 8, 8, 1),
+            gemm.BlockTransferDesc([4, 64, 1], [1, 0, 2], [1, 0, 2], 2, 8, 8, 1),
+            gemm.BlockTransferDesc([4, 16, 1], [1, 0, 2], [1, 0, 2], 2, 1, 8, 1),
+        ]
+        a_block_descriptions_col_major = [
+            gemm.BlockTransferDesc([4, 64, 1], [0, 2, 1], [0, 2, 1], 1, 4, 8, 1),
+            gemm.BlockTransferDesc([4, 64, 1], [0, 2, 1], [0, 2, 1], 1, 2, 8, 1),
+            gemm.BlockTransferDesc([4, 32, 1], [0, 2, 1], [0, 2, 1], 1, 4, 8, 1),
+            gemm.BlockTransferDesc([4, 64, 1], [0, 2, 1], [0, 2, 1], 1, 2, 8, 1),
+            gemm.BlockTransferDesc([4, 32, 1], [0, 2, 1], [0, 2, 1], 1, 4, 8, 1),
+            gemm.BlockTransferDesc([4, 32, 1], [0, 2, 1], [0, 2, 1], 1, 2, 8, 1),
+            gemm.BlockTransferDesc([4, 64, 1], [0, 2, 1], [0, 2, 1], 1, 2, 8, 1),
+            gemm.BlockTransferDesc([4, 64, 1], [0, 2, 1], [0, 2, 1], 1, 1, 8, 1),
+            gemm.BlockTransferDesc([4, 16, 1], [0, 2, 1], [0, 2, 1], 1, 1, 8, 1),
+        ]
+        b_block_descriptions_rowmajor = [
+            gemm.BlockTransferDesc([4, 64, 1], [0, 2, 1], [0, 2, 1], 1, 2, 8, 1),
+            gemm.BlockTransferDesc([4, 64, 1], [0, 2, 1], [0, 2, 1], 1, 4, 8, 1),
+            gemm.BlockTransferDesc([4, 32, 1], [0, 2, 1], [0, 2, 1], 1, 4, 8, 1),
+            gemm.BlockTransferDesc([4, 64, 1], [0, 2, 1], [0, 2, 1], 1, 2, 8, 1),
+            gemm.BlockTransferDesc([4, 32, 1], [0, 2, 1], [0, 2, 1], 1, 2, 8, 1),
+            gemm.BlockTransferDesc([4, 32, 1], [0, 2, 1], [0, 2, 1], 1, 4, 8, 1),
+            gemm.BlockTransferDesc([4, 64, 1], [0, 2, 1], [0, 2, 1], 1, 1, 8, 1),
+            gemm.BlockTransferDesc([4, 64, 1], [0, 2, 1], [0, 2, 1], 1, 2, 8, 1),
+            gemm.BlockTransferDesc([4, 16, 1], [0, 2, 1], [0, 2, 1], 1, 1, 8, 1),
+        ]
+        b_block_descriptions_colmajor = [
+            gemm.BlockTransferDesc([4, 64, 1], [1, 0, 2], [1, 0, 2], 2, 8, 8, 1),
+            gemm.BlockTransferDesc([4, 64, 1], [1, 0, 2], [1, 0, 2], 2, 8, 8, 1),
+            gemm.BlockTransferDesc([4, 32, 1], [1, 0, 2], [1, 0, 2], 2, 8, 8, 1),
+            gemm.BlockTransferDesc([4, 64, 1], [1, 0, 2], [1, 0, 2], 2, 8, 8, 1),
+            gemm.BlockTransferDesc([4, 32, 1], [1, 0, 2], [1, 0, 2], 2, 8, 8, 1),
+            gemm.BlockTransferDesc([4, 32, 1], [1, 0, 2], [1, 0, 2], 2, 8, 8, 1),
+            gemm.BlockTransferDesc([4, 64, 1], [1, 0, 2], [1, 0, 2], 2, 8, 8, 1),
+            gemm.BlockTransferDesc([4, 64, 1], [1, 0, 2], [1, 0, 2], 2, 8, 8, 1),
+            gemm.BlockTransferDesc([4, 16, 1], [1, 0, 2], [1, 0, 2], 2, 1, 8, 1),
+        ]
+        c_block_descriptions = [
+            gemm.CBlockTransferDesc(1, 1, [1, 32, 1, 8], 4),
+            gemm.CBlockTransferDesc(1, 1, [1, 32, 1, 8], 4),
+            gemm.CBlockTransferDesc(1, 1, [1, 16, 1, 8], 4),
+            gemm.CBlockTransferDesc(1, 1, [1, 32, 1, 8], 4),
+            gemm.CBlockTransferDesc(1, 1, [1, 32, 1, 4], 4),
+            gemm.CBlockTransferDesc(1, 1, [1, 16, 1, 8], 4),
+            gemm.CBlockTransferDesc(1, 1, [1, 32, 1, 8], 4),
+            gemm.CBlockTransferDesc(1, 1, [1, 32, 1, 8], 4),
+            gemm.CBlockTransferDesc(1, 1, [1, 16, 1, 4], 1),
+        ]
+        if a_element_desc.layout == library.LayoutType.RowMajor:
+            a_block_descriptions = a_block_descriptions_row_major
+        else:
+            a_block_descriptions = a_block_descriptions_col_major
+        if b_element_desc.layout == library.LayoutType.RowMajor:
+            b_block_descriptions = b_block_descriptions_rowmajor
+        else:
+            b_block_descriptions = b_block_descriptions_colmajor
+        operations = []
+        for tile_desc, a_block_desc, b_block_desc, c_block_desc in zip(
+            tile_descriptions, a_block_descriptions, b_block_descriptions, c_block_descriptions
+        ):
+            op = gemm.GemmOperation(
+                operation_kind=operation_kind,
+                extra_kind=c_element_op,
+                xdl_op_type=xdl_op_type,
+                A=a_element_desc,
+                B=b_element_desc,
+                C=c_element_desc,
+                a_elem_op=element_op,
+                b_elem_op=element_op,
+                epilogue_functor=c_element_op,
+                gemm_specialization=gemm.GemmSpecialization.MNKPadding,
+                tile_desc=copy.deepcopy(tile_desc),
+                a_block_transfer=copy.deepcopy(a_block_desc),
+                b_block_transfer=copy.deepcopy(b_block_desc),
+                c_block_transfer=copy.deepcopy(c_block_desc),
+                ds_dtype=ds_dtype,
+                ds_layout=ds_layout,
+                e_dtype=e_dtype,
+                acc_dtype=acc_dtype,
+            )
+            manifest.append(op)
+            operations.append(op)
     return operations
 
 
 def CreateGemmRRRBilinearOperator(manifest, c_element_op):
     operation_kind = library.GemmKind.Gemm
-    a_element_desc = library.TensorDesc(
-        library.DataType.f16, library.LayoutType.RowMajor
-    )
-    b_element_desc = library.TensorDesc(
-        library.DataType.f16, library.LayoutType.RowMajor
-    )
-    c_element_desc = library.TensorDesc(
-        library.DataType.f16, library.LayoutType.RowMajor
-    )
-
-    if c_element_op in [
-        library.TensorOperation.AddMulAdd,
-        library.TensorOperation.AddAddAdd,
-        library.TensorOperation.AddAddAddRelu,
-    ]:
-        ds_dtype = [library.DataType.f16, library.DataType.f16, library.DataType.f16]
-        ds_layout = [
-            library.LayoutType.RowMajor,
-            library.LayoutType.RowMajor,
-            library.LayoutType.RowMajor,
-        ]
-    elif c_element_op in [
-        library.TensorOperation.AddSigmoidMul,
-        library.TensorOperation.AddSigmoidMulTanh,
-        library.TensorOperation.AddAdd,
-        library.TensorOperation.AddMul,
-        library.TensorOperation.AddMulTanh,
-        library.TensorOperation.AddAddRelu,
-    ]:
-        ds_dtype = [library.DataType.f16, library.DataType.f16]
-        ds_layout = [library.LayoutType.RowMajor, library.LayoutType.RowMajor]
-    else:
-        ds_dtype = [library.DataType.f16]
-        ds_layout = [library.LayoutType.RowMajor]
-
-    e_dtype = library.DataType.f16
-    element_op = library.TensorOperation.PassThrough
-
-    xdl_op_type=gemm.XdlOpType.DeviceGemmMultipleD_Xdl_CShuffle
-
-    tile_descriptions = [
-        gemm.TileDesc(256,   256,   128,    32,   8,   8,   16,   16,    8,    4),
-        gemm.TileDesc(256,   128,   256,    32,   8,   8,   16,   16,    4,    8),
-        gemm.TileDesc(128,   128,   128,    32,   8,   8,   16,   16,    8,    4),
-        gemm.TileDesc(256,   128,   128,    32,   8,   8,   16,   16,    4,    4),
-        gemm.TileDesc(128,   128,    64,    32,   8,   8,   16,   16,    4,    4),
-        gemm.TileDesc(128,    64,   128,    32,   8,   8,   16,   16,    4,    4),
-        gemm.TileDesc(256,   128,    64,    32,   8,   8,   16,   16,    4,    2),
-        gemm.TileDesc(256,    64,   128,    32,   8,   8,   16,   16,    2,    4),
-        gemm.TileDesc( 64,    32,    32,    32,   8,   8,   16,   16,    2,    2),
-    ]
-    a_block_descriptions_row_major = [
-        gemm.BlockTransferDesc([4, 64, 1], [1, 0, 2], [1, 0, 2], 2, 8, 8, 1),
-        gemm.BlockTransferDesc([4, 64, 1], [1, 0, 2], [1, 0, 2], 2, 8, 8, 1),
-        gemm.BlockTransferDesc([4, 32, 1], [1, 0, 2], [1, 0, 2], 2, 8, 8, 1),
-        gemm.BlockTransferDesc([4, 64, 1], [1, 0, 2], [1, 0, 2], 2, 8, 8, 1),
-        gemm.BlockTransferDesc([4, 32, 1], [1, 0, 2], [1, 0, 2], 2, 8, 8, 1),
-        gemm.BlockTransferDesc([4, 32, 1], [1, 0, 2], [1, 0, 2], 2, 8, 8, 1),
-        gemm.BlockTransferDesc([4, 64, 1], [1, 0, 2], [1, 0, 2], 2, 8, 8, 1),
-        gemm.BlockTransferDesc([4, 64, 1], [1, 0, 2], [1, 0, 2], 2, 8, 8, 1),
-        gemm.BlockTransferDesc([4, 16, 1], [1, 0, 2], [1, 0, 2], 2, 1, 8, 1),
-    ]
-    a_block_descriptions_col_major = [
-        gemm.BlockTransferDesc([4, 64, 1], [0, 2, 1], [0, 2, 1], 1, 4, 8, 1),
-        gemm.BlockTransferDesc([4, 64, 1], [0, 2, 1], [0, 2, 1], 1, 2, 8, 1),
-        gemm.BlockTransferDesc([4, 32, 1], [0, 2, 1], [0, 2, 1], 1, 4, 8, 1),
-        gemm.BlockTransferDesc([4, 64, 1], [0, 2, 1], [0, 2, 1], 1, 2, 8, 1),
-        gemm.BlockTransferDesc([4, 32, 1], [0, 2, 1], [0, 2, 1], 1, 4, 8, 1),
-        gemm.BlockTransferDesc([4, 32, 1], [0, 2, 1], [0, 2, 1], 1, 2, 8, 1),
-        gemm.BlockTransferDesc([4, 64, 1], [0, 2, 1], [0, 2, 1], 1, 2, 8, 1),
-        gemm.BlockTransferDesc([4, 64, 1], [0, 2, 1], [0, 2, 1], 1, 1, 8, 1),
-        gemm.BlockTransferDesc([4, 16, 1], [0, 2, 1], [0, 2, 1], 1, 1, 8, 1),
-    ]
-    b_block_descriptions_rowmajor = [
-        gemm.BlockTransferDesc([4, 64, 1], [0, 2, 1], [0, 2, 1], 1, 2, 8, 1),
-        gemm.BlockTransferDesc([4, 64, 1], [0, 2, 1], [0, 2, 1], 1, 4, 8, 1),
-        gemm.BlockTransferDesc([4, 32, 1], [0, 2, 1], [0, 2, 1], 1, 4, 8, 1),
-        gemm.BlockTransferDesc([4, 64, 1], [0, 2, 1], [0, 2, 1], 1, 2, 8, 1),
-        gemm.BlockTransferDesc([4, 32, 1], [0, 2, 1], [0, 2, 1], 1, 2, 8, 1),
-        gemm.BlockTransferDesc([4, 32, 1], [0, 2, 1], [0, 2, 1], 1, 4, 8, 1),
-        gemm.BlockTransferDesc([4, 64, 1], [0, 2, 1], [0, 2, 1], 1, 1, 8, 1),
-        gemm.BlockTransferDesc([4, 64, 1], [0, 2, 1], [0, 2, 1], 1, 2, 8, 1),
-        gemm.BlockTransferDesc([4, 16, 1], [0, 2, 1], [0, 2, 1], 1, 1, 8, 1),
-    ]
-    b_block_descriptions_colmajor = [
-        gemm.BlockTransferDesc([4, 64, 1], [1, 0, 2], [1, 0, 2], 2, 8, 8, 1),
-        gemm.BlockTransferDesc([4, 64, 1], [1, 0, 2], [1, 0, 2], 2, 8, 8, 1),
-        gemm.BlockTransferDesc([4, 32, 1], [1, 0, 2], [1, 0, 2], 2, 8, 8, 1),
-        gemm.BlockTransferDesc([4, 64, 1], [1, 0, 2], [1, 0, 2], 2, 8, 8, 1),
-        gemm.BlockTransferDesc([4, 32, 1], [1, 0, 2], [1, 0, 2], 2, 8, 8, 1),
-        gemm.BlockTransferDesc([4, 32, 1], [1, 0, 2], [1, 0, 2], 2, 8, 8, 1),
-        gemm.BlockTransferDesc([4, 64, 1], [1, 0, 2], [1, 0, 2], 2, 8, 8, 1),
-        gemm.BlockTransferDesc([4, 64, 1], [1, 0, 2], [1, 0, 2], 2, 8, 8, 1),
-        gemm.BlockTransferDesc([4, 16, 1], [1, 0, 2], [1, 0, 2], 2, 1, 8, 1),
-    ]
-    c_block_descriptions = [
-        gemm.CBlockTransferDesc(1, 1, [1, 32, 1, 8], 4),
-        gemm.CBlockTransferDesc(1, 1, [1, 32, 1, 8], 4),
-        gemm.CBlockTransferDesc(1, 1, [1, 16, 1, 8], 4),
-        gemm.CBlockTransferDesc(1, 1, [1, 32, 1, 8], 4),
-        gemm.CBlockTransferDesc(1, 1, [1, 32, 1, 4], 4),
-        gemm.CBlockTransferDesc(1, 1, [1, 16, 1, 8], 4),
-        gemm.CBlockTransferDesc(1, 1, [1, 32, 1, 8], 4),
-        gemm.CBlockTransferDesc(1, 1, [1, 32, 1, 8], 4),
-        gemm.CBlockTransferDesc(1, 1, [1, 16, 1, 4], 1),
-    ]
-    if a_element_desc.layout == library.LayoutType.RowMajor:
-        a_block_descriptions = a_block_descriptions_row_major
-    else:
-        a_block_descriptions = a_block_descriptions_col_major
-    if b_element_desc.layout == library.LayoutType.RowMajor:
-        b_block_descriptions = b_block_descriptions_rowmajor
-    else:
-        b_block_descriptions = b_block_descriptions_colmajor
-    operations = []
-    for tile_desc, a_block_desc, b_block_desc, c_block_desc in zip(
-        tile_descriptions, a_block_descriptions, b_block_descriptions, c_block_descriptions
-    ):
-        op = gemm.GemmOperation(
-            operation_kind=operation_kind,
-            extra_kind=c_element_op,
-            xdl_op_type=xdl_op_type,
-            A=a_element_desc,
-            B=b_element_desc,
-            C=c_element_desc,
-            a_elem_op=element_op,
-            b_elem_op=element_op,
-            epilogue_functor=c_element_op,
-            gemm_specialization=gemm.GemmSpecialization.MNKPadding,
-            tile_desc=copy.deepcopy(tile_desc),
-            a_block_transfer=copy.deepcopy(a_block_desc),
-            b_block_transfer=copy.deepcopy(b_block_desc),
-            c_block_transfer=copy.deepcopy(c_block_desc),
-            ds_dtype=ds_dtype,
-            ds_layout=ds_layout,
-            e_dtype=e_dtype,
+    for dtype, acc_dtype in dtype_acc_types:
+        a_element_desc = library.TensorDesc(
+            dtype, library.LayoutType.RowMajor
         )
-        manifest.append(op)
-        operations.append(op)
+        b_element_desc = library.TensorDesc(
+            dtype, library.LayoutType.RowMajor
+        )
+        c_element_desc = library.TensorDesc(
+            dtype, library.LayoutType.RowMajor
+        )
+
+        if c_element_op in [
+            library.TensorOperation.AddMulAdd,
+            library.TensorOperation.AddAddAdd,
+            library.TensorOperation.AddAddAddRelu,
+        ]:
+            ds_dtype = [dtype, dtype, dtype]
+            ds_layout = [
+                library.LayoutType.RowMajor,
+                library.LayoutType.RowMajor,
+                library.LayoutType.RowMajor,
+            ]
+        elif c_element_op in [
+            library.TensorOperation.AddSigmoidMul,
+            library.TensorOperation.AddSigmoidMulTanh,
+            library.TensorOperation.AddAdd,
+            library.TensorOperation.AddMul,
+            library.TensorOperation.AddMulTanh,
+            library.TensorOperation.AddAddRelu,
+        ]:
+            ds_dtype = [dtype, dtype]
+            ds_layout = [library.LayoutType.RowMajor, library.LayoutType.RowMajor]
+        else:
+            ds_dtype = [dtype]
+            ds_layout = [library.LayoutType.RowMajor]
+
+        e_dtype = dtype
+        element_op = library.TensorOperation.PassThrough
+
+        xdl_op_type=gemm.XdlOpType.DeviceGemmMultipleD_Xdl_CShuffle
+
+        tile_descriptions = [
+            gemm.TileDesc(256,   256,   128,    32,   8,   8,   16,   16,    8,    4),
+            gemm.TileDesc(256,   128,   256,    32,   8,   8,   16,   16,    4,    8),
+            gemm.TileDesc(128,   128,   128,    32,   8,   8,   16,   16,    8,    4),
+            gemm.TileDesc(256,   128,   128,    32,   8,   8,   16,   16,    4,    4),
+            gemm.TileDesc(128,   128,    64,    32,   8,   8,   16,   16,    4,    4),
+            gemm.TileDesc(128,    64,   128,    32,   8,   8,   16,   16,    4,    4),
+            gemm.TileDesc(256,   128,    64,    32,   8,   8,   16,   16,    4,    2),
+            gemm.TileDesc(256,    64,   128,    32,   8,   8,   16,   16,    2,    4),
+            gemm.TileDesc( 64,    32,    32,    32,   8,   8,   16,   16,    2,    2),
+        ]
+        a_block_descriptions_row_major = [
+            gemm.BlockTransferDesc([4, 64, 1], [1, 0, 2], [1, 0, 2], 2, 8, 8, 1),
+            gemm.BlockTransferDesc([4, 64, 1], [1, 0, 2], [1, 0, 2], 2, 8, 8, 1),
+            gemm.BlockTransferDesc([4, 32, 1], [1, 0, 2], [1, 0, 2], 2, 8, 8, 1),
+            gemm.BlockTransferDesc([4, 64, 1], [1, 0, 2], [1, 0, 2], 2, 8, 8, 1),
+            gemm.BlockTransferDesc([4, 32, 1], [1, 0, 2], [1, 0, 2], 2, 8, 8, 1),
+            gemm.BlockTransferDesc([4, 32, 1], [1, 0, 2], [1, 0, 2], 2, 8, 8, 1),
+            gemm.BlockTransferDesc([4, 64, 1], [1, 0, 2], [1, 0, 2], 2, 8, 8, 1),
+            gemm.BlockTransferDesc([4, 64, 1], [1, 0, 2], [1, 0, 2], 2, 8, 8, 1),
+            gemm.BlockTransferDesc([4, 16, 1], [1, 0, 2], [1, 0, 2], 2, 1, 8, 1),
+        ]
+        a_block_descriptions_col_major = [
+            gemm.BlockTransferDesc([4, 64, 1], [0, 2, 1], [0, 2, 1], 1, 4, 8, 1),
+            gemm.BlockTransferDesc([4, 64, 1], [0, 2, 1], [0, 2, 1], 1, 2, 8, 1),
+            gemm.BlockTransferDesc([4, 32, 1], [0, 2, 1], [0, 2, 1], 1, 4, 8, 1),
+            gemm.BlockTransferDesc([4, 64, 1], [0, 2, 1], [0, 2, 1], 1, 2, 8, 1),
+            gemm.BlockTransferDesc([4, 32, 1], [0, 2, 1], [0, 2, 1], 1, 4, 8, 1),
+            gemm.BlockTransferDesc([4, 32, 1], [0, 2, 1], [0, 2, 1], 1, 2, 8, 1),
+            gemm.BlockTransferDesc([4, 64, 1], [0, 2, 1], [0, 2, 1], 1, 2, 8, 1),
+            gemm.BlockTransferDesc([4, 64, 1], [0, 2, 1], [0, 2, 1], 1, 1, 8, 1),
+            gemm.BlockTransferDesc([4, 16, 1], [0, 2, 1], [0, 2, 1], 1, 1, 8, 1),
+        ]
+        b_block_descriptions_rowmajor = [
+            gemm.BlockTransferDesc([4, 64, 1], [0, 2, 1], [0, 2, 1], 1, 2, 8, 1),
+            gemm.BlockTransferDesc([4, 64, 1], [0, 2, 1], [0, 2, 1], 1, 4, 8, 1),
+            gemm.BlockTransferDesc([4, 32, 1], [0, 2, 1], [0, 2, 1], 1, 4, 8, 1),
+            gemm.BlockTransferDesc([4, 64, 1], [0, 2, 1], [0, 2, 1], 1, 2, 8, 1),
+            gemm.BlockTransferDesc([4, 32, 1], [0, 2, 1], [0, 2, 1], 1, 2, 8, 1),
+            gemm.BlockTransferDesc([4, 32, 1], [0, 2, 1], [0, 2, 1], 1, 4, 8, 1),
+            gemm.BlockTransferDesc([4, 64, 1], [0, 2, 1], [0, 2, 1], 1, 1, 8, 1),
+            gemm.BlockTransferDesc([4, 64, 1], [0, 2, 1], [0, 2, 1], 1, 2, 8, 1),
+            gemm.BlockTransferDesc([4, 16, 1], [0, 2, 1], [0, 2, 1], 1, 1, 8, 1),
+        ]
+        b_block_descriptions_colmajor = [
+            gemm.BlockTransferDesc([4, 64, 1], [1, 0, 2], [1, 0, 2], 2, 8, 8, 1),
+            gemm.BlockTransferDesc([4, 64, 1], [1, 0, 2], [1, 0, 2], 2, 8, 8, 1),
+            gemm.BlockTransferDesc([4, 32, 1], [1, 0, 2], [1, 0, 2], 2, 8, 8, 1),
+            gemm.BlockTransferDesc([4, 64, 1], [1, 0, 2], [1, 0, 2], 2, 8, 8, 1),
+            gemm.BlockTransferDesc([4, 32, 1], [1, 0, 2], [1, 0, 2], 2, 8, 8, 1),
+            gemm.BlockTransferDesc([4, 32, 1], [1, 0, 2], [1, 0, 2], 2, 8, 8, 1),
+            gemm.BlockTransferDesc([4, 64, 1], [1, 0, 2], [1, 0, 2], 2, 8, 8, 1),
+            gemm.BlockTransferDesc([4, 64, 1], [1, 0, 2], [1, 0, 2], 2, 8, 8, 1),
+            gemm.BlockTransferDesc([4, 16, 1], [1, 0, 2], [1, 0, 2], 2, 1, 8, 1),
+        ]
+        c_block_descriptions = [
+            gemm.CBlockTransferDesc(1, 1, [1, 32, 1, 8], 4),
+            gemm.CBlockTransferDesc(1, 1, [1, 32, 1, 8], 4),
+            gemm.CBlockTransferDesc(1, 1, [1, 16, 1, 8], 4),
+            gemm.CBlockTransferDesc(1, 1, [1, 32, 1, 8], 4),
+            gemm.CBlockTransferDesc(1, 1, [1, 32, 1, 4], 4),
+            gemm.CBlockTransferDesc(1, 1, [1, 16, 1, 8], 4),
+            gemm.CBlockTransferDesc(1, 1, [1, 32, 1, 8], 4),
+            gemm.CBlockTransferDesc(1, 1, [1, 32, 1, 8], 4),
+            gemm.CBlockTransferDesc(1, 1, [1, 16, 1, 4], 1),
+        ]
+        if a_element_desc.layout == library.LayoutType.RowMajor:
+            a_block_descriptions = a_block_descriptions_row_major
+        else:
+            a_block_descriptions = a_block_descriptions_col_major
+        if b_element_desc.layout == library.LayoutType.RowMajor:
+            b_block_descriptions = b_block_descriptions_rowmajor
+        else:
+            b_block_descriptions = b_block_descriptions_colmajor
+        operations = []
+        for tile_desc, a_block_desc, b_block_desc, c_block_desc in zip(
+            tile_descriptions, a_block_descriptions, b_block_descriptions, c_block_descriptions
+        ):
+            op = gemm.GemmOperation(
+                operation_kind=operation_kind,
+                extra_kind=c_element_op,
+                xdl_op_type=xdl_op_type,
+                A=a_element_desc,
+                B=b_element_desc,
+                C=c_element_desc,
+                a_elem_op=element_op,
+                b_elem_op=element_op,
+                epilogue_functor=c_element_op,
+                gemm_specialization=gemm.GemmSpecialization.MNKPadding,
+                tile_desc=copy.deepcopy(tile_desc),
+                a_block_transfer=copy.deepcopy(a_block_desc),
+                b_block_transfer=copy.deepcopy(b_block_desc),
+                c_block_transfer=copy.deepcopy(c_block_desc),
+                ds_dtype=ds_dtype,
+                ds_layout=ds_layout,
+                e_dtype=e_dtype,
+                acc_dtype=acc_dtype,
+            )
+            manifest.append(op)
+            operations.append(op)
     return operations
 
 
 def CreateBmmRCROperator(manifest):
     operation_kind = library.GemmKind.BatchGemm
-    a_element_desc = library.TensorDesc(
-        library.DataType.f16, library.LayoutType.RowMajor
-    )
-    b_element_desc = library.TensorDesc(
-        library.DataType.f16, library.LayoutType.ColumnMajor
-    )
-    c_element_desc = library.TensorDesc(
-        library.DataType.f16, library.LayoutType.RowMajor
-    )
-    element_op = library.TensorOperation.PassThrough
-    # 0 indicates not print
-    tile_descriptions = [
-        gemm.TileDesc(256,   256,   128,    32,   8,   8,   16,   16,    8,    4),
-        gemm.TileDesc(256,   128,   256,    32,   8,   8,   16,   16,    4,    8),
-        gemm.TileDesc(128,   128,   128,    32,   8,   8,   16,   16,    8,    4),
-        gemm.TileDesc(256,   128,   128,    32,   8,   8,   16,   16,    4,    4),
-        gemm.TileDesc(128,   128,    64,    32,   8,   8,   16,   16,    4,    4),
-        gemm.TileDesc(128,    64,   128,    32,   8,   8,   16,   16,    4,    4),
-        gemm.TileDesc(256,   128,    64,    32,   8,   8,   16,   16,    4,    2),
-        gemm.TileDesc(256,    64,   128,    32,   8,   8,   16,   16,    2,    4),
-        gemm.TileDesc(64,    32,    32,    32,   8,   8,   16,   16,    2,    2)
-    ]
-
-    block_descriptions = []
-    for t in tile_descriptions:
-        block_transfer = -1
-        if t.block_size == 256:
-            block_transfer = [4, 64, 1]
-        if t.block_size == 128:
-            block_transfer = [4, 32, 1]
-        if t.block_size == 64:
-            block_transfer = [4, 16, 1]
-
-        assert block_transfer != -1, "Cannot determine block_transfer_size with block_size "+ str(t.block_size)
-        block_descriptions.append(
-            gemm.BlockTransferDesc(
-                block_transfer, [1, 0, 2], [1, 0, 2], 2, 8, 8, 1, True
-            )
+    for dtype, acc_dtype in dtype_acc_types:
+        a_element_desc = library.TensorDesc(
+            dtype, library.LayoutType.RowMajor
         )
-    gemm_specialization = [
-        gemm.GemmSpecialization.GemmDefault,
-        gemm.GemmSpecialization.MNKPadding,
-    ]
-    operations = []
-    for gemm_spec in gemm_specialization:
-        for tile_desc, block_desc in zip(tile_descriptions, block_descriptions):
-            new_operation = gemm.GemmOperation(
-                operation_kind=operation_kind,
-                extra_kind=element_op,
-                xdl_op_type=gemm.XdlOpType.DeviceBatchedGemmXdl,
-                A=a_element_desc,
-                B=b_element_desc,
-                C=c_element_desc,
-                a_elem_op=element_op,
-                b_elem_op=element_op,
-                epilogue_functor=element_op,
-                gemm_specialization=gemm_spec,
-                tile_desc=tile_desc,
-                a_block_transfer=block_desc,
-                b_block_transfer=block_desc,
+        b_element_desc = library.TensorDesc(
+            dtype, library.LayoutType.ColumnMajor
+        )
+        c_element_desc = library.TensorDesc(
+            dtype, library.LayoutType.RowMajor
+        )
+        element_op = library.TensorOperation.PassThrough
+        # 0 indicates not print
+        tile_descriptions = [
+            gemm.TileDesc(256,   256,   128,    32,   8,   8,   16,   16,    8,    4),
+            gemm.TileDesc(256,   128,   256,    32,   8,   8,   16,   16,    4,    8),
+            gemm.TileDesc(128,   128,   128,    32,   8,   8,   16,   16,    8,    4),
+            gemm.TileDesc(256,   128,   128,    32,   8,   8,   16,   16,    4,    4),
+            gemm.TileDesc(128,   128,    64,    32,   8,   8,   16,   16,    4,    4),
+            gemm.TileDesc(128,    64,   128,    32,   8,   8,   16,   16,    4,    4),
+            gemm.TileDesc(256,   128,    64,    32,   8,   8,   16,   16,    4,    2),
+            gemm.TileDesc(256,    64,   128,    32,   8,   8,   16,   16,    2,    4),
+            gemm.TileDesc(64,    32,    32,    32,   8,   8,   16,   16,    2,    2)
+        ]
+
+        block_descriptions = []
+        for t in tile_descriptions:
+            block_transfer = -1
+            if t.block_size == 256:
+                block_transfer = [4, 64, 1]
+            if t.block_size == 128:
+                block_transfer = [4, 32, 1]
+            if t.block_size == 64:
+                block_transfer = [4, 16, 1]
+
+            assert block_transfer != -1, "Cannot determine block_transfer_size with block_size "+ str(t.block_size)
+            block_descriptions.append(
+                gemm.BlockTransferDesc(
+                    block_transfer, [1, 0, 2], [1, 0, 2], 2, 8, 8, 1, True
+                )
             )
-            manifest.append(new_operation)
-            operations.append(new_operation)
+        gemm_specialization = [
+            gemm.GemmSpecialization.GemmDefault,
+            gemm.GemmSpecialization.MNKPadding,
+        ]
+        operations = []
+        for gemm_spec in gemm_specialization:
+            for tile_desc, block_desc in zip(tile_descriptions, block_descriptions):
+                new_operation = gemm.GemmOperation(
+                    operation_kind=operation_kind,
+                    extra_kind=element_op,
+                    xdl_op_type=gemm.XdlOpType.DeviceBatchedGemmXdl,
+                    A=a_element_desc,
+                    B=b_element_desc,
+                    C=c_element_desc,
+                    a_elem_op=element_op,
+                    b_elem_op=element_op,
+                    epilogue_functor=element_op,
+                    gemm_specialization=gemm_spec,
+                    tile_desc=tile_desc,
+                    a_block_transfer=block_desc,
+                    b_block_transfer=block_desc,
+                    acc_dtype=acc_dtype,
+                )
+                manifest.append(new_operation)
+                operations.append(new_operation)
     return operations
 
 
 def CreateGemmRCRPermOperator(manifest, c_element_op):
     operation_kind = library.GemmKind.GemmPermute
-    a_element_desc = library.TensorDesc(
-        library.DataType.f16, library.LayoutType.RowMajor
-    )
-    b_element_desc = library.TensorDesc(
-        library.DataType.f16, library.LayoutType.ColumnMajor
-    )
-    c_element_desc = library.TensorDesc(
-        library.DataType.f16, library.LayoutType.RowMajor
-    )
-    ds_dtype = [library.DataType.f16]
-    e_dtype = library.DataType.f16
-    element_op = library.TensorOperation.PassThrough
-    # 0 indicates not print
-    tile_descriptions = [
-        gemm.TileDesc(256,   256,   128,    32,   8,   8,   16,   16,    8,    4),
-        gemm.TileDesc(256,   128,   256,    32,   8,   8,   16,   16,    4,    8),
-        gemm.TileDesc(128,   128,   128,    32,   8,   8,   16,   16,    8,    4),
-        gemm.TileDesc(256,   128,   128,    32,   8,   8,   16,   16,    4,    4),
-        gemm.TileDesc(128,   128,    64,    32,   8,   8,   16,   16,    4,    4),
-        gemm.TileDesc(128,    64,   128,    32,   8,   8,   16,   16,    4,    4),
-        gemm.TileDesc(256,   128,    64,    32,   8,   8,   16,   16,    4,    2),
-        gemm.TileDesc(256,    64,   128,    32,   8,   8,   16,   16,    2,    4),
-        gemm.TileDesc(64,    32,    32,    32,   8,   8,   16,   16,    2,    2)
-    ]
-
-    block_descriptions = []
-    c_block_descriptions = []
-    for t in tile_descriptions:
-        block_transfer = -1
-        c_block_transfer = -1
-        if t.block_size == 256:
-            block_transfer = [4, 64, 1]
-            # TODO:figure out the last dimension
-            c_block_transfer = gemm.CBlockTransferDesc(1, 1, [1, 32, 1, 8], 1)
-        if t.block_size == 128:
-            block_transfer = [4, 32, 1]
-            if t.n_per_block == 128:
-                c_block_transfer = gemm.CBlockTransferDesc(1, 1, [1, 16, 1, 8], 1)
-            else:
-                c_block_transfer = gemm.CBlockTransferDesc(1, 1, [1, 32, 1, 4], 1)
-        if t.block_size == 64:
-            block_transfer = [4, 16, 1]
-            c_block_transfer = gemm.CBlockTransferDesc(1, 1, [1, 16, 1, 4], 1)
-
-        assert block_transfer != -1 and c_block_transfer != -1, "Cannot determine block_transfer_size with block_size " + str(t.block_size)
-        block_descriptions.append(
-            gemm.BlockTransferDesc(block_transfer, [1, 0, 2], [1, 0, 2], 2, 8, 8, 1)
+    for dtype, acc_dtype in dtype_acc_types:
+        a_element_desc = library.TensorDesc(
+            dtype, library.LayoutType.RowMajor
         )
-        c_block_descriptions.append(c_block_transfer)
-    gemm_specialization = [
-        gemm.GemmSpecialization.GemmDefault,
-        gemm.GemmSpecialization.MNKPadding,
-    ]
-    operations = []
-    for gemm_spec in gemm_specialization:
-        for tile_desc, block_desc, c_block_desc in zip(
-            tile_descriptions, block_descriptions, c_block_descriptions
-        ):
-            new_operation = gemm.GemmOperation(
-                operation_kind=operation_kind,
-                extra_kind=c_element_op,
-                xdl_op_type=gemm.XdlOpType.DeviceGemmBiasCPermute_Xdl,
-                A=a_element_desc,
-                B=b_element_desc,
-                C=c_element_desc,
-                a_elem_op=element_op,
-                b_elem_op=element_op,
-                epilogue_functor=c_element_op,
-                gemm_specialization=gemm_spec,
-                tile_desc=tile_desc,
-                a_block_transfer=block_desc,
-                b_block_transfer=block_desc,
-                c_block_transfer=c_block_desc,
-                ds_dtype=ds_dtype,
-                e_dtype=e_dtype,
+        b_element_desc = library.TensorDesc(
+            dtype, library.LayoutType.ColumnMajor
+        )
+        c_element_desc = library.TensorDesc(
+            dtype, library.LayoutType.RowMajor
+        )
+        ds_dtype = [dtype]
+        e_dtype = dtype
+        element_op = library.TensorOperation.PassThrough
+        # 0 indicates not print
+        tile_descriptions = [
+            gemm.TileDesc(256,   256,   128,    32,   8,   8,   16,   16,    8,    4),
+            gemm.TileDesc(256,   128,   256,    32,   8,   8,   16,   16,    4,    8),
+            gemm.TileDesc(128,   128,   128,    32,   8,   8,   16,   16,    8,    4),
+            gemm.TileDesc(256,   128,   128,    32,   8,   8,   16,   16,    4,    4),
+            gemm.TileDesc(128,   128,    64,    32,   8,   8,   16,   16,    4,    4),
+            gemm.TileDesc(128,    64,   128,    32,   8,   8,   16,   16,    4,    4),
+            gemm.TileDesc(256,   128,    64,    32,   8,   8,   16,   16,    4,    2),
+            gemm.TileDesc(256,    64,   128,    32,   8,   8,   16,   16,    2,    4),
+            gemm.TileDesc(64,    32,    32,    32,   8,   8,   16,   16,    2,    2)
+        ]
+
+        block_descriptions = []
+        c_block_descriptions = []
+        for t in tile_descriptions:
+            block_transfer = -1
+            c_block_transfer = -1
+            if t.block_size == 256:
+                block_transfer = [4, 64, 1]
+                # TODO:figure out the last dimension
+                c_block_transfer = gemm.CBlockTransferDesc(1, 1, [1, 32, 1, 8], 1)
+            if t.block_size == 128:
+                block_transfer = [4, 32, 1]
+                if t.n_per_block == 128:
+                    c_block_transfer = gemm.CBlockTransferDesc(1, 1, [1, 16, 1, 8], 1)
+                else:
+                    c_block_transfer = gemm.CBlockTransferDesc(1, 1, [1, 32, 1, 4], 1)
+            if t.block_size == 64:
+                block_transfer = [4, 16, 1]
+                c_block_transfer = gemm.CBlockTransferDesc(1, 1, [1, 16, 1, 4], 1)
+
+            assert block_transfer != -1 and c_block_transfer != -1, "Cannot determine block_transfer_size with block_size " + str(t.block_size)
+            block_descriptions.append(
+                gemm.BlockTransferDesc(block_transfer, [1, 0, 2], [1, 0, 2], 2, 8, 8, 1)
             )
-            manifest.append(new_operation)
-            operations.append(new_operation)
+            c_block_descriptions.append(c_block_transfer)
+        gemm_specialization = [
+            gemm.GemmSpecialization.GemmDefault,
+            gemm.GemmSpecialization.MNKPadding,
+        ]
+        operations = []
+        for gemm_spec in gemm_specialization:
+            for tile_desc, block_desc, c_block_desc in zip(
+                tile_descriptions, block_descriptions, c_block_descriptions
+            ):
+                new_operation = gemm.GemmOperation(
+                    operation_kind=operation_kind,
+                    extra_kind=c_element_op,
+                    xdl_op_type=gemm.XdlOpType.DeviceGemmBiasCPermute_Xdl,
+                    A=a_element_desc,
+                    B=b_element_desc,
+                    C=c_element_desc,
+                    a_elem_op=element_op,
+                    b_elem_op=element_op,
+                    epilogue_functor=c_element_op,
+                    gemm_specialization=gemm_spec,
+                    tile_desc=tile_desc,
+                    a_block_transfer=block_desc,
+                    b_block_transfer=block_desc,
+                    c_block_transfer=c_block_desc,
+                    ds_dtype=ds_dtype,
+                    e_dtype=e_dtype,
+                    acc_dtype=acc_dtype,
+                )
+                manifest.append(new_operation)
+                operations.append(new_operation)
     return operations
 
 
 def CreateGemmRRRPermOperator(manifest, c_element_op):
     operation_kind = library.GemmKind.GemmPermute
-    a_element_desc = library.TensorDesc(
-        library.DataType.f16, library.LayoutType.RowMajor
-    )
-    b_element_desc = library.TensorDesc(
-        library.DataType.f16, library.LayoutType.RowMajor
-    )
-    c_element_desc = library.TensorDesc(
-        library.DataType.f16, library.LayoutType.RowMajor
-    )
-    ds_dtype = [library.DataType.f16]
-    e_dtype = library.DataType.f16
-    element_op = library.TensorOperation.PassThrough
-    # 0 indicates not print
-    tile_descriptions = [
-        gemm.TileDesc(256,   256,   128,    32,   8,   8,   16,   16,    8,    4),
-        gemm.TileDesc(256,   128,   256,    32,   8,   8,   16,   16,    4,    8),
-        gemm.TileDesc(128,   128,   128,    32,   8,   8,   16,   16,    8,    4),
-        gemm.TileDesc(256,   128,   128,    32,   8,   8,   16,   16,    4,    4),
-        gemm.TileDesc(128,   128,    64,    32,   8,   8,   16,   16,    4,    4),
-        gemm.TileDesc(128,    64,   128,    32,   8,   8,   16,   16,    4,    4),
-        gemm.TileDesc(256,   128,    64,    32,   8,   8,   16,   16,    4,    2),
-        gemm.TileDesc(256,    64,   128,    32,   8,   8,   16,   16,    2,    4),
-        gemm.TileDesc(64,    32,    32,    32,   8,   8,   16,   16,    2,    2)
-    ]
-
-    b_block_descriptions = [
-        gemm.BlockTransferDesc([8, 32, 1], [0, 2, 1], [0, 2, 1], 1, 4, 2, 0),
-        gemm.BlockTransferDesc([4, 64, 1], [0, 2, 1], [0, 2, 1], 1, 2, 8, 1),
-        gemm.BlockTransferDesc([4, 64, 1], [0, 2, 1], [0, 2, 1], 1, 4, 2, 0),
-        gemm.BlockTransferDesc([4, 64, 1], [0, 2, 1], [0, 2, 1], 1, 4, 8, 1),
-        gemm.BlockTransferDesc([4, 32, 1], [0, 2, 1], [0, 2, 1], 1, 4, 2, 0),
-        gemm.BlockTransferDesc([4, 32, 1], [0, 2, 1], [0, 2, 1], 1, 4, 8, 1),
-        gemm.BlockTransferDesc([8, 32, 1], [0, 2, 1], [0, 2, 1], 1, 4, 2, 0),
-        gemm.BlockTransferDesc([4, 64, 1], [0, 2, 1], [0, 2, 1], 1, 2, 8, 1),
-        gemm.BlockTransferDesc([8, 16, 1], [0, 2, 1], [0, 2, 1], 1, 4, 2, 0),
-        gemm.BlockTransferDesc([4, 32, 1], [0, 2, 1], [0, 2, 1], 1, 2, 8, 1),
-        gemm.BlockTransferDesc([4, 32, 1], [0, 2, 1], [0, 2, 1], 1, 4, 2, 0),
-        gemm.BlockTransferDesc([4, 32, 1], [0, 2, 1], [0, 2, 1], 1, 4, 8, 1),
-        gemm.BlockTransferDesc([16, 16, 1], [0, 2, 1], [0, 2, 1], 1, 4, 2, 0),
-        gemm.BlockTransferDesc([4, 64, 1], [0, 2, 1], [0, 2, 1], 1, 1, 8, 1),
-        gemm.BlockTransferDesc([8, 32, 1], [0, 2, 1], [0, 2, 1], 1, 4, 2, 0),
-        gemm.BlockTransferDesc([4, 64, 1], [0, 2, 1], [0, 2, 1], 1, 2, 8, 1),
-    ]
-    a_block_descriptions = []
-    c_block_descriptions = []
-    for t in tile_descriptions:
-        a_block_transfer = -1
-        c_block_transfer = -1
-        if t.block_size == 256:
-            a_block_transfer = [4, 64, 1]
-            # TODO:figure out the last dimension
-            c_block_transfer = gemm.CBlockTransferDesc(1, 1, [1, 32, 1, 8], 1)
-        if t.block_size == 128:
-            a_block_transfer = [4, 32, 1]
-            if t.n_per_block == 128:
-                c_block_transfer = gemm.CBlockTransferDesc(1, 1, [1, 16, 1, 8], 1)
-            else:
-                c_block_transfer = gemm.CBlockTransferDesc(1, 1, [1, 32, 1, 4], 1)
-        if t.block_size == 64:
-            a_block_transfer = [4, 16, 1]
-            c_block_transfer = gemm.CBlockTransferDesc(1, 1, [1, 16, 1, 4], 1)
-
-        assert a_block_transfer != -1 and c_block_transfer != -1 ,"Cannot determine block_transfer_size with block_size " + str(t.block_size)
-        a_block_descriptions.append(
-            gemm.BlockTransferDesc(a_block_transfer, [1, 0, 2], [1, 0, 2], 2, 8, 8, 1)
+    for dtype, acc_dtype in dtype_acc_types:
+        a_element_desc = library.TensorDesc(
+            dtype, library.LayoutType.RowMajor
         )
-        c_block_descriptions.append(c_block_transfer)
-    gemm_specialization = [
-        gemm.GemmSpecialization.GemmDefault,
-        gemm.GemmSpecialization.MNKPadding,
-    ]
-    operations = []
-    for gemm_spec in gemm_specialization:
-        for tile_desc, a_block_desc, b_block_desc, c_block_desc in zip(
-            tile_descriptions,
-            a_block_descriptions,
-            b_block_descriptions,
-            c_block_descriptions,
-        ):
-            new_operation = gemm.GemmOperation(
-                operation_kind=operation_kind,
-                extra_kind=c_element_op,
-                xdl_op_type=gemm.XdlOpType.DeviceGemmBiasCPermute_Xdl,
-                A=a_element_desc,
-                B=b_element_desc,
-                C=c_element_desc,
-                a_elem_op=element_op,
-                b_elem_op=element_op,
-                epilogue_functor=c_element_op,
-                gemm_specialization=gemm_spec,
-                tile_desc=tile_desc,
-                a_block_transfer=a_block_desc,
-                b_block_transfer=b_block_desc,
-                c_block_transfer=c_block_desc,
-                ds_dtype=ds_dtype,
-                e_dtype=e_dtype,
+        b_element_desc = library.TensorDesc(
+            dtype, library.LayoutType.RowMajor
+        )
+        c_element_desc = library.TensorDesc(
+            dtype, library.LayoutType.RowMajor
+        )
+        ds_dtype = [dtype]
+        e_dtype = dtype
+        element_op = library.TensorOperation.PassThrough
+        # 0 indicates not print
+        tile_descriptions = [
+            gemm.TileDesc(256,   256,   128,    32,   8,   8,   16,   16,    8,    4),
+            gemm.TileDesc(256,   128,   256,    32,   8,   8,   16,   16,    4,    8),
+            gemm.TileDesc(128,   128,   128,    32,   8,   8,   16,   16,    8,    4),
+            gemm.TileDesc(256,   128,   128,    32,   8,   8,   16,   16,    4,    4),
+            gemm.TileDesc(128,   128,    64,    32,   8,   8,   16,   16,    4,    4),
+            gemm.TileDesc(128,    64,   128,    32,   8,   8,   16,   16,    4,    4),
+            gemm.TileDesc(256,   128,    64,    32,   8,   8,   16,   16,    4,    2),
+            gemm.TileDesc(256,    64,   128,    32,   8,   8,   16,   16,    2,    4),
+            gemm.TileDesc(64,    32,    32,    32,   8,   8,   16,   16,    2,    2)
+        ]
+
+        b_block_descriptions = [
+            gemm.BlockTransferDesc([8, 32, 1], [0, 2, 1], [0, 2, 1], 1, 4, 2, 0),
+            gemm.BlockTransferDesc([4, 64, 1], [0, 2, 1], [0, 2, 1], 1, 2, 8, 1),
+            gemm.BlockTransferDesc([4, 64, 1], [0, 2, 1], [0, 2, 1], 1, 4, 2, 0),
+            gemm.BlockTransferDesc([4, 64, 1], [0, 2, 1], [0, 2, 1], 1, 4, 8, 1),
+            gemm.BlockTransferDesc([4, 32, 1], [0, 2, 1], [0, 2, 1], 1, 4, 2, 0),
+            gemm.BlockTransferDesc([4, 32, 1], [0, 2, 1], [0, 2, 1], 1, 4, 8, 1),
+            gemm.BlockTransferDesc([8, 32, 1], [0, 2, 1], [0, 2, 1], 1, 4, 2, 0),
+            gemm.BlockTransferDesc([4, 64, 1], [0, 2, 1], [0, 2, 1], 1, 2, 8, 1),
+            gemm.BlockTransferDesc([8, 16, 1], [0, 2, 1], [0, 2, 1], 1, 4, 2, 0),
+            gemm.BlockTransferDesc([4, 32, 1], [0, 2, 1], [0, 2, 1], 1, 2, 8, 1),
+            gemm.BlockTransferDesc([4, 32, 1], [0, 2, 1], [0, 2, 1], 1, 4, 2, 0),
+            gemm.BlockTransferDesc([4, 32, 1], [0, 2, 1], [0, 2, 1], 1, 4, 8, 1),
+            gemm.BlockTransferDesc([16, 16, 1], [0, 2, 1], [0, 2, 1], 1, 4, 2, 0),
+            gemm.BlockTransferDesc([4, 64, 1], [0, 2, 1], [0, 2, 1], 1, 1, 8, 1),
+            gemm.BlockTransferDesc([8, 32, 1], [0, 2, 1], [0, 2, 1], 1, 4, 2, 0),
+            gemm.BlockTransferDesc([4, 64, 1], [0, 2, 1], [0, 2, 1], 1, 2, 8, 1),
+        ]
+        a_block_descriptions = []
+        c_block_descriptions = []
+        for t in tile_descriptions:
+            a_block_transfer = -1
+            c_block_transfer = -1
+            if t.block_size == 256:
+                a_block_transfer = [4, 64, 1]
+                # TODO:figure out the last dimension
+                c_block_transfer = gemm.CBlockTransferDesc(1, 1, [1, 32, 1, 8], 1)
+            if t.block_size == 128:
+                a_block_transfer = [4, 32, 1]
+                if t.n_per_block == 128:
+                    c_block_transfer = gemm.CBlockTransferDesc(1, 1, [1, 16, 1, 8], 1)
+                else:
+                    c_block_transfer = gemm.CBlockTransferDesc(1, 1, [1, 32, 1, 4], 1)
+            if t.block_size == 64:
+                a_block_transfer = [4, 16, 1]
+                c_block_transfer = gemm.CBlockTransferDesc(1, 1, [1, 16, 1, 4], 1)
+
+            assert a_block_transfer != -1 and c_block_transfer != -1 ,"Cannot determine block_transfer_size with block_size " + str(t.block_size)
+            a_block_descriptions.append(
+                gemm.BlockTransferDesc(a_block_transfer, [1, 0, 2], [1, 0, 2], 2, 8, 8, 1)
             )
-            manifest.append(new_operation)
-            operations.append(new_operation)
+            c_block_descriptions.append(c_block_transfer)
+        gemm_specialization = [
+            gemm.GemmSpecialization.GemmDefault,
+            gemm.GemmSpecialization.MNKPadding,
+        ]
+        operations = []
+        for gemm_spec in gemm_specialization:
+            for tile_desc, a_block_desc, b_block_desc, c_block_desc in zip(
+                tile_descriptions,
+                a_block_descriptions,
+                b_block_descriptions,
+                c_block_descriptions,
+            ):
+                new_operation = gemm.GemmOperation(
+                    operation_kind=operation_kind,
+                    extra_kind=c_element_op,
+                    xdl_op_type=gemm.XdlOpType.DeviceGemmBiasCPermute_Xdl,
+                    A=a_element_desc,
+                    B=b_element_desc,
+                    C=c_element_desc,
+                    a_elem_op=element_op,
+                    b_elem_op=element_op,
+                    epilogue_functor=c_element_op,
+                    gemm_specialization=gemm_spec,
+                    tile_desc=tile_desc,
+                    a_block_transfer=a_block_desc,
+                    b_block_transfer=b_block_desc,
+                    c_block_transfer=c_block_desc,
+                    ds_dtype=ds_dtype,
+                    e_dtype=e_dtype,
+                    acc_dtype=acc_dtype,
+                )
+                manifest.append(new_operation)
+                operations.append(new_operation)
     return operations
 
 
 def CreateGemmRCRm2n3PermOperator(manifest, c_element_op):
     operation_kind = library.GemmKind.GemmPermuteM2N3
-    a_element_desc = library.TensorDesc(
-        library.DataType.f16, library.LayoutType.RowMajor
-    )
-    b_element_desc = library.TensorDesc(
-        library.DataType.f16, library.LayoutType.ColumnMajor
-    )
-    c_element_desc = library.TensorDesc(
-        library.DataType.f16, library.LayoutType.RowMajor
-    )
-    ds_dtype = [library.DataType.f16]
-    e_dtype = library.DataType.f16
-    element_op = library.TensorOperation.PassThrough
-    # 0 indicates not print
-    tile_descriptions = [
-        gemm.TileDesc(256,   256,   128,    32,   8,   8,   16,   16,    8,    4),
-        gemm.TileDesc(256,   128,   256,    32,   8,   8,   16,   16,    4,    8),
-        gemm.TileDesc(128,   128,   128,    32,   8,   8,   16,   16,    8,    4),
-        gemm.TileDesc(256,   128,   128,    32,   8,   8,   16,   16,    4,    4),
-        gemm.TileDesc(128,   128,    64,    32,   8,   8,   16,   16,    4,    4),
-        gemm.TileDesc(128,    64,   128,    32,   8,   8,   16,   16,    4,    4),
-        gemm.TileDesc(256,   128,    64,    32,   8,   8,   16,   16,    4,    2),
-        gemm.TileDesc(256,    64,   128,    32,   8,   8,   16,   16,    2,    4),
-        gemm.TileDesc(64,    32,    32,    32,   8,   8,   16,   16,    2,    2)
-    ]
-
-    block_descriptions = []
-    c_block_descriptions = []
-    for t in tile_descriptions:
-        block_transfer = -1
-        c_block_transfer = -1
-        if t.block_size == 256:
-            block_transfer = [4, 64, 1]
-            # TODO:figure out the last dimension
-            c_block_transfer = gemm.CBlockTransferDesc(1, 1, [1, 32, 1, 8], 8)
-        if t.block_size == 128:
-            block_transfer = [4, 32, 1]
-            if t.n_per_block == 128:
-                c_block_transfer = gemm.CBlockTransferDesc(1, 1, [1, 16, 1, 8], 8)
-            else:
-                c_block_transfer = gemm.CBlockTransferDesc(1, 1, [1, 32, 1, 4], 8)
-        if t.block_size == 64:
-            block_transfer = [4, 16, 1]
-            c_block_transfer = gemm.CBlockTransferDesc(1, 1, [1, 16, 1, 4], 8)
-
-        assert block_transfer != -1 and c_block_transfer != -1, f"Cannot determine block_transfer_size with block_size {str(t.block_size)}"
-        block_descriptions.append(
-            gemm.BlockTransferDesc(block_transfer, [1, 0, 2], [1, 0, 2], 2, 8, 8, 1)
+    for dtype, acc_dtype in dtype_acc_types:
+        a_element_desc = library.TensorDesc(
+            dtype, library.LayoutType.RowMajor
         )
-        c_block_descriptions.append(c_block_transfer)
-    gemm_specialization = [
-        gemm.GemmSpecialization.GemmDefault,
-        gemm.GemmSpecialization.MNKPadding,
-    ]
-    operations = []
-    for gemm_spec in gemm_specialization:
-        for tile_desc, block_desc, c_block_desc in zip(
-            tile_descriptions, block_descriptions, c_block_descriptions
-        ):
-            new_operation = gemm.GemmOperation(
-                operation_kind=operation_kind,
-                extra_kind=c_element_op,
-                xdl_op_type=gemm.XdlOpType.DeviceBatchedContractionMultipleD_Xdl_CShuffle,
-                A=a_element_desc,
-                B=b_element_desc,
-                C=c_element_desc,
-                a_elem_op=element_op,
-                b_elem_op=element_op,
-                epilogue_functor=c_element_op,
-                gemm_specialization=gemm_spec,
-                tile_desc=tile_desc,
-                a_block_transfer=block_desc,
-                b_block_transfer=block_desc,
-                c_block_transfer=c_block_desc,
-                ds_dtype=ds_dtype,
-                e_dtype=e_dtype,
+        b_element_desc = library.TensorDesc(
+            dtype, library.LayoutType.ColumnMajor
+        )
+        c_element_desc = library.TensorDesc(
+            dtype, library.LayoutType.RowMajor
+        )
+        ds_dtype = [dtype]
+        e_dtype = dtype
+        element_op = library.TensorOperation.PassThrough
+        # 0 indicates not print
+        tile_descriptions = [
+            gemm.TileDesc(256,   256,   128,    32,   8,   8,   16,   16,    8,    4),
+            gemm.TileDesc(256,   128,   256,    32,   8,   8,   16,   16,    4,    8),
+            gemm.TileDesc(128,   128,   128,    32,   8,   8,   16,   16,    8,    4),
+            gemm.TileDesc(256,   128,   128,    32,   8,   8,   16,   16,    4,    4),
+            gemm.TileDesc(128,   128,    64,    32,   8,   8,   16,   16,    4,    4),
+            gemm.TileDesc(128,    64,   128,    32,   8,   8,   16,   16,    4,    4),
+            gemm.TileDesc(256,   128,    64,    32,   8,   8,   16,   16,    4,    2),
+            gemm.TileDesc(256,    64,   128,    32,   8,   8,   16,   16,    2,    4),
+            gemm.TileDesc(64,    32,    32,    32,   8,   8,   16,   16,    2,    2)
+        ]
+
+        block_descriptions = []
+        c_block_descriptions = []
+        for t in tile_descriptions:
+            block_transfer = -1
+            c_block_transfer = -1
+            if t.block_size == 256:
+                block_transfer = [4, 64, 1]
+                # TODO:figure out the last dimension
+                c_block_transfer = gemm.CBlockTransferDesc(1, 1, [1, 32, 1, 8], 8)
+            if t.block_size == 128:
+                block_transfer = [4, 32, 1]
+                if t.n_per_block == 128:
+                    c_block_transfer = gemm.CBlockTransferDesc(1, 1, [1, 16, 1, 8], 8)
+                else:
+                    c_block_transfer = gemm.CBlockTransferDesc(1, 1, [1, 32, 1, 4], 8)
+            if t.block_size == 64:
+                block_transfer = [4, 16, 1]
+                c_block_transfer = gemm.CBlockTransferDesc(1, 1, [1, 16, 1, 4], 8)
+
+            assert block_transfer != -1 and c_block_transfer != -1, f"Cannot determine block_transfer_size with block_size {str(t.block_size)}"
+            block_descriptions.append(
+                gemm.BlockTransferDesc(block_transfer, [1, 0, 2], [1, 0, 2], 2, 8, 8, 1)
             )
-            manifest.append(new_operation)
-            operations.append(new_operation)
+            c_block_descriptions.append(c_block_transfer)
+        gemm_specialization = [
+            gemm.GemmSpecialization.GemmDefault,
+            gemm.GemmSpecialization.MNKPadding,
+        ]
+        operations = []
+        for gemm_spec in gemm_specialization:
+            for tile_desc, block_desc, c_block_desc in zip(
+                tile_descriptions, block_descriptions, c_block_descriptions
+            ):
+                new_operation = gemm.GemmOperation(
+                    operation_kind=operation_kind,
+                    extra_kind=c_element_op,
+                    xdl_op_type=gemm.XdlOpType.DeviceBatchedContractionMultipleD_Xdl_CShuffle,
+                    A=a_element_desc,
+                    B=b_element_desc,
+                    C=c_element_desc,
+                    a_elem_op=element_op,
+                    b_elem_op=element_op,
+                    epilogue_functor=c_element_op,
+                    gemm_specialization=gemm_spec,
+                    tile_desc=tile_desc,
+                    a_block_transfer=block_desc,
+                    b_block_transfer=block_desc,
+                    c_block_transfer=c_block_desc,
+                    ds_dtype=ds_dtype,
+                    e_dtype=e_dtype,
+                    acc_dtype=acc_dtype,
+                )
+                manifest.append(new_operation)
+                operations.append(new_operation)
     return operations
 
 
 def CreateGemmRCRm3n2PermOperator(manifest, c_element_op):
     operation_kind = library.GemmKind.GemmPermuteM3N2
-    a_element_desc = library.TensorDesc(
-        library.DataType.f16, library.LayoutType.RowMajor
-    )
-    b_element_desc = library.TensorDesc(
-        library.DataType.f16, library.LayoutType.ColumnMajor
-    )
-    c_element_desc = library.TensorDesc(
-        library.DataType.f16, library.LayoutType.RowMajor
-    )
-    ds_dtype = [library.DataType.f16]
-    e_dtype = library.DataType.f16
-    element_op = library.TensorOperation.PassThrough
-    # 0 indicates not print
-    tile_descriptions = [
-        gemm.TileDesc(256,   256,   128,    32,   8,   8,   16,   16,    8,    4),
-        gemm.TileDesc(256,   128,   256,    32,   8,   8,   16,   16,    4,    8),
-        gemm.TileDesc(128,   128,   128,    32,   8,   8,   16,   16,    8,    4),
-        gemm.TileDesc(256,   128,   128,    32,   8,   8,   16,   16,    4,    4),
-        gemm.TileDesc(128,   128,    64,    32,   8,   8,   16,   16,    4,    4),
-        gemm.TileDesc(128,    64,   128,    32,   8,   8,   16,   16,    4,    4),
-        gemm.TileDesc(256,   128,    64,    32,   8,   8,   16,   16,    4,    2),
-        gemm.TileDesc(256,    64,   128,    32,   8,   8,   16,   16,    2,    4),
-        gemm.TileDesc(64,    32,    32,    32,   8,   8,   16,   16,    2,    2)
-    ]
-
-    block_descriptions = []
-    c_block_descriptions = []
-    for t in tile_descriptions:
-        block_transfer = -1
-        c_block_transfer = -1
-        if t.block_size == 256:
-            block_transfer = [4, 64, 1]
-            # TODO:figure out the last dimension
-            c_block_transfer = gemm.CBlockTransferDesc(1, 1, [1, 32, 1, 8], 1)
-        if t.block_size == 128:
-            block_transfer = [4, 32, 1]
-            if t.n_per_block == 128:
-                c_block_transfer = gemm.CBlockTransferDesc(1, 1, [1, 16, 1, 8], 1)
-            else:
-                c_block_transfer = gemm.CBlockTransferDesc(1, 1, [1, 32, 1, 4], 1)
-        if t.block_size == 64:
-            block_transfer = [4, 16, 1]
-            c_block_transfer = gemm.CBlockTransferDesc(1, 1, [1, 16, 1, 4], 1)
-
-        assert block_transfer != -1 and c_block_transfer != -1, f"Cannot determine block_transfer_size with block_size {str(t.block_size)}"
-        block_descriptions.append(
-            gemm.BlockTransferDesc(block_transfer, [1, 0, 2], [1, 0, 2], 2, 8, 8, 1)
+    for dtype, acc_dtype in dtype_acc_types:
+        a_element_desc = library.TensorDesc(
+            dtype, library.LayoutType.RowMajor
         )
-        c_block_descriptions.append(c_block_transfer)
-    gemm_specialization = [
-        gemm.GemmSpecialization.GemmDefault,
-        gemm.GemmSpecialization.MNKPadding,
-    ]
-    operations = []
-    for gemm_spec in gemm_specialization:
-        for tile_desc, block_desc, c_block_desc in zip(
-            tile_descriptions, block_descriptions, c_block_descriptions
-        ):
-            new_operation = gemm.GemmOperation(
-                operation_kind=operation_kind,
-                extra_kind=c_element_op,
-                xdl_op_type=gemm.XdlOpType.DeviceBatchedContractionMultipleD_Xdl_CShuffle,
-                A=a_element_desc,
-                B=b_element_desc,
-                C=c_element_desc,
-                a_elem_op=element_op,
-                b_elem_op=element_op,
-                epilogue_functor=c_element_op,
-                gemm_specialization=gemm_spec,
-                tile_desc=tile_desc,
-                a_block_transfer=block_desc,
-                b_block_transfer=block_desc,
-                c_block_transfer=c_block_desc,
-                ds_dtype=ds_dtype,
-                e_dtype=e_dtype,
+        b_element_desc = library.TensorDesc(
+            dtype, library.LayoutType.ColumnMajor
+        )
+        c_element_desc = library.TensorDesc(
+            dtype, library.LayoutType.RowMajor
+        )
+        ds_dtype = [dtype]
+        e_dtype = dtype
+        element_op = library.TensorOperation.PassThrough
+        # 0 indicates not print
+        tile_descriptions = [
+            gemm.TileDesc(256,   256,   128,    32,   8,   8,   16,   16,    8,    4),
+            gemm.TileDesc(256,   128,   256,    32,   8,   8,   16,   16,    4,    8),
+            gemm.TileDesc(128,   128,   128,    32,   8,   8,   16,   16,    8,    4),
+            gemm.TileDesc(256,   128,   128,    32,   8,   8,   16,   16,    4,    4),
+            gemm.TileDesc(128,   128,    64,    32,   8,   8,   16,   16,    4,    4),
+            gemm.TileDesc(128,    64,   128,    32,   8,   8,   16,   16,    4,    4),
+            gemm.TileDesc(256,   128,    64,    32,   8,   8,   16,   16,    4,    2),
+            gemm.TileDesc(256,    64,   128,    32,   8,   8,   16,   16,    2,    4),
+            gemm.TileDesc(64,    32,    32,    32,   8,   8,   16,   16,    2,    2)
+        ]
+
+        block_descriptions = []
+        c_block_descriptions = []
+        for t in tile_descriptions:
+            block_transfer = -1
+            c_block_transfer = -1
+            if t.block_size == 256:
+                block_transfer = [4, 64, 1]
+                # TODO:figure out the last dimension
+                c_block_transfer = gemm.CBlockTransferDesc(1, 1, [1, 32, 1, 8], 1)
+            if t.block_size == 128:
+                block_transfer = [4, 32, 1]
+                if t.n_per_block == 128:
+                    c_block_transfer = gemm.CBlockTransferDesc(1, 1, [1, 16, 1, 8], 1)
+                else:
+                    c_block_transfer = gemm.CBlockTransferDesc(1, 1, [1, 32, 1, 4], 1)
+            if t.block_size == 64:
+                block_transfer = [4, 16, 1]
+                c_block_transfer = gemm.CBlockTransferDesc(1, 1, [1, 16, 1, 4], 1)
+
+            assert block_transfer != -1 and c_block_transfer != -1, f"Cannot determine block_transfer_size with block_size {str(t.block_size)}"
+            block_descriptions.append(
+                gemm.BlockTransferDesc(block_transfer, [1, 0, 2], [1, 0, 2], 2, 8, 8, 1)
             )
-            manifest.append(new_operation)
-            operations.append(new_operation)
+            c_block_descriptions.append(c_block_transfer)
+        gemm_specialization = [
+            gemm.GemmSpecialization.GemmDefault,
+            gemm.GemmSpecialization.MNKPadding,
+        ]
+        operations = []
+        for gemm_spec in gemm_specialization:
+            for tile_desc, block_desc, c_block_desc in zip(
+                tile_descriptions, block_descriptions, c_block_descriptions
+            ):
+                new_operation = gemm.GemmOperation(
+                    operation_kind=operation_kind,
+                    extra_kind=c_element_op,
+                    xdl_op_type=gemm.XdlOpType.DeviceBatchedContractionMultipleD_Xdl_CShuffle,
+                    A=a_element_desc,
+                    B=b_element_desc,
+                    C=c_element_desc,
+                    a_elem_op=element_op,
+                    b_elem_op=element_op,
+                    epilogue_functor=c_element_op,
+                    gemm_specialization=gemm_spec,
+                    tile_desc=tile_desc,
+                    a_block_transfer=block_desc,
+                    b_block_transfer=block_desc,
+                    c_block_transfer=c_block_desc,
+                    ds_dtype=ds_dtype,
+                    e_dtype=e_dtype,
+                    acc_dtype=acc_dtype,
+                )
+                manifest.append(new_operation)
+                operations.append(new_operation)
     return operations
 
 
 def CreateBmmRCRPermOperator(manifest):
     operation_kind = library.GemmKind.BatchGemmPermute
-    a_element_desc = library.TensorDesc(
-        library.DataType.f16, library.LayoutType.RowMajor
-    )
-    b_element_desc = library.TensorDesc(
-        library.DataType.f16, library.LayoutType.ColumnMajor
-    )
-    c_element_desc = library.TensorDesc(
-        library.DataType.f16, library.LayoutType.RowMajor
-    )
-    element_op = library.TensorOperation.PassThrough
-    # 0 indicates not print
-    tile_descriptions = [
-        gemm.TileDesc(256,   256,   128,    32,   8,   8,   16,   16,    8,    4),
-        gemm.TileDesc(256,   128,   256,    32,   8,   8,   16,   16,    4,    8),
-        gemm.TileDesc(128,   128,   128,    32,   8,   8,   16,   16,    8,    4),
-        gemm.TileDesc(256,   128,   128,    32,   8,   8,   16,   16,    4,    4),
-        gemm.TileDesc(128,   128,    64,    32,   8,   8,   16,   16,    4,    4),
-        gemm.TileDesc(128,    64,   128,    32,   8,   8,   16,   16,    4,    4),
-        gemm.TileDesc(256,   128,    64,    32,   8,   8,   16,   16,    4,    2),
-        gemm.TileDesc(256,    64,   128,    32,   8,   8,   16,   16,    2,    4),
-        gemm.TileDesc(64,    32,    32,    32,   8,   8,   16,   16,    2,    2)
-    ]
-
-    block_descriptions = []
-    c_block_descriptions = []
-    for t in tile_descriptions:
-        block_transfer = -1
-        c_block_transfer = -1
-        if t.block_size == 256:
-            block_transfer = [4, 64, 1]
-            c_block_transfer = gemm.CBlockTransferDesc(1, 1, [1, 32, 1, 8], 8)
-        if t.block_size == 128:
-            block_transfer = [4, 32, 1]
-            if t.n_per_block == 128:
-                c_block_transfer = gemm.CBlockTransferDesc(1, 1, [1, 16, 1, 8], 8)
-            else:
-                c_block_transfer = gemm.CBlockTransferDesc(1, 1, [1, 32, 1, 4], 8)
-        if t.block_size == 64:
-            block_transfer = [4, 16, 1]
-            c_block_transfer = gemm.CBlockTransferDesc(1, 1, [1, 16, 1, 4], 8)
-
-        assert block_transfer != -1 and c_block_transfer != -1, f"Cannot determine block_transfer_size with block_size {str(t.block_size)}"
-        block_descriptions.append(
-            gemm.BlockTransferDesc(block_transfer, [1, 0, 2], [1, 0, 2], 2, 8, 8, 1)
+    for dtype, acc_dtype in dtype_acc_types:
+        a_element_desc = library.TensorDesc(
+            dtype, library.LayoutType.RowMajor
         )
-        c_block_descriptions.append(c_block_transfer)
+        b_element_desc = library.TensorDesc(
+            dtype, library.LayoutType.ColumnMajor
+        )
+        c_element_desc = library.TensorDesc(
+            dtype, library.LayoutType.RowMajor
+        )
+        element_op = library.TensorOperation.PassThrough
+        # 0 indicates not print
+        tile_descriptions = [
+            gemm.TileDesc(256,   256,   128,    32,   8,   8,   16,   16,    8,    4),
+            gemm.TileDesc(256,   128,   256,    32,   8,   8,   16,   16,    4,    8),
+            gemm.TileDesc(128,   128,   128,    32,   8,   8,   16,   16,    8,    4),
+            gemm.TileDesc(256,   128,   128,    32,   8,   8,   16,   16,    4,    4),
+            gemm.TileDesc(128,   128,    64,    32,   8,   8,   16,   16,    4,    4),
+            gemm.TileDesc(128,    64,   128,    32,   8,   8,   16,   16,    4,    4),
+            gemm.TileDesc(256,   128,    64,    32,   8,   8,   16,   16,    4,    2),
+            gemm.TileDesc(256,    64,   128,    32,   8,   8,   16,   16,    2,    4),
+            gemm.TileDesc(64,    32,    32,    32,   8,   8,   16,   16,    2,    2)
+        ]
 
-    gemm_specialization = [
-        gemm.GemmSpecialization.GemmDefault,
-        gemm.GemmSpecialization.MNKPadding,
-    ]
-    operations = []
-    for gemm_spec in gemm_specialization:
-        for tile_desc, block_desc, c_block_desc in zip(
-            tile_descriptions, block_descriptions, c_block_descriptions
-        ):
-            new_operation = gemm.GemmOperation(
-                operation_kind=operation_kind,
-                extra_kind=element_op,
-                xdl_op_type=gemm.XdlOpType.DeviceBatchedGemmCPermuteXdl,
-                A=a_element_desc,
-                B=b_element_desc,
-                C=c_element_desc,
-                a_elem_op=element_op,
-                b_elem_op=element_op,
-                epilogue_functor=element_op,
-                gemm_specialization=gemm_spec,
-                tile_desc=tile_desc,
-                a_block_transfer=block_desc,
-                b_block_transfer=block_desc,
-                c_block_transfer=c_block_desc,
+        block_descriptions = []
+        c_block_descriptions = []
+        for t in tile_descriptions:
+            block_transfer = -1
+            c_block_transfer = -1
+            if t.block_size == 256:
+                block_transfer = [4, 64, 1]
+                c_block_transfer = gemm.CBlockTransferDesc(1, 1, [1, 32, 1, 8], 8)
+            if t.block_size == 128:
+                block_transfer = [4, 32, 1]
+                if t.n_per_block == 128:
+                    c_block_transfer = gemm.CBlockTransferDesc(1, 1, [1, 16, 1, 8], 8)
+                else:
+                    c_block_transfer = gemm.CBlockTransferDesc(1, 1, [1, 32, 1, 4], 8)
+            if t.block_size == 64:
+                block_transfer = [4, 16, 1]
+                c_block_transfer = gemm.CBlockTransferDesc(1, 1, [1, 16, 1, 4], 8)
+
+            assert block_transfer != -1 and c_block_transfer != -1, f"Cannot determine block_transfer_size with block_size {str(t.block_size)}"
+            block_descriptions.append(
+                gemm.BlockTransferDesc(block_transfer, [1, 0, 2], [1, 0, 2], 2, 8, 8, 1)
             )
-            manifest.append(new_operation)
-            operations.append(new_operation)
+            c_block_descriptions.append(c_block_transfer)
+
+        gemm_specialization = [
+            gemm.GemmSpecialization.GemmDefault,
+            gemm.GemmSpecialization.MNKPadding,
+        ]
+        operations = []
+        for gemm_spec in gemm_specialization:
+            for tile_desc, block_desc, c_block_desc in zip(
+                tile_descriptions, block_descriptions, c_block_descriptions
+            ):
+                new_operation = gemm.GemmOperation(
+                    operation_kind=operation_kind,
+                    extra_kind=element_op,
+                    xdl_op_type=gemm.XdlOpType.DeviceBatchedGemmCPermuteXdl,
+                    A=a_element_desc,
+                    B=b_element_desc,
+                    C=c_element_desc,
+                    a_elem_op=element_op,
+                    b_elem_op=element_op,
+                    epilogue_functor=element_op,
+                    gemm_specialization=gemm_spec,
+                    tile_desc=tile_desc,
+                    a_block_transfer=block_desc,
+                    b_block_transfer=block_desc,
+                    c_block_transfer=c_block_desc,
+                    acc_dtype=acc_dtype,
+                )
+                manifest.append(new_operation)
+                operations.append(new_operation)
     return operations
 
 
@@ -1407,101 +1386,103 @@ def CreateBmmSoftmaxBmmOperator(
     operation_kind=library.GemmKind.BatchGemmSoftmaxGemm,
     xdl_op_type=gemm.XdlOpType.DeviceBatchedGemmSoftmaxGemm_Xdl_CShuffle,
 ):
-    a_element_desc = library.TensorDesc(
-        library.DataType.f16, library.LayoutType.RowMajor
-    )
-    b_element_desc = library.TensorDesc(
-        library.DataType.f16, library.LayoutType.ColumnMajor
-    )
-    c_element_desc = library.TensorDesc(
-        library.DataType.f16, library.LayoutType.RowMajor
-    )
-    element_op = library.TensorOperation.PassThrough
-    tile_descriptions = [
-        gemm.AttnTileDesc(256, 256, 128, 32, 64, 32, 8, 8, 2, 32, 32, 2, 4, 2),
-        gemm.AttnTileDesc(256, 256, 128, 32, 128, 32, 8, 8, 2, 32, 32, 2, 4, 4),
-        gemm.AttnTileDesc(256, 128, 256, 32, 64, 32, 8, 8, 2, 32, 32, 1, 8, 2),
-        gemm.AttnTileDesc(256, 128, 256, 32, 128, 32, 8, 8, 2, 32, 32, 1, 8, 4),
-        gemm.AttnTileDesc(256, 128, 128, 64, 64, 32, 8, 8, 2, 32, 32, 1, 4, 2),
-        gemm.AttnTileDesc(256, 128, 128, 32, 64, 32, 8, 8, 2, 32, 32, 1, 4, 2),
-        gemm.AttnTileDesc(256, 128, 128, 64, 128, 32, 8, 8, 2, 32, 32, 1, 4, 4),
-        gemm.AttnTileDesc(256, 128, 128, 32, 128, 32, 8, 8, 2, 32, 32, 1, 4, 4),
-        gemm.AttnTileDesc(256, 64, 256, 32, 128, 32, 8, 8, 2, 16, 16, 1, 16, 8),
-        gemm.AttnTileDesc(256, 64, 256, 32, 64, 32, 8, 8, 2, 16, 16, 1, 16, 4),
-        gemm.AttnTileDesc(256, 64, 256, 64, 128, 32, 8, 8, 2, 16, 16, 1, 16, 8),
-        gemm.AttnTileDesc(256, 64, 256, 64, 64, 32, 8, 8, 2, 16, 16, 1, 16, 4),
-        gemm.AttnTileDesc(256, 128, 128, 64, 128, 32, 8, 8, 2, 32, 32, 1, 4, 4),
-        gemm.AttnTileDesc(256, 128, 64, 32, 128, 32, 8, 8, 2, 32, 32, 1, 2, 4),
-    ]
-
-    block_descriptions = [
-        gemm.BlockTransferDesc([4, 64, 1], [1, 0, 2], [1, 0, 2], 2, 8, 8, 1),
-        gemm.BlockTransferDesc([4, 64, 1], [1, 0, 2], [1, 0, 2], 2, 8, 8, 1),
-        gemm.BlockTransferDesc([4, 64, 1], [1, 0, 2], [1, 0, 2], 2, 8, 8, 1),
-        gemm.BlockTransferDesc([4, 64, 1], [1, 0, 2], [1, 0, 2], 2, 8, 8, 1),
-        gemm.BlockTransferDesc([8, 32, 1], [1, 0, 2], [1, 0, 2], 2, 8, 8, 0),
-        gemm.BlockTransferDesc([4, 64, 1], [1, 0, 2], [1, 0, 2], 2, 8, 8, 1),
-        gemm.BlockTransferDesc([8, 32, 1], [1, 0, 2], [1, 0, 2], 2, 8, 8, 0),
-        gemm.BlockTransferDesc([4, 64, 1], [1, 0, 2], [1, 0, 2], 2, 8, 8, 1),
-        gemm.BlockTransferDesc([4, 64, 1], [1, 0, 2], [1, 0, 2], 2, 8, 8, 1),
-        gemm.BlockTransferDesc([4, 64, 1], [1, 0, 2], [1, 0, 2], 2, 8, 8, 1),
-        gemm.BlockTransferDesc([8, 32, 1], [1, 0, 2], [1, 0, 2], 2, 8, 8, 1),
-        gemm.BlockTransferDesc([8, 32, 1], [1, 0, 2], [1, 0, 2], 2, 8, 8, 1),
-        gemm.BlockTransferDesc([8, 32, 1], [1, 0, 2], [1, 0, 2], 2, 8, 8, 0),
-        gemm.BlockTransferDesc([4, 64, 1], [1, 0, 2], [1, 0, 2], 2, 8, 8, 1),
-    ]
-    c_block_descriptions, b1_block_descriptions = [], []
-    for i in range(len(tile_descriptions)):
-        if i in [0, 2, 4, 5, 9, 11]:
-            block_transfer = [16, 16, 1]
-        else:
-            block_transfer = [8, 32, 1]
-        b1_block_descriptions.append(
-            gemm.BlockTransferDesc(block_transfer, [0, 2, 1], [0, 2, 1], 1, 4, 2, 0)
+    for dtype, acc_dtype in dtype_acc_types:
+        a_element_desc = library.TensorDesc(
+            dtype, library.LayoutType.RowMajor
         )
-
-        if i in [8, 10]:
-            c_block_transfer = gemm.CBlockTransferDesc(1, 8, [1, 16, 1, 16], 8)
-        else:
-            c_shuffle = 4 if i in [9, 11] else 2
-            c_block_transfer = gemm.CBlockTransferDesc(1, c_shuffle, [1, 32, 1, 8], 8)
-
-        c_block_descriptions.append(c_block_transfer)
-
-    gemm_specialization = []
-    for i in range(len(tile_descriptions)):
-        if i < 12:
-            gemm_specialization.append(gemm.GemmSpecialization.GemmDefault)
-        else:
-            gemm_specialization.append(gemm.GemmSpecialization.MNOPadding)
-
-    operations = []
-    for tile_desc, block_desc, b1_block_desc, c_block_desc, gemm_spec in zip(
-        tile_descriptions,
-        block_descriptions,
-        b1_block_descriptions,
-        c_block_descriptions,
-        gemm_specialization,
-    ):
-        new_operation = gemm.GemmOperation(
-            operation_kind=operation_kind,
-            extra_kind=element_op,
-            xdl_op_type=xdl_op_type,
-            A=a_element_desc,
-            B=b_element_desc,
-            C=c_element_desc,
-            a_elem_op=element_op,
-            b_elem_op=element_op,
-            epilogue_functor=element_op,
-            gemm_specialization=gemm_spec,
-            tile_desc=tile_desc,
-            a_block_transfer=block_desc,
-            b_block_transfer=block_desc,
-            b1_block_transfer=b1_block_desc,
-            c_block_transfer=c_block_desc,
+        b_element_desc = library.TensorDesc(
+            dtype, library.LayoutType.ColumnMajor
         )
-        manifest.append(new_operation)
-        operations.append(new_operation)
+        c_element_desc = library.TensorDesc(
+            dtype, library.LayoutType.RowMajor
+        )
+        element_op = library.TensorOperation.PassThrough
+        tile_descriptions = [
+            gemm.AttnTileDesc(256, 256, 128, 32, 64, 32, 8, 8, 2, 32, 32, 2, 4, 2),
+            gemm.AttnTileDesc(256, 256, 128, 32, 128, 32, 8, 8, 2, 32, 32, 2, 4, 4),
+            gemm.AttnTileDesc(256, 128, 256, 32, 64, 32, 8, 8, 2, 32, 32, 1, 8, 2),
+            gemm.AttnTileDesc(256, 128, 256, 32, 128, 32, 8, 8, 2, 32, 32, 1, 8, 4),
+            gemm.AttnTileDesc(256, 128, 128, 64, 64, 32, 8, 8, 2, 32, 32, 1, 4, 2),
+            gemm.AttnTileDesc(256, 128, 128, 32, 64, 32, 8, 8, 2, 32, 32, 1, 4, 2),
+            gemm.AttnTileDesc(256, 128, 128, 64, 128, 32, 8, 8, 2, 32, 32, 1, 4, 4),
+            gemm.AttnTileDesc(256, 128, 128, 32, 128, 32, 8, 8, 2, 32, 32, 1, 4, 4),
+            gemm.AttnTileDesc(256, 64, 256, 32, 128, 32, 8, 8, 2, 16, 16, 1, 16, 8),
+            gemm.AttnTileDesc(256, 64, 256, 32, 64, 32, 8, 8, 2, 16, 16, 1, 16, 4),
+            gemm.AttnTileDesc(256, 64, 256, 64, 128, 32, 8, 8, 2, 16, 16, 1, 16, 8),
+            gemm.AttnTileDesc(256, 64, 256, 64, 64, 32, 8, 8, 2, 16, 16, 1, 16, 4),
+            gemm.AttnTileDesc(256, 128, 128, 64, 128, 32, 8, 8, 2, 32, 32, 1, 4, 4),
+            gemm.AttnTileDesc(256, 128, 64, 32, 128, 32, 8, 8, 2, 32, 32, 1, 2, 4),
+        ]
+
+        block_descriptions = [
+            gemm.BlockTransferDesc([4, 64, 1], [1, 0, 2], [1, 0, 2], 2, 8, 8, 1),
+            gemm.BlockTransferDesc([4, 64, 1], [1, 0, 2], [1, 0, 2], 2, 8, 8, 1),
+            gemm.BlockTransferDesc([4, 64, 1], [1, 0, 2], [1, 0, 2], 2, 8, 8, 1),
+            gemm.BlockTransferDesc([4, 64, 1], [1, 0, 2], [1, 0, 2], 2, 8, 8, 1),
+            gemm.BlockTransferDesc([8, 32, 1], [1, 0, 2], [1, 0, 2], 2, 8, 8, 0),
+            gemm.BlockTransferDesc([4, 64, 1], [1, 0, 2], [1, 0, 2], 2, 8, 8, 1),
+            gemm.BlockTransferDesc([8, 32, 1], [1, 0, 2], [1, 0, 2], 2, 8, 8, 0),
+            gemm.BlockTransferDesc([4, 64, 1], [1, 0, 2], [1, 0, 2], 2, 8, 8, 1),
+            gemm.BlockTransferDesc([4, 64, 1], [1, 0, 2], [1, 0, 2], 2, 8, 8, 1),
+            gemm.BlockTransferDesc([4, 64, 1], [1, 0, 2], [1, 0, 2], 2, 8, 8, 1),
+            gemm.BlockTransferDesc([8, 32, 1], [1, 0, 2], [1, 0, 2], 2, 8, 8, 1),
+            gemm.BlockTransferDesc([8, 32, 1], [1, 0, 2], [1, 0, 2], 2, 8, 8, 1),
+            gemm.BlockTransferDesc([8, 32, 1], [1, 0, 2], [1, 0, 2], 2, 8, 8, 0),
+            gemm.BlockTransferDesc([4, 64, 1], [1, 0, 2], [1, 0, 2], 2, 8, 8, 1),
+        ]
+        c_block_descriptions, b1_block_descriptions = [], []
+        for i in range(len(tile_descriptions)):
+            if i in [0, 2, 4, 5, 9, 11]:
+                block_transfer = [16, 16, 1]
+            else:
+                block_transfer = [8, 32, 1]
+            b1_block_descriptions.append(
+                gemm.BlockTransferDesc(block_transfer, [0, 2, 1], [0, 2, 1], 1, 4, 2, 0)
+            )
+
+            if i in [8, 10]:
+                c_block_transfer = gemm.CBlockTransferDesc(1, 8, [1, 16, 1, 16], 8)
+            else:
+                c_shuffle = 4 if i in [9, 11] else 2
+                c_block_transfer = gemm.CBlockTransferDesc(1, c_shuffle, [1, 32, 1, 8], 8)
+
+            c_block_descriptions.append(c_block_transfer)
+
+        gemm_specialization = []
+        for i in range(len(tile_descriptions)):
+            if i < 12:
+                gemm_specialization.append(gemm.GemmSpecialization.GemmDefault)
+            else:
+                gemm_specialization.append(gemm.GemmSpecialization.MNOPadding)
+
+        operations = []
+        for tile_desc, block_desc, b1_block_desc, c_block_desc, gemm_spec in zip(
+            tile_descriptions,
+            block_descriptions,
+            b1_block_descriptions,
+            c_block_descriptions,
+            gemm_specialization,
+        ):
+            new_operation = gemm.GemmOperation(
+                operation_kind=operation_kind,
+                extra_kind=element_op,
+                xdl_op_type=xdl_op_type,
+                A=a_element_desc,
+                B=b_element_desc,
+                C=c_element_desc,
+                a_elem_op=element_op,
+                b_elem_op=element_op,
+                epilogue_functor=element_op,
+                gemm_specialization=gemm_spec,
+                tile_desc=tile_desc,
+                a_block_transfer=block_desc,
+                b_block_transfer=block_desc,
+                b1_block_transfer=b1_block_desc,
+                c_block_transfer=c_block_desc,
+                acc_dtype=acc_dtype,
+            )
+            manifest.append(new_operation)
+            operations.append(new_operation)
     return operations
 
 
@@ -1511,909 +1492,931 @@ def CreateBmmSoftmaxBmmPermOperator(
     xdl_op_type=gemm.XdlOpType.DeviceBatchedGemmSoftmaxGemmPermute_Xdl_CShuffle,
     causal_mask=None,
 ):
-    a_element_desc = library.TensorDesc(
-        library.DataType.f16, library.LayoutType.RowMajor
-    )
-    b_element_desc = library.TensorDesc(
-        library.DataType.f16, library.LayoutType.ColumnMajor
-    )
-    c_element_desc = library.TensorDesc(
-        library.DataType.f16, library.LayoutType.RowMajor
-    )
-    element_op = library.TensorOperation.PassThrough
-    tile_descriptions = [
-        gemm.AttnTileDesc(256, 256, 128, 32, 64, 32, 8, 8, 2, 32, 32, 2, 4, 2),
-        gemm.AttnTileDesc(256, 256, 128, 32, 128, 32, 8, 8, 2, 32, 32, 2, 4, 4),
-        gemm.AttnTileDesc(256, 128, 256, 32, 64, 32, 8, 8, 2, 32, 32, 1, 8, 2),
-        gemm.AttnTileDesc(256, 128, 256, 32, 128, 32, 8, 8, 2, 32, 32, 1, 8, 4),
-        gemm.AttnTileDesc(256, 128, 128, 64, 64, 32, 8, 8, 2, 32, 32, 1, 4, 2),
-        gemm.AttnTileDesc(256, 128, 128, 32, 64, 32, 8, 8, 2, 32, 32, 1, 4, 2),
-        gemm.AttnTileDesc(256, 128, 128, 64, 128, 32, 8, 8, 2, 32, 32, 1, 4, 4),
-        gemm.AttnTileDesc(256, 128, 128, 32, 128, 32, 8, 8, 2, 32, 32, 1, 4, 4),
-        gemm.AttnTileDesc(256, 64, 256, 32, 128, 32, 8, 8, 2, 16, 16, 1, 16, 8),
-        gemm.AttnTileDesc(256, 64, 256, 32, 64, 32, 8, 8, 2, 16, 16, 1, 16, 4),
-        gemm.AttnTileDesc(256, 64, 256, 64, 128, 32, 8, 8, 2, 16, 16, 1, 16, 8),
-        gemm.AttnTileDesc(256, 64, 256, 64, 64, 32, 8, 8, 2, 16, 16, 1, 16, 4),
-        gemm.AttnTileDesc(256, 128, 128, 64, 128, 32, 8, 8, 2, 32, 32, 1, 4, 4),
-        gemm.AttnTileDesc(256, 128, 64, 32, 128, 32, 8, 8, 2, 32, 32, 1, 2, 4),
-        # for MNKOPadding
-        gemm.AttnTileDesc(256, 128, 128, 64, 128, 32, 8, 8, 2, 32, 32, 1, 4, 4),
-        gemm.AttnTileDesc(256, 128, 64, 32, 128, 32, 8, 8, 2, 32, 32, 1, 2, 4),
-    ]
-
-    block_descriptions = [
-        gemm.BlockTransferDesc([4, 64, 1], [1, 0, 2], [1, 0, 2], 2, 8, 8, 1),
-        gemm.BlockTransferDesc([4, 64, 1], [1, 0, 2], [1, 0, 2], 2, 8, 8, 1),
-        gemm.BlockTransferDesc([4, 64, 1], [1, 0, 2], [1, 0, 2], 2, 8, 8, 1),
-        gemm.BlockTransferDesc([4, 64, 1], [1, 0, 2], [1, 0, 2], 2, 8, 8, 1),
-        gemm.BlockTransferDesc([8, 32, 1], [1, 0, 2], [1, 0, 2], 2, 8, 8, 0),
-        gemm.BlockTransferDesc([4, 64, 1], [1, 0, 2], [1, 0, 2], 2, 8, 8, 1),
-        gemm.BlockTransferDesc([8, 32, 1], [1, 0, 2], [1, 0, 2], 2, 8, 8, 0),
-        gemm.BlockTransferDesc([4, 64, 1], [1, 0, 2], [1, 0, 2], 2, 8, 8, 1),
-        gemm.BlockTransferDesc([4, 64, 1], [1, 0, 2], [1, 0, 2], 2, 8, 8, 1),
-        gemm.BlockTransferDesc([4, 64, 1], [1, 0, 2], [1, 0, 2], 2, 8, 8, 1),
-        gemm.BlockTransferDesc([8, 32, 1], [1, 0, 2], [1, 0, 2], 2, 8, 8, 1),
-        gemm.BlockTransferDesc([8, 32, 1], [1, 0, 2], [1, 0, 2], 2, 8, 8, 1),
-        gemm.BlockTransferDesc([8, 32, 1], [1, 0, 2], [1, 0, 2], 2, 8, 8, 0),
-        gemm.BlockTransferDesc([4, 64, 1], [1, 0, 2], [1, 0, 2], 2, 8, 8, 1),
-        # for MNKOPadding
-        gemm.BlockTransferDesc([8, 32, 1], [1, 0, 2], [1, 0, 2], 2, 8, 8, 0),
-        gemm.BlockTransferDesc([4, 64, 1], [1, 0, 2], [1, 0, 2], 2, 8, 8, 1),
-    ]
-    causal_mask_flag = 0
-    if causal_mask is not None:
-        causal_mask_flag = 1 if library.TensorOperationTag[causal_mask] == "True" else 0
-
-    c_block_descriptions, b1_block_descriptions = [], []
-    for i in range(len(tile_descriptions)):
-        if i in [0, 2, 4, 5, 9, 11]:
-            block_transfer = [16, 16, 1]
-        else:
-            block_transfer = [8, 32, 1]
-        b1_block_descriptions.append(
-            gemm.BlockTransferDesc(block_transfer, [0, 2, 1], [0, 2, 1], 1, 4, 2, 0)
+    for dtype, acc_dtype in dtype_acc_types:
+        a_element_desc = library.TensorDesc(
+            dtype, library.LayoutType.RowMajor
         )
+        b_element_desc = library.TensorDesc(
+            dtype, library.LayoutType.ColumnMajor
+        )
+        c_element_desc = library.TensorDesc(
+            dtype, library.LayoutType.RowMajor
+        )
+        element_op = library.TensorOperation.PassThrough
+        tile_descriptions = [
+            gemm.AttnTileDesc(256, 256, 128, 32, 64, 32, 8, 8, 2, 32, 32, 2, 4, 2),
+            gemm.AttnTileDesc(256, 256, 128, 32, 128, 32, 8, 8, 2, 32, 32, 2, 4, 4),
+            gemm.AttnTileDesc(256, 128, 256, 32, 64, 32, 8, 8, 2, 32, 32, 1, 8, 2),
+            gemm.AttnTileDesc(256, 128, 256, 32, 128, 32, 8, 8, 2, 32, 32, 1, 8, 4),
+            gemm.AttnTileDesc(256, 128, 128, 64, 64, 32, 8, 8, 2, 32, 32, 1, 4, 2),
+            gemm.AttnTileDesc(256, 128, 128, 32, 64, 32, 8, 8, 2, 32, 32, 1, 4, 2),
+            gemm.AttnTileDesc(256, 128, 128, 64, 128, 32, 8, 8, 2, 32, 32, 1, 4, 4),
+            gemm.AttnTileDesc(256, 128, 128, 32, 128, 32, 8, 8, 2, 32, 32, 1, 4, 4),
+            gemm.AttnTileDesc(256, 64, 256, 32, 128, 32, 8, 8, 2, 16, 16, 1, 16, 8),
+            gemm.AttnTileDesc(256, 64, 256, 32, 64, 32, 8, 8, 2, 16, 16, 1, 16, 4),
+            gemm.AttnTileDesc(256, 64, 256, 64, 128, 32, 8, 8, 2, 16, 16, 1, 16, 8),
+            gemm.AttnTileDesc(256, 64, 256, 64, 64, 32, 8, 8, 2, 16, 16, 1, 16, 4),
+            gemm.AttnTileDesc(256, 128, 128, 64, 128, 32, 8, 8, 2, 32, 32, 1, 4, 4),
+            gemm.AttnTileDesc(256, 128, 64, 32, 128, 32, 8, 8, 2, 32, 32, 1, 2, 4),
+            # for MNKOPadding
+            gemm.AttnTileDesc(256, 128, 128, 64, 128, 32, 8, 8, 2, 32, 32, 1, 4, 4),
+            gemm.AttnTileDesc(256, 128, 64, 32, 128, 32, 8, 8, 2, 32, 32, 1, 2, 4),
+        ]
 
-        if i in [8, 10]:
-            c_block_transfer = gemm.MaskedCBlockTransferDesc(
-                1, 8, [1, 16, 1, 16], 8, causal_mask_flag
-            )
-        else:
-            c_shuffle = 4 if i in [9, 11] else 2
-            c_block_transfer = gemm.MaskedCBlockTransferDesc(
-                1, c_shuffle, [1, 32, 1, 8], 8, causal_mask_flag
+        block_descriptions = [
+            gemm.BlockTransferDesc([4, 64, 1], [1, 0, 2], [1, 0, 2], 2, 8, 8, 1),
+            gemm.BlockTransferDesc([4, 64, 1], [1, 0, 2], [1, 0, 2], 2, 8, 8, 1),
+            gemm.BlockTransferDesc([4, 64, 1], [1, 0, 2], [1, 0, 2], 2, 8, 8, 1),
+            gemm.BlockTransferDesc([4, 64, 1], [1, 0, 2], [1, 0, 2], 2, 8, 8, 1),
+            gemm.BlockTransferDesc([8, 32, 1], [1, 0, 2], [1, 0, 2], 2, 8, 8, 0),
+            gemm.BlockTransferDesc([4, 64, 1], [1, 0, 2], [1, 0, 2], 2, 8, 8, 1),
+            gemm.BlockTransferDesc([8, 32, 1], [1, 0, 2], [1, 0, 2], 2, 8, 8, 0),
+            gemm.BlockTransferDesc([4, 64, 1], [1, 0, 2], [1, 0, 2], 2, 8, 8, 1),
+            gemm.BlockTransferDesc([4, 64, 1], [1, 0, 2], [1, 0, 2], 2, 8, 8, 1),
+            gemm.BlockTransferDesc([4, 64, 1], [1, 0, 2], [1, 0, 2], 2, 8, 8, 1),
+            gemm.BlockTransferDesc([8, 32, 1], [1, 0, 2], [1, 0, 2], 2, 8, 8, 1),
+            gemm.BlockTransferDesc([8, 32, 1], [1, 0, 2], [1, 0, 2], 2, 8, 8, 1),
+            gemm.BlockTransferDesc([8, 32, 1], [1, 0, 2], [1, 0, 2], 2, 8, 8, 0),
+            gemm.BlockTransferDesc([4, 64, 1], [1, 0, 2], [1, 0, 2], 2, 8, 8, 1),
+            # for MNKOPadding
+            gemm.BlockTransferDesc([8, 32, 1], [1, 0, 2], [1, 0, 2], 2, 8, 8, 0),
+            gemm.BlockTransferDesc([4, 64, 1], [1, 0, 2], [1, 0, 2], 2, 8, 8, 1),
+        ]
+        causal_mask_flag = 0
+        if causal_mask is not None:
+            causal_mask_flag = 1 if library.TensorOperationTag[causal_mask] == "True" else 0
+
+        c_block_descriptions, b1_block_descriptions = [], []
+        for i in range(len(tile_descriptions)):
+            if i in [0, 2, 4, 5, 9, 11]:
+                block_transfer = [16, 16, 1]
+            else:
+                block_transfer = [8, 32, 1]
+            b1_block_descriptions.append(
+                gemm.BlockTransferDesc(block_transfer, [0, 2, 1], [0, 2, 1], 1, 4, 2, 0)
             )
 
-        c_block_descriptions.append(c_block_transfer)
+            if i in [8, 10]:
+                c_block_transfer = gemm.MaskedCBlockTransferDesc(
+                    1, 8, [1, 16, 1, 16], 8, causal_mask_flag
+                )
+            else:
+                c_shuffle = 4 if i in [9, 11] else 2
+                c_block_transfer = gemm.MaskedCBlockTransferDesc(
+                    1, c_shuffle, [1, 32, 1, 8], 8, causal_mask_flag
+                )
 
-    gemm_specialization = []
-    for i in range(len(tile_descriptions)):
-        if i < 12:
-            gemm_specialization.append(gemm.GemmSpecialization.GemmDefault)
-        elif i in [12, 13]:
-            gemm_specialization.append(gemm.GemmSpecialization.MNOPadding)
-        else:
-            gemm_specialization.append(gemm.GemmSpecialization.MNKOPadding)
+            c_block_descriptions.append(c_block_transfer)
 
-    operations = []
-    extra_op = element_op if causal_mask_flag == 0 else causal_mask
-    for tile_desc, block_desc, b1_block_desc, c_block_desc, gemm_spec in zip(
-        tile_descriptions,
-        block_descriptions,
-        b1_block_descriptions,
-        c_block_descriptions,
-        gemm_specialization,
-    ):
-        new_operation = gemm.GemmOperation(
-            operation_kind=operation_kind,
-            extra_kind=extra_op,
-            xdl_op_type=xdl_op_type,
-            A=a_element_desc,
-            B=b_element_desc,
-            C=c_element_desc,
-            a_elem_op=element_op,
-            b_elem_op=element_op,
-            epilogue_functor=element_op,
-            gemm_specialization=gemm_spec,
-            tile_desc=tile_desc,
-            a_block_transfer=block_desc,
-            b_block_transfer=block_desc,
-            b1_block_transfer=b1_block_desc,
-            c_block_transfer=c_block_desc,
-        )
-        manifest.append(new_operation)
-        operations.append(new_operation)
+        gemm_specialization = []
+        for i in range(len(tile_descriptions)):
+            if i < 12:
+                gemm_specialization.append(gemm.GemmSpecialization.GemmDefault)
+            elif i in [12, 13]:
+                gemm_specialization.append(gemm.GemmSpecialization.MNOPadding)
+            else:
+                gemm_specialization.append(gemm.GemmSpecialization.MNKOPadding)
+
+        operations = []
+        extra_op = element_op if causal_mask_flag == 0 else causal_mask
+        for tile_desc, block_desc, b1_block_desc, c_block_desc, gemm_spec in zip(
+            tile_descriptions,
+            block_descriptions,
+            b1_block_descriptions,
+            c_block_descriptions,
+            gemm_specialization,
+        ):
+            new_operation = gemm.GemmOperation(
+                operation_kind=operation_kind,
+                extra_kind=extra_op,
+                xdl_op_type=xdl_op_type,
+                A=a_element_desc,
+                B=b_element_desc,
+                C=c_element_desc,
+                a_elem_op=element_op,
+                b_elem_op=element_op,
+                epilogue_functor=element_op,
+                gemm_specialization=gemm_spec,
+                tile_desc=tile_desc,
+                a_block_transfer=block_desc,
+                b_block_transfer=block_desc,
+                b1_block_transfer=b1_block_desc,
+                c_block_transfer=c_block_desc,
+                acc_dtype=acc_dtype,
+            )
+            manifest.append(new_operation)
+            operations.append(new_operation)
     return operations
 
 
 def CreateBmmRRROperator(manifest):
     operation_kind = library.GemmKind.BatchGemm
-    a_element_desc = library.TensorDesc(
-        library.DataType.f16, library.LayoutType.RowMajor
-    )
-    b_element_desc = library.TensorDesc(
-        library.DataType.f16, library.LayoutType.RowMajor
-    )
-    c_element_desc = library.TensorDesc(
-        library.DataType.f16, library.LayoutType.RowMajor
-    )
-    element_op = library.TensorOperation.PassThrough
-    # 0 indicates not print
-    tile_descriptions = [
-        gemm.TileDesc(256, 256, 128, 4, 8, 0, 32, 32, 4, 2),
-        gemm.TileDesc(256, 128, 256, 4, 8, 0, 32, 32, 2, 4),
-        gemm.TileDesc(128, 128, 128, 4, 8, 0, 32, 32, 4, 2),
-        gemm.TileDesc(256, 128, 128, 4, 8, 0, 32, 32, 2, 2),
-        gemm.TileDesc(128, 128, 64, 4, 8, 0, 32, 32, 2, 2),
-        gemm.TileDesc(128, 64, 128, 4, 8, 0, 32, 32, 2, 2),
-        gemm.TileDesc(256, 128, 64, 4, 8, 0, 32, 32, 2, 1),
-        gemm.TileDesc(256, 64, 128, 4, 8, 0, 32, 32, 1, 2),
-        gemm.TileDesc(128, 32, 256, 4, 8, 0, 32, 32, 1, 4),
-        gemm.TileDesc(128, 32, 128, 4, 8, 0, 32, 32, 1, 2),
-        gemm.TileDesc(128, 32, 64, 4, 8, 0, 32, 32, 1, 1),
-        gemm.TileDesc(64, 32, 32, 4, 8, 0, 32, 32, 1, 1),
-        gemm.TileDesc(128, 16, 256, 4, 8, 0, 16, 16, 1, 8),
-        gemm.TileDesc(128, 16, 128, 4, 8, 0, 16, 16, 1, 4),
-        gemm.TileDesc(128, 16, 64, 4, 8, 0, 16, 16, 1, 2),
-        gemm.TileDesc(128, 16, 32, 4, 8, 0, 16, 16, 1, 1),
-        gemm.TileDesc(64, 16, 16, 4, 8, 0, 16, 16, 1, 1),
-    ]
-
-    a_block_descriptions = []
-    for t in tile_descriptions:
-        a_block_transfer = -1
-        if t.block_size == 256:
-            a_block_transfer = [4, 64, 1]
-        if t.block_size == 128 and t.m_per_block != 16:
-            a_block_transfer = [4, 32, 1]
-        if t.block_size == 64 or t.m_per_block == 16:
-            a_block_transfer = [4, 16, 1]
-
-        assert a_block_transfer != -1, f"Cannot determine block_transfer_size with block_size {str(t.block_size)}"
-        a_block_descriptions.append(
-            gemm.BlockTransferDesc(
-                a_block_transfer, [1, 0, 2], [1, 0, 2], 2, 8, 8, 1, True
-            )
+    for dtype, acc_dtype in dtype_acc_types:
+        a_element_desc = library.TensorDesc(
+            dtype, library.LayoutType.RowMajor
         )
-    b_block_descriptions = [
-        gemm.BlockTransferDesc([4, 64, 1], [0, 2, 1], [0, 2, 1], 1, 2, 8, 1, True),
-        gemm.BlockTransferDesc([4, 64, 1], [0, 2, 1], [0, 2, 1], 1, 4, 8, 1, True),
-        gemm.BlockTransferDesc([4, 32, 1], [0, 2, 1], [0, 2, 1], 1, 4, 8, 1, True),
-        gemm.BlockTransferDesc([4, 64, 1], [0, 2, 1], [0, 2, 1], 1, 2, 8, 1, True),
-        gemm.BlockTransferDesc([4, 32, 1], [0, 2, 1], [0, 2, 1], 1, 2, 8, 1, True),
-        gemm.BlockTransferDesc([4, 32, 1], [0, 2, 1], [0, 2, 1], 1, 4, 8, 1, True),
-        gemm.BlockTransferDesc([4, 64, 1], [0, 2, 1], [0, 2, 1], 1, 1, 8, 1, True),
-        gemm.BlockTransferDesc([4, 64, 1], [0, 2, 1], [0, 2, 1], 1, 2, 8, 1, True),
-        gemm.BlockTransferDesc([4, 32, 1], [0, 2, 1], [0, 2, 1], 1, 8, 8, 1, True),
-        gemm.BlockTransferDesc([4, 32, 1], [0, 2, 1], [0, 2, 1], 1, 4, 8, 1, True),
-        gemm.BlockTransferDesc([4, 32, 1], [0, 2, 1], [0, 2, 1], 1, 2, 8, 1, True),
-        gemm.BlockTransferDesc([4, 16, 1], [0, 2, 1], [0, 2, 1], 1, 2, 8, 1, True),
-        gemm.BlockTransferDesc([4, 32, 1], [0, 2, 1], [0, 2, 1], 1, 8, 8, 1, True),
-        gemm.BlockTransferDesc([4, 32, 1], [0, 2, 1], [0, 2, 1], 1, 4, 8, 1, True),
-        gemm.BlockTransferDesc([4, 32, 1], [0, 2, 1], [0, 2, 1], 1, 2, 8, 1, True),
-        gemm.BlockTransferDesc([4, 32, 1], [0, 2, 1], [0, 2, 1], 1, 1, 8, 1, True),
-        gemm.BlockTransferDesc([4, 16, 1], [0, 2, 1], [0, 2, 1], 1, 1, 8, 1, True),
-    ]
-    gemm_specialization = [
-        gemm.GemmSpecialization.GemmDefault,
-        gemm.GemmSpecialization.MNKPadding,
-    ]
-    operations = []
-    for gemm_spec in gemm_specialization:
-        for tile_desc, a_block_desc, b_block_desc in zip(
-            tile_descriptions, a_block_descriptions, b_block_descriptions
-        ):
-            new_operation = gemm.GemmOperation(
-                operation_kind=operation_kind,
-                extra_kind=element_op,
-                xdl_op_type=gemm.XdlOpType.DeviceBatchedGemmXdl,
-                A=a_element_desc,
-                B=b_element_desc,
-                C=c_element_desc,
-                a_elem_op=element_op,
-                b_elem_op=element_op,
-                epilogue_functor=element_op,
-                gemm_specialization=gemm_spec,
-                tile_desc=tile_desc,
-                a_block_transfer=a_block_desc,
-                b_block_transfer=b_block_desc,
+        b_element_desc = library.TensorDesc(
+            dtype, library.LayoutType.RowMajor
+        )
+        c_element_desc = library.TensorDesc(
+            dtype, library.LayoutType.RowMajor
+        )
+        element_op = library.TensorOperation.PassThrough
+        # 0 indicates not print
+        tile_descriptions = [
+            gemm.TileDesc(256, 256, 128, 4, 8, 0, 32, 32, 4, 2),
+            gemm.TileDesc(256, 128, 256, 4, 8, 0, 32, 32, 2, 4),
+            gemm.TileDesc(128, 128, 128, 4, 8, 0, 32, 32, 4, 2),
+            gemm.TileDesc(256, 128, 128, 4, 8, 0, 32, 32, 2, 2),
+            gemm.TileDesc(128, 128, 64, 4, 8, 0, 32, 32, 2, 2),
+            gemm.TileDesc(128, 64, 128, 4, 8, 0, 32, 32, 2, 2),
+            gemm.TileDesc(256, 128, 64, 4, 8, 0, 32, 32, 2, 1),
+            gemm.TileDesc(256, 64, 128, 4, 8, 0, 32, 32, 1, 2),
+            gemm.TileDesc(128, 32, 256, 4, 8, 0, 32, 32, 1, 4),
+            gemm.TileDesc(128, 32, 128, 4, 8, 0, 32, 32, 1, 2),
+            gemm.TileDesc(128, 32, 64, 4, 8, 0, 32, 32, 1, 1),
+            gemm.TileDesc(64, 32, 32, 4, 8, 0, 32, 32, 1, 1),
+            gemm.TileDesc(128, 16, 256, 4, 8, 0, 16, 16, 1, 8),
+            gemm.TileDesc(128, 16, 128, 4, 8, 0, 16, 16, 1, 4),
+            gemm.TileDesc(128, 16, 64, 4, 8, 0, 16, 16, 1, 2),
+            gemm.TileDesc(128, 16, 32, 4, 8, 0, 16, 16, 1, 1),
+            gemm.TileDesc(64, 16, 16, 4, 8, 0, 16, 16, 1, 1),
+        ]
+
+        a_block_descriptions = []
+        for t in tile_descriptions:
+            a_block_transfer = -1
+            if t.block_size == 256:
+                a_block_transfer = [4, 64, 1]
+            if t.block_size == 128 and t.m_per_block != 16:
+                a_block_transfer = [4, 32, 1]
+            if t.block_size == 64 or t.m_per_block == 16:
+                a_block_transfer = [4, 16, 1]
+
+            assert a_block_transfer != -1, f"Cannot determine block_transfer_size with block_size {str(t.block_size)}"
+            a_block_descriptions.append(
+                gemm.BlockTransferDesc(
+                    a_block_transfer, [1, 0, 2], [1, 0, 2], 2, 8, 8, 1, True
+                )
             )
-            manifest.append(new_operation)
-            operations.append(new_operation)
+        b_block_descriptions = [
+            gemm.BlockTransferDesc([4, 64, 1], [0, 2, 1], [0, 2, 1], 1, 2, 8, 1, True),
+            gemm.BlockTransferDesc([4, 64, 1], [0, 2, 1], [0, 2, 1], 1, 4, 8, 1, True),
+            gemm.BlockTransferDesc([4, 32, 1], [0, 2, 1], [0, 2, 1], 1, 4, 8, 1, True),
+            gemm.BlockTransferDesc([4, 64, 1], [0, 2, 1], [0, 2, 1], 1, 2, 8, 1, True),
+            gemm.BlockTransferDesc([4, 32, 1], [0, 2, 1], [0, 2, 1], 1, 2, 8, 1, True),
+            gemm.BlockTransferDesc([4, 32, 1], [0, 2, 1], [0, 2, 1], 1, 4, 8, 1, True),
+            gemm.BlockTransferDesc([4, 64, 1], [0, 2, 1], [0, 2, 1], 1, 1, 8, 1, True),
+            gemm.BlockTransferDesc([4, 64, 1], [0, 2, 1], [0, 2, 1], 1, 2, 8, 1, True),
+            gemm.BlockTransferDesc([4, 32, 1], [0, 2, 1], [0, 2, 1], 1, 8, 8, 1, True),
+            gemm.BlockTransferDesc([4, 32, 1], [0, 2, 1], [0, 2, 1], 1, 4, 8, 1, True),
+            gemm.BlockTransferDesc([4, 32, 1], [0, 2, 1], [0, 2, 1], 1, 2, 8, 1, True),
+            gemm.BlockTransferDesc([4, 16, 1], [0, 2, 1], [0, 2, 1], 1, 2, 8, 1, True),
+            gemm.BlockTransferDesc([4, 32, 1], [0, 2, 1], [0, 2, 1], 1, 8, 8, 1, True),
+            gemm.BlockTransferDesc([4, 32, 1], [0, 2, 1], [0, 2, 1], 1, 4, 8, 1, True),
+            gemm.BlockTransferDesc([4, 32, 1], [0, 2, 1], [0, 2, 1], 1, 2, 8, 1, True),
+            gemm.BlockTransferDesc([4, 32, 1], [0, 2, 1], [0, 2, 1], 1, 1, 8, 1, True),
+            gemm.BlockTransferDesc([4, 16, 1], [0, 2, 1], [0, 2, 1], 1, 1, 8, 1, True),
+        ]
+        gemm_specialization = [
+            gemm.GemmSpecialization.GemmDefault,
+            gemm.GemmSpecialization.MNKPadding,
+        ]
+        operations = []
+        for gemm_spec in gemm_specialization:
+            for tile_desc, a_block_desc, b_block_desc in zip(
+                tile_descriptions, a_block_descriptions, b_block_descriptions
+            ):
+                new_operation = gemm.GemmOperation(
+                    operation_kind=operation_kind,
+                    extra_kind=element_op,
+                    xdl_op_type=gemm.XdlOpType.DeviceBatchedGemmXdl,
+                    A=a_element_desc,
+                    B=b_element_desc,
+                    C=c_element_desc,
+                    a_elem_op=element_op,
+                    b_elem_op=element_op,
+                    epilogue_functor=element_op,
+                    gemm_specialization=gemm_spec,
+                    tile_desc=tile_desc,
+                    a_block_transfer=a_block_desc,
+                    b_block_transfer=b_block_desc,
+                    acc_dtype=acc_dtype,
+                )
+                manifest.append(new_operation)
+                operations.append(new_operation)
     return operations
 
 
 def CreateBmmRRRBillinearOperator(manifest, c_element_op):
     operation_kind = library.GemmKind.BatchGemm
-    a_element_desc = library.TensorDesc(
-        library.DataType.f16, library.LayoutType.RowMajor
-    )
-    b_element_desc = library.TensorDesc(
-        library.DataType.f16, library.LayoutType.RowMajor
-    )
-    c_element_desc = library.TensorDesc(
-        library.DataType.f16, library.LayoutType.RowMajor
-    )
-    element_op = library.TensorOperation.PassThrough
-    # 0 indicates not print
-    tile_descriptions = [
-        gemm.TileDesc(256, 256, 128, 32, 8, 2, 32, 32, 4, 2),
-        gemm.TileDesc(256, 256, 128, 32, 8, 8, 32, 32, 4, 2),
-        gemm.TileDesc(256, 128, 256, 32, 8, 2, 32, 32, 2, 4),
-        gemm.TileDesc(256, 128, 256, 32, 8, 8, 32, 32, 2, 4),
-        gemm.TileDesc(128, 128, 128, 32, 8, 2, 32, 32, 4, 2),
-        gemm.TileDesc(128, 128, 128, 32, 8, 8, 32, 32, 4, 2),
-        gemm.TileDesc(256, 128, 128, 32, 8, 2, 32, 32, 2, 2),
-        gemm.TileDesc(256, 128, 128, 32, 8, 8, 32, 32, 2, 2),
-        gemm.TileDesc(128, 128, 64, 32, 8, 2, 32, 32, 2, 2),
-        gemm.TileDesc(128, 128, 64, 32, 8, 8, 32, 32, 2, 2),
-        gemm.TileDesc(128, 64, 128, 32, 8, 2, 32, 32, 2, 2),
-        gemm.TileDesc(128, 64, 128, 32, 8, 8, 32, 32, 2, 2),
-        gemm.TileDesc(256, 128, 64, 32, 8, 2, 32, 32, 2, 1),
-        gemm.TileDesc(256, 128, 64, 32, 8, 8, 32, 32, 2, 1),
-        gemm.TileDesc(256, 64, 128, 32, 8, 2, 32, 32, 1, 2),
-        gemm.TileDesc(256, 64, 128, 32, 8, 8, 32, 32, 1, 2),
-    ]
-
-    a_block_descriptions = []
-    c_block_descriptions = []
-    for t in tile_descriptions:
-        a_block_transfer = -1
-        c_block_transfer = -1
-        if t.block_size == 256:
-            a_block_transfer = [4, 64, 1]
-            c_block_transfer = gemm.CBlockTransferDesc(1, 1, [1, 32, 1, 8], 8)
-        if t.block_size == 128 and t.n_per_block != 64:
-            a_block_transfer = [4, 32, 1]
-            c_block_transfer = gemm.CBlockTransferDesc(1, 1, [1, 16, 1, 8], 8)
-        if t.block_size == 128 and t.n_per_block == 64:
-            a_block_transfer = [4, 32, 1]
-            c_block_transfer = gemm.CBlockTransferDesc(1, 1, [1, 32, 1, 4], 8)
-
-        assert a_block_transfer != -1 and c_block_transfer != -1 ,"Cannot determine block_transfer_size with block_size " + str(t.block_size)
-        a_block_descriptions.append(
-            gemm.BlockTransferDesc(
-                a_block_transfer, [1, 0, 2], [1, 0, 2], 2, 8, 8, 1, True
-            )
+    for dtype, acc_dtype in dtype_acc_types:
+        a_element_desc = library.TensorDesc(
+            dtype, library.LayoutType.RowMajor
         )
-        c_block_descriptions.append(c_block_transfer)
-    b_block_descriptions = [
-        gemm.BlockTransferDesc([8, 32, 1], [0, 2, 1], [0, 2, 1], 1, 4, 2, 0, True),
-        gemm.BlockTransferDesc([4, 64, 1], [0, 2, 1], [0, 2, 1], 1, 2, 8, 1, True),
-        gemm.BlockTransferDesc([4, 64, 1], [0, 2, 1], [0, 2, 1], 1, 4, 2, 0, True),
-        gemm.BlockTransferDesc([4, 64, 1], [0, 2, 1], [0, 2, 1], 1, 4, 8, 1, True),
-        gemm.BlockTransferDesc([4, 32, 1], [0, 2, 1], [0, 2, 1], 1, 4, 2, 0, True),
-        gemm.BlockTransferDesc([4, 32, 1], [0, 2, 1], [0, 2, 1], 1, 4, 8, 1, True),
-        gemm.BlockTransferDesc([8, 32, 1], [0, 2, 1], [0, 2, 1], 1, 4, 2, 0, True),
-        gemm.BlockTransferDesc([4, 64, 1], [0, 2, 1], [0, 2, 1], 1, 2, 8, 1, True),
-        gemm.BlockTransferDesc([8, 16, 1], [0, 2, 1], [0, 2, 1], 1, 4, 2, 0, True),
-        gemm.BlockTransferDesc([4, 32, 1], [0, 2, 1], [0, 2, 1], 1, 2, 8, 1, True),
-        gemm.BlockTransferDesc([4, 32, 1], [0, 2, 1], [0, 2, 1], 1, 4, 2, 0, True),
-        gemm.BlockTransferDesc([4, 32, 1], [0, 2, 1], [0, 2, 1], 1, 4, 8, 1, True),
-        gemm.BlockTransferDesc([16, 16, 1], [0, 2, 1], [0, 2, 1], 1, 4, 2, 0, True),
-        gemm.BlockTransferDesc([4, 64, 1], [0, 2, 1], [0, 2, 1], 1, 1, 8, 1, True),
-        gemm.BlockTransferDesc([8, 32, 1], [0, 2, 1], [0, 2, 1], 1, 4, 2, 0, True),
-        gemm.BlockTransferDesc([4, 64, 1], [0, 2, 1], [0, 2, 1], 1, 2, 8, 1, True),
-    ]
-    gemm_specialization = [
-        gemm.GemmSpecialization.GemmDefault,
-        gemm.GemmSpecialization.MNKPadding,
-    ]
-    operations = []
-    ds_dtype = [library.DataType.f16]
-    ds_layout = [library.LayoutType.RowMajor]
-    e_dtype = library.DataType.f16
-    for gemm_spec in gemm_specialization:
-        for tile_desc, a_block_desc, b_block_desc, c_block_desc in zip(
-            tile_descriptions,
-            a_block_descriptions,
-            b_block_descriptions,
-            c_block_descriptions,
-        ):
-            new_operation = gemm.GemmOperation(
-                operation_kind=operation_kind,
-                extra_kind=c_element_op,
-                xdl_op_type=gemm.XdlOpType.DeviceBatchedGemmMultiD_Xdl,
-                A=a_element_desc,
-                B=b_element_desc,
-                C=c_element_desc,
-                a_elem_op=element_op,
-                b_elem_op=element_op,
-                epilogue_functor=c_element_op,
-                gemm_specialization=gemm_spec,
-                tile_desc=tile_desc,
-                a_block_transfer=a_block_desc,
-                b_block_transfer=b_block_desc,
-                c_block_transfer=c_block_desc,
-                ds_dtype=ds_dtype,
-                ds_layout=ds_layout,
-                e_dtype=e_dtype,
+        b_element_desc = library.TensorDesc(
+            dtype, library.LayoutType.RowMajor
+        )
+        c_element_desc = library.TensorDesc(
+            dtype, library.LayoutType.RowMajor
+        )
+        element_op = library.TensorOperation.PassThrough
+        # 0 indicates not print
+        tile_descriptions = [
+            gemm.TileDesc(256, 256, 128, 32, 8, 2, 32, 32, 4, 2),
+            gemm.TileDesc(256, 256, 128, 32, 8, 8, 32, 32, 4, 2),
+            gemm.TileDesc(256, 128, 256, 32, 8, 2, 32, 32, 2, 4),
+            gemm.TileDesc(256, 128, 256, 32, 8, 8, 32, 32, 2, 4),
+            gemm.TileDesc(128, 128, 128, 32, 8, 2, 32, 32, 4, 2),
+            gemm.TileDesc(128, 128, 128, 32, 8, 8, 32, 32, 4, 2),
+            gemm.TileDesc(256, 128, 128, 32, 8, 2, 32, 32, 2, 2),
+            gemm.TileDesc(256, 128, 128, 32, 8, 8, 32, 32, 2, 2),
+            gemm.TileDesc(128, 128, 64, 32, 8, 2, 32, 32, 2, 2),
+            gemm.TileDesc(128, 128, 64, 32, 8, 8, 32, 32, 2, 2),
+            gemm.TileDesc(128, 64, 128, 32, 8, 2, 32, 32, 2, 2),
+            gemm.TileDesc(128, 64, 128, 32, 8, 8, 32, 32, 2, 2),
+            gemm.TileDesc(256, 128, 64, 32, 8, 2, 32, 32, 2, 1),
+            gemm.TileDesc(256, 128, 64, 32, 8, 8, 32, 32, 2, 1),
+            gemm.TileDesc(256, 64, 128, 32, 8, 2, 32, 32, 1, 2),
+            gemm.TileDesc(256, 64, 128, 32, 8, 8, 32, 32, 1, 2),
+        ]
+
+        a_block_descriptions = []
+        c_block_descriptions = []
+        for t in tile_descriptions:
+            a_block_transfer = -1
+            c_block_transfer = -1
+            if t.block_size == 256:
+                a_block_transfer = [4, 64, 1]
+                c_block_transfer = gemm.CBlockTransferDesc(1, 1, [1, 32, 1, 8], 8)
+            if t.block_size == 128 and t.n_per_block != 64:
+                a_block_transfer = [4, 32, 1]
+                c_block_transfer = gemm.CBlockTransferDesc(1, 1, [1, 16, 1, 8], 8)
+            if t.block_size == 128 and t.n_per_block == 64:
+                a_block_transfer = [4, 32, 1]
+                c_block_transfer = gemm.CBlockTransferDesc(1, 1, [1, 32, 1, 4], 8)
+
+            assert a_block_transfer != -1 and c_block_transfer != -1 ,"Cannot determine block_transfer_size with block_size " + str(t.block_size)
+            a_block_descriptions.append(
+                gemm.BlockTransferDesc(
+                    a_block_transfer, [1, 0, 2], [1, 0, 2], 2, 8, 8, 1, True
+                )
             )
-            manifest.append(new_operation)
-            operations.append(new_operation)
+            c_block_descriptions.append(c_block_transfer)
+        b_block_descriptions = [
+            gemm.BlockTransferDesc([8, 32, 1], [0, 2, 1], [0, 2, 1], 1, 4, 2, 0, True),
+            gemm.BlockTransferDesc([4, 64, 1], [0, 2, 1], [0, 2, 1], 1, 2, 8, 1, True),
+            gemm.BlockTransferDesc([4, 64, 1], [0, 2, 1], [0, 2, 1], 1, 4, 2, 0, True),
+            gemm.BlockTransferDesc([4, 64, 1], [0, 2, 1], [0, 2, 1], 1, 4, 8, 1, True),
+            gemm.BlockTransferDesc([4, 32, 1], [0, 2, 1], [0, 2, 1], 1, 4, 2, 0, True),
+            gemm.BlockTransferDesc([4, 32, 1], [0, 2, 1], [0, 2, 1], 1, 4, 8, 1, True),
+            gemm.BlockTransferDesc([8, 32, 1], [0, 2, 1], [0, 2, 1], 1, 4, 2, 0, True),
+            gemm.BlockTransferDesc([4, 64, 1], [0, 2, 1], [0, 2, 1], 1, 2, 8, 1, True),
+            gemm.BlockTransferDesc([8, 16, 1], [0, 2, 1], [0, 2, 1], 1, 4, 2, 0, True),
+            gemm.BlockTransferDesc([4, 32, 1], [0, 2, 1], [0, 2, 1], 1, 2, 8, 1, True),
+            gemm.BlockTransferDesc([4, 32, 1], [0, 2, 1], [0, 2, 1], 1, 4, 2, 0, True),
+            gemm.BlockTransferDesc([4, 32, 1], [0, 2, 1], [0, 2, 1], 1, 4, 8, 1, True),
+            gemm.BlockTransferDesc([16, 16, 1], [0, 2, 1], [0, 2, 1], 1, 4, 2, 0, True),
+            gemm.BlockTransferDesc([4, 64, 1], [0, 2, 1], [0, 2, 1], 1, 1, 8, 1, True),
+            gemm.BlockTransferDesc([8, 32, 1], [0, 2, 1], [0, 2, 1], 1, 4, 2, 0, True),
+            gemm.BlockTransferDesc([4, 64, 1], [0, 2, 1], [0, 2, 1], 1, 2, 8, 1, True),
+        ]
+        gemm_specialization = [
+            gemm.GemmSpecialization.GemmDefault,
+            gemm.GemmSpecialization.MNKPadding,
+        ]
+        operations = []
+        ds_dtype = [dtype]
+        ds_layout = [library.LayoutType.RowMajor]
+        e_dtype = dtype
+        for gemm_spec in gemm_specialization:
+            for tile_desc, a_block_desc, b_block_desc, c_block_desc in zip(
+                tile_descriptions,
+                a_block_descriptions,
+                b_block_descriptions,
+                c_block_descriptions,
+            ):
+                new_operation = gemm.GemmOperation(
+                    operation_kind=operation_kind,
+                    extra_kind=c_element_op,
+                    xdl_op_type=gemm.XdlOpType.DeviceBatchedGemmMultiD_Xdl,
+                    A=a_element_desc,
+                    B=b_element_desc,
+                    C=c_element_desc,
+                    a_elem_op=element_op,
+                    b_elem_op=element_op,
+                    epilogue_functor=c_element_op,
+                    gemm_specialization=gemm_spec,
+                    tile_desc=tile_desc,
+                    a_block_transfer=a_block_desc,
+                    b_block_transfer=b_block_desc,
+                    c_block_transfer=c_block_desc,
+                    ds_dtype=ds_dtype,
+                    ds_layout=ds_layout,
+                    e_dtype=e_dtype,
+                    acc_dtype=acc_dtype,
+                )
+                manifest.append(new_operation)
+                operations.append(new_operation)
     return operations
 
 
 def CreateBmmCCRBillinearOperator(manifest, c_element_op):
     operation_kind = library.GemmKind.BatchGemm
-    a_element_desc = library.TensorDesc(
-        library.DataType.f16, library.LayoutType.ColumnMajor
-    )
-    b_element_desc = library.TensorDesc(
-        library.DataType.f16, library.LayoutType.ColumnMajor
-    )
-    c_element_desc = library.TensorDesc(
-        library.DataType.f16, library.LayoutType.RowMajor
-    )
-    element_op = library.TensorOperation.PassThrough
-    # 0 indicates not print
-    tile_descriptions = [
-        gemm.TileDesc(256, 256, 128, 32, 2, 8, 32, 32, 4, 2),
-        gemm.TileDesc(256, 256, 128, 32, 8, 8, 32, 32, 4, 2),
-        gemm.TileDesc(256, 128, 256, 32, 2, 8, 32, 32, 2, 4),
-        gemm.TileDesc(256, 128, 256, 32, 8, 8, 32, 32, 2, 4),
-        gemm.TileDesc(128, 128, 128, 32, 2, 8, 32, 32, 4, 2),
-        gemm.TileDesc(128, 128, 128, 32, 8, 8, 32, 32, 4, 2),
-        gemm.TileDesc(256, 128, 128, 32, 2, 8, 32, 32, 2, 2),
-        gemm.TileDesc(256, 128, 128, 32, 8, 8, 32, 32, 2, 2),
-        gemm.TileDesc(128, 128, 64, 32, 2, 8, 32, 32, 2, 2),
-        gemm.TileDesc(128, 128, 64, 32, 8, 8, 32, 32, 2, 2),
-        gemm.TileDesc(128, 64, 128, 32, 2, 8, 32, 32, 2, 2),
-        gemm.TileDesc(128, 64, 128, 32, 8, 8, 32, 32, 2, 2),
-        gemm.TileDesc(256, 128, 64, 32, 2, 8, 32, 32, 2, 1),
-        gemm.TileDesc(256, 128, 64, 32, 8, 8, 32, 32, 2, 1),
-        gemm.TileDesc(256, 64, 128, 32, 2, 8, 32, 32, 1, 2),
-        gemm.TileDesc(256, 64, 128, 32, 8, 8, 32, 32, 1, 2),
-    ]
-
-    b_block_descriptions = []
-    c_block_descriptions = []
-    for t in tile_descriptions:
-        b_block_transfer = -1
-        c_block_transfer = -1
-        if t.block_size == 256:
-            b_block_transfer = [4, 64, 1]
-            c_block_transfer = gemm.CBlockTransferDesc(1, 1, [1, 32, 1, 8], 8)
-        if t.block_size == 128 and t.n_per_block != 64:
-            b_block_transfer = [4, 32, 1]
-            c_block_transfer = gemm.CBlockTransferDesc(1, 1, [1, 16, 1, 8], 8)
-        if t.block_size == 128 and t.n_per_block == 64:
-            b_block_transfer = [4, 32, 1]
-            c_block_transfer = gemm.CBlockTransferDesc(1, 1, [1, 32, 1, 4], 8)
-
-        assert b_block_transfer != -1 and c_block_transfer != -1, f"Cannot determine block_transfer_size with block_size {str(t.block_size)}"
-        b_block_descriptions.append(
-            gemm.BlockTransferDesc(
-                b_block_transfer, [1, 0, 2], [1, 0, 2], 2, 8, 8, 1, True
-            )
+    for dtype, acc_dtype in dtype_acc_types:
+        a_element_desc = library.TensorDesc(
+            dtype, library.LayoutType.ColumnMajor
         )
-        c_block_descriptions.append(c_block_transfer)
-    a_block_descriptions = [
-        gemm.BlockTransferDesc([4, 64, 1], [0, 2, 1], [0, 2, 1], 1, 4, 2, 0, True),
-        gemm.BlockTransferDesc([4, 64, 1], [0, 2, 1], [0, 2, 1], 1, 4, 8, 1, True),
-        gemm.BlockTransferDesc([8, 32, 1], [0, 2, 1], [0, 2, 1], 1, 4, 2, 0, True),
-        gemm.BlockTransferDesc([4, 64, 1], [0, 2, 1], [0, 2, 1], 1, 2, 8, 1, True),
-        gemm.BlockTransferDesc([4, 32, 1], [0, 2, 1], [0, 2, 1], 1, 4, 2, 0, True),
-        gemm.BlockTransferDesc([4, 32, 1], [0, 2, 1], [0, 2, 1], 1, 4, 8, 1, True),
-        gemm.BlockTransferDesc([8, 32, 1], [0, 2, 1], [0, 2, 1], 1, 4, 2, 0, True),
-        gemm.BlockTransferDesc([4, 64, 1], [0, 2, 1], [0, 2, 1], 1, 2, 8, 1, True),
-        gemm.BlockTransferDesc([4, 32, 1], [0, 2, 1], [0, 2, 1], 1, 4, 2, 0, True),
-        gemm.BlockTransferDesc([4, 32, 1], [0, 2, 1], [0, 2, 1], 1, 4, 8, 1, True),
-        gemm.BlockTransferDesc([8, 16, 1], [0, 2, 1], [0, 2, 1], 1, 4, 2, 0, True),
-        gemm.BlockTransferDesc([4, 32, 1], [0, 2, 1], [0, 2, 1], 1, 2, 8, 1, True),
-        gemm.BlockTransferDesc([8, 32, 1], [0, 2, 1], [0, 2, 1], 1, 4, 2, 0, True),
-        gemm.BlockTransferDesc([4, 64, 1], [0, 2, 1], [0, 2, 1], 1, 2, 8, 1, True),
-        gemm.BlockTransferDesc([16, 16, 1], [0, 2, 1], [0, 2, 1], 1, 4, 2, 0, True),
-        gemm.BlockTransferDesc([4, 64, 1], [0, 2, 1], [0, 2, 1], 1, 1, 8, 1, True),
-    ]
-    gemm_specialization = [
-        gemm.GemmSpecialization.GemmDefault,
-        gemm.GemmSpecialization.MNKPadding,
-    ]
-    operations = []
-    ds_dtype = [library.DataType.f16]
-    ds_layout = [library.LayoutType.RowMajor]
-    e_dtype = library.DataType.f16
-    for gemm_spec in gemm_specialization:
-        for tile_desc, a_block_desc, b_block_desc, c_block_desc in zip(
-            tile_descriptions,
-            a_block_descriptions,
-            b_block_descriptions,
-            c_block_descriptions,
-        ):
-            new_operation = gemm.GemmOperation(
-                operation_kind=operation_kind,
-                extra_kind=c_element_op,
-                xdl_op_type=gemm.XdlOpType.DeviceBatchedGemmMultiD_Xdl,
-                A=a_element_desc,
-                B=b_element_desc,
-                C=c_element_desc,
-                a_elem_op=element_op,
-                b_elem_op=element_op,
-                epilogue_functor=c_element_op,
-                gemm_specialization=gemm_spec,
-                tile_desc=tile_desc,
-                a_block_transfer=a_block_desc,
-                b_block_transfer=b_block_desc,
-                c_block_transfer=c_block_desc,
-                ds_dtype=ds_dtype,
-                ds_layout=ds_layout,
-                e_dtype=e_dtype,
+        b_element_desc = library.TensorDesc(
+            dtype, library.LayoutType.ColumnMajor
+        )
+        c_element_desc = library.TensorDesc(
+            dtype, library.LayoutType.RowMajor
+        )
+        element_op = library.TensorOperation.PassThrough
+        # 0 indicates not print
+        tile_descriptions = [
+            gemm.TileDesc(256, 256, 128, 32, 2, 8, 32, 32, 4, 2),
+            gemm.TileDesc(256, 256, 128, 32, 8, 8, 32, 32, 4, 2),
+            gemm.TileDesc(256, 128, 256, 32, 2, 8, 32, 32, 2, 4),
+            gemm.TileDesc(256, 128, 256, 32, 8, 8, 32, 32, 2, 4),
+            gemm.TileDesc(128, 128, 128, 32, 2, 8, 32, 32, 4, 2),
+            gemm.TileDesc(128, 128, 128, 32, 8, 8, 32, 32, 4, 2),
+            gemm.TileDesc(256, 128, 128, 32, 2, 8, 32, 32, 2, 2),
+            gemm.TileDesc(256, 128, 128, 32, 8, 8, 32, 32, 2, 2),
+            gemm.TileDesc(128, 128, 64, 32, 2, 8, 32, 32, 2, 2),
+            gemm.TileDesc(128, 128, 64, 32, 8, 8, 32, 32, 2, 2),
+            gemm.TileDesc(128, 64, 128, 32, 2, 8, 32, 32, 2, 2),
+            gemm.TileDesc(128, 64, 128, 32, 8, 8, 32, 32, 2, 2),
+            gemm.TileDesc(256, 128, 64, 32, 2, 8, 32, 32, 2, 1),
+            gemm.TileDesc(256, 128, 64, 32, 8, 8, 32, 32, 2, 1),
+            gemm.TileDesc(256, 64, 128, 32, 2, 8, 32, 32, 1, 2),
+            gemm.TileDesc(256, 64, 128, 32, 8, 8, 32, 32, 1, 2),
+        ]
+
+        b_block_descriptions = []
+        c_block_descriptions = []
+        for t in tile_descriptions:
+            b_block_transfer = -1
+            c_block_transfer = -1
+            if t.block_size == 256:
+                b_block_transfer = [4, 64, 1]
+                c_block_transfer = gemm.CBlockTransferDesc(1, 1, [1, 32, 1, 8], 8)
+            if t.block_size == 128 and t.n_per_block != 64:
+                b_block_transfer = [4, 32, 1]
+                c_block_transfer = gemm.CBlockTransferDesc(1, 1, [1, 16, 1, 8], 8)
+            if t.block_size == 128 and t.n_per_block == 64:
+                b_block_transfer = [4, 32, 1]
+                c_block_transfer = gemm.CBlockTransferDesc(1, 1, [1, 32, 1, 4], 8)
+
+            assert b_block_transfer != -1 and c_block_transfer != -1, f"Cannot determine block_transfer_size with block_size {str(t.block_size)}"
+            b_block_descriptions.append(
+                gemm.BlockTransferDesc(
+                    b_block_transfer, [1, 0, 2], [1, 0, 2], 2, 8, 8, 1, True
+                )
             )
-            manifest.append(new_operation)
-            operations.append(new_operation)
+            c_block_descriptions.append(c_block_transfer)
+        a_block_descriptions = [
+            gemm.BlockTransferDesc([4, 64, 1], [0, 2, 1], [0, 2, 1], 1, 4, 2, 0, True),
+            gemm.BlockTransferDesc([4, 64, 1], [0, 2, 1], [0, 2, 1], 1, 4, 8, 1, True),
+            gemm.BlockTransferDesc([8, 32, 1], [0, 2, 1], [0, 2, 1], 1, 4, 2, 0, True),
+            gemm.BlockTransferDesc([4, 64, 1], [0, 2, 1], [0, 2, 1], 1, 2, 8, 1, True),
+            gemm.BlockTransferDesc([4, 32, 1], [0, 2, 1], [0, 2, 1], 1, 4, 2, 0, True),
+            gemm.BlockTransferDesc([4, 32, 1], [0, 2, 1], [0, 2, 1], 1, 4, 8, 1, True),
+            gemm.BlockTransferDesc([8, 32, 1], [0, 2, 1], [0, 2, 1], 1, 4, 2, 0, True),
+            gemm.BlockTransferDesc([4, 64, 1], [0, 2, 1], [0, 2, 1], 1, 2, 8, 1, True),
+            gemm.BlockTransferDesc([4, 32, 1], [0, 2, 1], [0, 2, 1], 1, 4, 2, 0, True),
+            gemm.BlockTransferDesc([4, 32, 1], [0, 2, 1], [0, 2, 1], 1, 4, 8, 1, True),
+            gemm.BlockTransferDesc([8, 16, 1], [0, 2, 1], [0, 2, 1], 1, 4, 2, 0, True),
+            gemm.BlockTransferDesc([4, 32, 1], [0, 2, 1], [0, 2, 1], 1, 2, 8, 1, True),
+            gemm.BlockTransferDesc([8, 32, 1], [0, 2, 1], [0, 2, 1], 1, 4, 2, 0, True),
+            gemm.BlockTransferDesc([4, 64, 1], [0, 2, 1], [0, 2, 1], 1, 2, 8, 1, True),
+            gemm.BlockTransferDesc([16, 16, 1], [0, 2, 1], [0, 2, 1], 1, 4, 2, 0, True),
+            gemm.BlockTransferDesc([4, 64, 1], [0, 2, 1], [0, 2, 1], 1, 1, 8, 1, True),
+        ]
+        gemm_specialization = [
+            gemm.GemmSpecialization.GemmDefault,
+            gemm.GemmSpecialization.MNKPadding,
+        ]
+        operations = []
+        ds_dtype = [dtype]
+        ds_layout = [library.LayoutType.RowMajor]
+        e_dtype = dtype
+        for gemm_spec in gemm_specialization:
+            for tile_desc, a_block_desc, b_block_desc, c_block_desc in zip(
+                tile_descriptions,
+                a_block_descriptions,
+                b_block_descriptions,
+                c_block_descriptions,
+            ):
+                new_operation = gemm.GemmOperation(
+                    operation_kind=operation_kind,
+                    extra_kind=c_element_op,
+                    xdl_op_type=gemm.XdlOpType.DeviceBatchedGemmMultiD_Xdl,
+                    A=a_element_desc,
+                    B=b_element_desc,
+                    C=c_element_desc,
+                    a_elem_op=element_op,
+                    b_elem_op=element_op,
+                    epilogue_functor=c_element_op,
+                    gemm_specialization=gemm_spec,
+                    tile_desc=tile_desc,
+                    a_block_transfer=a_block_desc,
+                    b_block_transfer=b_block_desc,
+                    c_block_transfer=c_block_desc,
+                    ds_dtype=ds_dtype,
+                    ds_layout=ds_layout,
+                    e_dtype=e_dtype,
+                    acc_dtype=acc_dtype,
+                )
+                manifest.append(new_operation)
+                operations.append(new_operation)
     return operations
 
 
 def CreateBmmCRRBillinearOperator(manifest, c_element_op):
     operation_kind = library.GemmKind.BatchGemm
-    a_element_desc = library.TensorDesc(
-        library.DataType.f16, library.LayoutType.ColumnMajor
-    )
-    b_element_desc = library.TensorDesc(
-        library.DataType.f16, library.LayoutType.RowMajor
-    )
-    c_element_desc = library.TensorDesc(
-        library.DataType.f16, library.LayoutType.RowMajor
-    )
-    element_op = library.TensorOperation.PassThrough
-    # 0 indicates not print
-    tile_descriptions = [
-        gemm.TileDesc(256, 256, 128, 32, 2, 2, 32, 32, 4, 2),
-        gemm.TileDesc(256, 256, 128, 32, 8, 8, 32, 32, 4, 2),
-        gemm.TileDesc(256, 128, 256, 32, 2, 2, 32, 32, 2, 4),
-        gemm.TileDesc(256, 128, 256, 32, 8, 8, 32, 32, 2, 4),
-        gemm.TileDesc(128, 128, 128, 32, 2, 2, 32, 32, 4, 2),
-        gemm.TileDesc(128, 128, 128, 32, 8, 8, 32, 32, 4, 2),
-        gemm.TileDesc(256, 128, 128, 32, 2, 2, 32, 32, 2, 2),
-        gemm.TileDesc(256, 128, 128, 32, 8, 8, 32, 32, 2, 2),
-        gemm.TileDesc(128, 128, 64, 32, 2, 2, 32, 32, 2, 2),
-        gemm.TileDesc(128, 128, 64, 32, 8, 8, 32, 32, 2, 2),
-        gemm.TileDesc(128, 64, 128, 32, 2, 2, 32, 32, 2, 2),
-        gemm.TileDesc(128, 64, 128, 32, 8, 8, 32, 32, 2, 2),
-        gemm.TileDesc(256, 128, 64, 32, 2, 2, 32, 32, 2, 1),
-        gemm.TileDesc(256, 128, 64, 32, 8, 8, 32, 32, 2, 1),
-        gemm.TileDesc(256, 64, 128, 32, 2, 2, 32, 32, 1, 2),
-        gemm.TileDesc(256, 64, 128, 32, 8, 8, 32, 32, 1, 2),
-    ]
-
-    b_block_descriptions = []
-    c_block_descriptions = []
-    for t in tile_descriptions:
-        b_block_transfer = -1
-        c_block_transfer = -1
-        if t.block_size == 256:
-            b_block_transfer = [4, 64, 1]
-            c_block_transfer = gemm.CBlockTransferDesc(1, 1, [1, 32, 1, 8], 8)
-        if t.block_size == 128 and t.n_per_block != 64:
-            b_block_transfer = [4, 32, 1]
-            c_block_transfer = gemm.CBlockTransferDesc(1, 1, [1, 16, 1, 8], 8)
-        if t.block_size == 128 and t.n_per_block == 64:
-            b_block_transfer = [4, 32, 1]
-            c_block_transfer = gemm.CBlockTransferDesc(1, 1, [1, 32, 1, 4], 8)
-
-        assert b_block_transfer != -1 and c_block_transfer != -1, f"Cannot determine block_transfer_size with block_size {str(t.block_size)}"
-        b_block_descriptions.append(
-            gemm.BlockTransferDesc(
-                b_block_transfer, [1, 0, 2], [1, 0, 2], 2, 8, 8, 1, True
-            )
+    for dtype, acc_dtype in dtype_acc_types:
+        a_element_desc = library.TensorDesc(
+            dtype, library.LayoutType.ColumnMajor
         )
-        c_block_descriptions.append(c_block_transfer)
-    a_block_descriptions = [
-        gemm.BlockTransferDesc([4, 64, 1], [0, 2, 1], [0, 2, 1], 1, 4, 2, 0, True),
-        gemm.BlockTransferDesc([4, 64, 1], [0, 2, 1], [0, 2, 1], 1, 4, 8, 1, True),
-        gemm.BlockTransferDesc([8, 32, 1], [0, 2, 1], [0, 2, 1], 1, 4, 2, 0, True),
-        gemm.BlockTransferDesc([4, 64, 1], [0, 2, 1], [0, 2, 1], 1, 2, 8, 1, True),
-        gemm.BlockTransferDesc([4, 32, 1], [0, 2, 1], [0, 2, 1], 1, 4, 2, 0, True),
-        gemm.BlockTransferDesc([4, 32, 1], [0, 2, 1], [0, 2, 1], 1, 4, 8, 1, True),
-        gemm.BlockTransferDesc([8, 32, 1], [0, 2, 1], [0, 2, 1], 1, 4, 2, 0, True),
-        gemm.BlockTransferDesc([4, 64, 1], [0, 2, 1], [0, 2, 1], 1, 2, 8, 1, True),
-        gemm.BlockTransferDesc([4, 32, 1], [0, 2, 1], [0, 2, 1], 1, 4, 2, 0, True),
-        gemm.BlockTransferDesc([4, 32, 1], [0, 2, 1], [0, 2, 1], 1, 4, 8, 1, True),
-        gemm.BlockTransferDesc([8, 16, 1], [0, 2, 1], [0, 2, 1], 1, 4, 2, 0, True),
-        gemm.BlockTransferDesc([4, 32, 1], [0, 2, 1], [0, 2, 1], 1, 2, 8, 1, True),
-        gemm.BlockTransferDesc([8, 32, 1], [0, 2, 1], [0, 2, 1], 1, 4, 2, 0, True),
-        gemm.BlockTransferDesc([4, 64, 1], [0, 2, 1], [0, 2, 1], 1, 2, 8, 1, True),
-        gemm.BlockTransferDesc([16, 16, 1], [0, 2, 1], [0, 2, 1], 1, 4, 2, 0, True),
-        gemm.BlockTransferDesc([4, 64, 1], [0, 2, 1], [0, 2, 1], 1, 1, 8, 1, True),
-    ]
-    gemm_specialization = [
-        gemm.GemmSpecialization.GemmDefault,
-        gemm.GemmSpecialization.MNKPadding,
-    ]
-    operations = []
-    ds_dtype = [library.DataType.f16]
-    ds_layout = [library.LayoutType.RowMajor]
-    e_dtype = library.DataType.f16
-    for gemm_spec in gemm_specialization:
-        for tile_desc, a_block_desc, b_block_desc, c_block_desc in zip(
-            tile_descriptions,
-            a_block_descriptions,
-            b_block_descriptions,
-            c_block_descriptions,
-        ):
-            new_operation = gemm.GemmOperation(
-                operation_kind=operation_kind,
-                extra_kind=c_element_op,
-                xdl_op_type=gemm.XdlOpType.DeviceBatchedGemmMultiD_Xdl,
-                A=a_element_desc,
-                B=b_element_desc,
-                C=c_element_desc,
-                a_elem_op=element_op,
-                b_elem_op=element_op,
-                epilogue_functor=c_element_op,
-                gemm_specialization=gemm_spec,
-                tile_desc=tile_desc,
-                a_block_transfer=a_block_desc,
-                b_block_transfer=b_block_desc,
-                c_block_transfer=c_block_desc,
-                ds_dtype=ds_dtype,
-                ds_layout=ds_layout,
-                e_dtype=e_dtype,
+        b_element_desc = library.TensorDesc(
+            dtype, library.LayoutType.RowMajor
+        )
+        c_element_desc = library.TensorDesc(
+            dtype, library.LayoutType.RowMajor
+        )
+        element_op = library.TensorOperation.PassThrough
+        # 0 indicates not print
+        tile_descriptions = [
+            gemm.TileDesc(256, 256, 128, 32, 2, 2, 32, 32, 4, 2),
+            gemm.TileDesc(256, 256, 128, 32, 8, 8, 32, 32, 4, 2),
+            gemm.TileDesc(256, 128, 256, 32, 2, 2, 32, 32, 2, 4),
+            gemm.TileDesc(256, 128, 256, 32, 8, 8, 32, 32, 2, 4),
+            gemm.TileDesc(128, 128, 128, 32, 2, 2, 32, 32, 4, 2),
+            gemm.TileDesc(128, 128, 128, 32, 8, 8, 32, 32, 4, 2),
+            gemm.TileDesc(256, 128, 128, 32, 2, 2, 32, 32, 2, 2),
+            gemm.TileDesc(256, 128, 128, 32, 8, 8, 32, 32, 2, 2),
+            gemm.TileDesc(128, 128, 64, 32, 2, 2, 32, 32, 2, 2),
+            gemm.TileDesc(128, 128, 64, 32, 8, 8, 32, 32, 2, 2),
+            gemm.TileDesc(128, 64, 128, 32, 2, 2, 32, 32, 2, 2),
+            gemm.TileDesc(128, 64, 128, 32, 8, 8, 32, 32, 2, 2),
+            gemm.TileDesc(256, 128, 64, 32, 2, 2, 32, 32, 2, 1),
+            gemm.TileDesc(256, 128, 64, 32, 8, 8, 32, 32, 2, 1),
+            gemm.TileDesc(256, 64, 128, 32, 2, 2, 32, 32, 1, 2),
+            gemm.TileDesc(256, 64, 128, 32, 8, 8, 32, 32, 1, 2),
+        ]
+
+        b_block_descriptions = []
+        c_block_descriptions = []
+        for t in tile_descriptions:
+            b_block_transfer = -1
+            c_block_transfer = -1
+            if t.block_size == 256:
+                b_block_transfer = [4, 64, 1]
+                c_block_transfer = gemm.CBlockTransferDesc(1, 1, [1, 32, 1, 8], 8)
+            if t.block_size == 128 and t.n_per_block != 64:
+                b_block_transfer = [4, 32, 1]
+                c_block_transfer = gemm.CBlockTransferDesc(1, 1, [1, 16, 1, 8], 8)
+            if t.block_size == 128 and t.n_per_block == 64:
+                b_block_transfer = [4, 32, 1]
+                c_block_transfer = gemm.CBlockTransferDesc(1, 1, [1, 32, 1, 4], 8)
+
+            assert b_block_transfer != -1 and c_block_transfer != -1, f"Cannot determine block_transfer_size with block_size {str(t.block_size)}"
+            b_block_descriptions.append(
+                gemm.BlockTransferDesc(
+                    b_block_transfer, [1, 0, 2], [1, 0, 2], 2, 8, 8, 1, True
+                )
             )
-            manifest.append(new_operation)
-            operations.append(new_operation)
+            c_block_descriptions.append(c_block_transfer)
+        a_block_descriptions = [
+            gemm.BlockTransferDesc([4, 64, 1], [0, 2, 1], [0, 2, 1], 1, 4, 2, 0, True),
+            gemm.BlockTransferDesc([4, 64, 1], [0, 2, 1], [0, 2, 1], 1, 4, 8, 1, True),
+            gemm.BlockTransferDesc([8, 32, 1], [0, 2, 1], [0, 2, 1], 1, 4, 2, 0, True),
+            gemm.BlockTransferDesc([4, 64, 1], [0, 2, 1], [0, 2, 1], 1, 2, 8, 1, True),
+            gemm.BlockTransferDesc([4, 32, 1], [0, 2, 1], [0, 2, 1], 1, 4, 2, 0, True),
+            gemm.BlockTransferDesc([4, 32, 1], [0, 2, 1], [0, 2, 1], 1, 4, 8, 1, True),
+            gemm.BlockTransferDesc([8, 32, 1], [0, 2, 1], [0, 2, 1], 1, 4, 2, 0, True),
+            gemm.BlockTransferDesc([4, 64, 1], [0, 2, 1], [0, 2, 1], 1, 2, 8, 1, True),
+            gemm.BlockTransferDesc([4, 32, 1], [0, 2, 1], [0, 2, 1], 1, 4, 2, 0, True),
+            gemm.BlockTransferDesc([4, 32, 1], [0, 2, 1], [0, 2, 1], 1, 4, 8, 1, True),
+            gemm.BlockTransferDesc([8, 16, 1], [0, 2, 1], [0, 2, 1], 1, 4, 2, 0, True),
+            gemm.BlockTransferDesc([4, 32, 1], [0, 2, 1], [0, 2, 1], 1, 2, 8, 1, True),
+            gemm.BlockTransferDesc([8, 32, 1], [0, 2, 1], [0, 2, 1], 1, 4, 2, 0, True),
+            gemm.BlockTransferDesc([4, 64, 1], [0, 2, 1], [0, 2, 1], 1, 2, 8, 1, True),
+            gemm.BlockTransferDesc([16, 16, 1], [0, 2, 1], [0, 2, 1], 1, 4, 2, 0, True),
+            gemm.BlockTransferDesc([4, 64, 1], [0, 2, 1], [0, 2, 1], 1, 1, 8, 1, True),
+        ]
+        gemm_specialization = [
+            gemm.GemmSpecialization.GemmDefault,
+            gemm.GemmSpecialization.MNKPadding,
+        ]
+        operations = []
+        ds_dtype = [dtype]
+        ds_layout = [library.LayoutType.RowMajor]
+        e_dtype = dtype
+        for gemm_spec in gemm_specialization:
+            for tile_desc, a_block_desc, b_block_desc, c_block_desc in zip(
+                tile_descriptions,
+                a_block_descriptions,
+                b_block_descriptions,
+                c_block_descriptions,
+            ):
+                new_operation = gemm.GemmOperation(
+                    operation_kind=operation_kind,
+                    extra_kind=c_element_op,
+                    xdl_op_type=gemm.XdlOpType.DeviceBatchedGemmMultiD_Xdl,
+                    A=a_element_desc,
+                    B=b_element_desc,
+                    C=c_element_desc,
+                    a_elem_op=element_op,
+                    b_elem_op=element_op,
+                    epilogue_functor=c_element_op,
+                    gemm_specialization=gemm_spec,
+                    tile_desc=tile_desc,
+                    a_block_transfer=a_block_desc,
+                    b_block_transfer=b_block_desc,
+                    c_block_transfer=c_block_desc,
+                    ds_dtype=ds_dtype,
+                    ds_layout=ds_layout,
+                    e_dtype=e_dtype,
+                    acc_dtype=acc_dtype,
+                )
+                manifest.append(new_operation)
+                operations.append(new_operation)
     return operations
 
 
 def CreateBmmRRRPermOperator(manifest):
     operation_kind = library.GemmKind.BatchGemmPermute
-    a_element_desc = library.TensorDesc(
-        library.DataType.f16, library.LayoutType.RowMajor
-    )
-    b_element_desc = library.TensorDesc(
-        library.DataType.f16, library.LayoutType.RowMajor
-    )
-    c_element_desc = library.TensorDesc(
-        library.DataType.f16, library.LayoutType.RowMajor
-    )
-    element_op = library.TensorOperation.PassThrough
-    # 0 indicates not print
-    tile_descriptions = [
-        gemm.TileDesc(256, 256, 128, 32, 8, 2, 32, 32, 4, 2),
-        gemm.TileDesc(256, 256, 128, 32, 8, 8, 32, 32, 4, 2),
-        gemm.TileDesc(256, 128, 256, 32, 8, 2, 32, 32, 2, 4),
-        gemm.TileDesc(256, 128, 256, 32, 8, 8, 32, 32, 2, 4),
-        gemm.TileDesc(128, 128, 128, 32, 8, 2, 32, 32, 4, 2),
-        gemm.TileDesc(128, 128, 128, 32, 8, 8, 32, 32, 4, 2),
-        gemm.TileDesc(256, 128, 128, 32, 8, 2, 32, 32, 2, 2),
-        gemm.TileDesc(256, 128, 128, 32, 8, 8, 32, 32, 2, 2),
-        gemm.TileDesc(128, 128, 64, 32, 8, 2, 32, 32, 2, 2),
-        gemm.TileDesc(128, 128, 64, 32, 8, 8, 32, 32, 2, 2),
-        gemm.TileDesc(128, 64, 128, 32, 8, 2, 32, 32, 2, 2),
-        gemm.TileDesc(128, 64, 128, 32, 8, 8, 32, 32, 2, 2),
-        gemm.TileDesc(256, 128, 64, 32, 8, 2, 32, 32, 2, 1),
-        gemm.TileDesc(256, 128, 64, 32, 8, 8, 32, 32, 2, 1),
-        gemm.TileDesc(256, 64, 128, 32, 8, 2, 32, 32, 1, 2),
-        gemm.TileDesc(256, 64, 128, 32, 8, 8, 32, 32, 1, 2),
-    ]
-
-    b_block_descriptions = [
-        gemm.BlockTransferDesc([8, 32, 1], [0, 2, 1], [0, 2, 1], 1, 4, 2, 0),
-        gemm.BlockTransferDesc([4, 64, 1], [0, 2, 1], [0, 2, 1], 1, 2, 8, 1),
-        gemm.BlockTransferDesc([4, 64, 1], [0, 2, 1], [0, 2, 1], 1, 4, 2, 0),
-        gemm.BlockTransferDesc([4, 64, 1], [0, 2, 1], [0, 2, 1], 1, 4, 8, 1),
-        gemm.BlockTransferDesc([4, 32, 1], [0, 2, 1], [0, 2, 1], 1, 4, 2, 0),
-        gemm.BlockTransferDesc([4, 32, 1], [0, 2, 1], [0, 2, 1], 1, 4, 8, 1),
-        gemm.BlockTransferDesc([8, 32, 1], [0, 2, 1], [0, 2, 1], 1, 4, 2, 0),
-        gemm.BlockTransferDesc([4, 64, 1], [0, 2, 1], [0, 2, 1], 1, 2, 8, 1),
-        gemm.BlockTransferDesc([8, 16, 1], [0, 2, 1], [0, 2, 1], 1, 4, 2, 0),
-        gemm.BlockTransferDesc([4, 32, 1], [0, 2, 1], [0, 2, 1], 1, 2, 8, 1),
-        gemm.BlockTransferDesc([4, 32, 1], [0, 2, 1], [0, 2, 1], 1, 4, 2, 0),
-        gemm.BlockTransferDesc([4, 32, 1], [0, 2, 1], [0, 2, 1], 1, 4, 8, 1),
-        gemm.BlockTransferDesc([16, 16, 1], [0, 2, 1], [0, 2, 1], 1, 4, 2, 0),
-        gemm.BlockTransferDesc([4, 64, 1], [0, 2, 1], [0, 2, 1], 1, 1, 8, 1),
-        gemm.BlockTransferDesc([8, 32, 1], [0, 2, 1], [0, 2, 1], 1, 4, 2, 0),
-        gemm.BlockTransferDesc([4, 64, 1], [0, 2, 1], [0, 2, 1], 1, 2, 8, 1),
-    ]
-    a_block_descriptions = []
-    c_block_descriptions = []
-    for t in tile_descriptions:
-        a_block_transfer = -1
-        c_block_transfer = -1
-        if t.block_size == 256:
-            a_block_transfer = [4, 64, 1]
-            c_block_transfer = gemm.CBlockTransferDesc(1, 1, [1, 32, 1, 8], 8)
-        if t.block_size == 128:
-            a_block_transfer = [4, 32, 1]
-            if t.n_per_block == 128:
-                c_block_transfer = gemm.CBlockTransferDesc(1, 1, [1, 16, 1, 8], 8)
-            if t.n_per_block == 64:
-                c_block_transfer = gemm.CBlockTransferDesc(1, 1, [1, 32, 1, 4], 8)
-
-        assert a_block_transfer != -1 and c_block_transfer != -1 ,"Cannot determine block_transfer_size with block_size " + str(t.block_size)
-        a_block_descriptions.append(
-            gemm.BlockTransferDesc(a_block_transfer, [1, 0, 2], [1, 0, 2], 2, 8, 8, 1)
+    for dtype, acc_dtype in dtype_acc_types:
+        a_element_desc = library.TensorDesc(
+            dtype, library.LayoutType.RowMajor
         )
-        c_block_descriptions.append(c_block_transfer)
+        b_element_desc = library.TensorDesc(
+            dtype, library.LayoutType.RowMajor
+        )
+        c_element_desc = library.TensorDesc(
+            dtype, library.LayoutType.RowMajor
+        )
+        element_op = library.TensorOperation.PassThrough
+        # 0 indicates not print
+        tile_descriptions = [
+            gemm.TileDesc(256, 256, 128, 32, 8, 2, 32, 32, 4, 2),
+            gemm.TileDesc(256, 256, 128, 32, 8, 8, 32, 32, 4, 2),
+            gemm.TileDesc(256, 128, 256, 32, 8, 2, 32, 32, 2, 4),
+            gemm.TileDesc(256, 128, 256, 32, 8, 8, 32, 32, 2, 4),
+            gemm.TileDesc(128, 128, 128, 32, 8, 2, 32, 32, 4, 2),
+            gemm.TileDesc(128, 128, 128, 32, 8, 8, 32, 32, 4, 2),
+            gemm.TileDesc(256, 128, 128, 32, 8, 2, 32, 32, 2, 2),
+            gemm.TileDesc(256, 128, 128, 32, 8, 8, 32, 32, 2, 2),
+            gemm.TileDesc(128, 128, 64, 32, 8, 2, 32, 32, 2, 2),
+            gemm.TileDesc(128, 128, 64, 32, 8, 8, 32, 32, 2, 2),
+            gemm.TileDesc(128, 64, 128, 32, 8, 2, 32, 32, 2, 2),
+            gemm.TileDesc(128, 64, 128, 32, 8, 8, 32, 32, 2, 2),
+            gemm.TileDesc(256, 128, 64, 32, 8, 2, 32, 32, 2, 1),
+            gemm.TileDesc(256, 128, 64, 32, 8, 8, 32, 32, 2, 1),
+            gemm.TileDesc(256, 64, 128, 32, 8, 2, 32, 32, 1, 2),
+            gemm.TileDesc(256, 64, 128, 32, 8, 8, 32, 32, 1, 2),
+        ]
 
-    gemm_specialization = [
-        gemm.GemmSpecialization.GemmDefault,
-        gemm.GemmSpecialization.MNKPadding,
-    ]
-    operations = []
-    for gemm_spec in gemm_specialization:
-        for tile_desc, a_block_desc, b_block_desc, c_block_desc in zip(
-            tile_descriptions,
-            a_block_descriptions,
-            b_block_descriptions,
-            c_block_descriptions,
-        ):
-            new_operation = gemm.GemmOperation(
-                operation_kind=operation_kind,
-                extra_kind=element_op,
-                xdl_op_type=gemm.XdlOpType.DeviceBatchedGemmCPermuteXdl,
-                A=a_element_desc,
-                B=b_element_desc,
-                C=c_element_desc,
-                a_elem_op=element_op,
-                b_elem_op=element_op,
-                epilogue_functor=element_op,
-                gemm_specialization=gemm_spec,
-                tile_desc=tile_desc,
-                a_block_transfer=a_block_desc,
-                b_block_transfer=b_block_desc,
-                c_block_transfer=c_block_desc,
+        b_block_descriptions = [
+            gemm.BlockTransferDesc([8, 32, 1], [0, 2, 1], [0, 2, 1], 1, 4, 2, 0),
+            gemm.BlockTransferDesc([4, 64, 1], [0, 2, 1], [0, 2, 1], 1, 2, 8, 1),
+            gemm.BlockTransferDesc([4, 64, 1], [0, 2, 1], [0, 2, 1], 1, 4, 2, 0),
+            gemm.BlockTransferDesc([4, 64, 1], [0, 2, 1], [0, 2, 1], 1, 4, 8, 1),
+            gemm.BlockTransferDesc([4, 32, 1], [0, 2, 1], [0, 2, 1], 1, 4, 2, 0),
+            gemm.BlockTransferDesc([4, 32, 1], [0, 2, 1], [0, 2, 1], 1, 4, 8, 1),
+            gemm.BlockTransferDesc([8, 32, 1], [0, 2, 1], [0, 2, 1], 1, 4, 2, 0),
+            gemm.BlockTransferDesc([4, 64, 1], [0, 2, 1], [0, 2, 1], 1, 2, 8, 1),
+            gemm.BlockTransferDesc([8, 16, 1], [0, 2, 1], [0, 2, 1], 1, 4, 2, 0),
+            gemm.BlockTransferDesc([4, 32, 1], [0, 2, 1], [0, 2, 1], 1, 2, 8, 1),
+            gemm.BlockTransferDesc([4, 32, 1], [0, 2, 1], [0, 2, 1], 1, 4, 2, 0),
+            gemm.BlockTransferDesc([4, 32, 1], [0, 2, 1], [0, 2, 1], 1, 4, 8, 1),
+            gemm.BlockTransferDesc([16, 16, 1], [0, 2, 1], [0, 2, 1], 1, 4, 2, 0),
+            gemm.BlockTransferDesc([4, 64, 1], [0, 2, 1], [0, 2, 1], 1, 1, 8, 1),
+            gemm.BlockTransferDesc([8, 32, 1], [0, 2, 1], [0, 2, 1], 1, 4, 2, 0),
+            gemm.BlockTransferDesc([4, 64, 1], [0, 2, 1], [0, 2, 1], 1, 2, 8, 1),
+        ]
+        a_block_descriptions = []
+        c_block_descriptions = []
+        for t in tile_descriptions:
+            a_block_transfer = -1
+            c_block_transfer = -1
+            if t.block_size == 256:
+                a_block_transfer = [4, 64, 1]
+                c_block_transfer = gemm.CBlockTransferDesc(1, 1, [1, 32, 1, 8], 8)
+            if t.block_size == 128:
+                a_block_transfer = [4, 32, 1]
+                if t.n_per_block == 128:
+                    c_block_transfer = gemm.CBlockTransferDesc(1, 1, [1, 16, 1, 8], 8)
+                if t.n_per_block == 64:
+                    c_block_transfer = gemm.CBlockTransferDesc(1, 1, [1, 32, 1, 4], 8)
+
+            assert a_block_transfer != -1 and c_block_transfer != -1 ,"Cannot determine block_transfer_size with block_size " + str(t.block_size)
+            a_block_descriptions.append(
+                gemm.BlockTransferDesc(a_block_transfer, [1, 0, 2], [1, 0, 2], 2, 8, 8, 1)
             )
-            manifest.append(new_operation)
-            operations.append(new_operation)
+            c_block_descriptions.append(c_block_transfer)
+
+        gemm_specialization = [
+            gemm.GemmSpecialization.GemmDefault,
+            gemm.GemmSpecialization.MNKPadding,
+        ]
+        operations = []
+        for gemm_spec in gemm_specialization:
+            for tile_desc, a_block_desc, b_block_desc, c_block_desc in zip(
+                tile_descriptions,
+                a_block_descriptions,
+                b_block_descriptions,
+                c_block_descriptions,
+            ):
+                new_operation = gemm.GemmOperation(
+                    operation_kind=operation_kind,
+                    extra_kind=element_op,
+                    xdl_op_type=gemm.XdlOpType.DeviceBatchedGemmCPermuteXdl,
+                    A=a_element_desc,
+                    B=b_element_desc,
+                    C=c_element_desc,
+                    a_elem_op=element_op,
+                    b_elem_op=element_op,
+                    epilogue_functor=element_op,
+                    gemm_specialization=gemm_spec,
+                    tile_desc=tile_desc,
+                    a_block_transfer=a_block_desc,
+                    b_block_transfer=b_block_desc,
+                    c_block_transfer=c_block_desc,
+                    acc_dtype=acc_dtype,
+                )
+                manifest.append(new_operation)
+                operations.append(new_operation)
     return operations
 
 
 def CreateBmmCCROperator(manifest):
     operation_kind = library.GemmKind.BatchGemm
-    a_element_desc = library.TensorDesc(
-        library.DataType.f16, library.LayoutType.ColumnMajor
-    )
-    b_element_desc = library.TensorDesc(
-        library.DataType.f16, library.LayoutType.ColumnMajor
-    )
-    c_element_desc = library.TensorDesc(
-        library.DataType.f16, library.LayoutType.RowMajor
-    )
-    element_op = library.TensorOperation.PassThrough
-    # 0 indicates not print
-    tile_descriptions = [
-        gemm.TileDesc(256, 256, 128, 4, 8, 0, 32, 32, 4, 2),
-        gemm.TileDesc(256, 128, 256, 4, 8, 0, 32, 32, 2, 4),
-        gemm.TileDesc(128, 128, 128, 4, 8, 0, 32, 32, 4, 2),
-        gemm.TileDesc(256, 128, 128, 4, 8, 0, 32, 32, 2, 2),
-        gemm.TileDesc(128, 128, 64, 4, 8, 0, 32, 32, 2, 2),
-        gemm.TileDesc(128, 64, 128, 4, 8, 0, 32, 32, 2, 2),
-        gemm.TileDesc(256, 128, 64, 4, 8, 0, 32, 32, 2, 1),
-        gemm.TileDesc(256, 64, 128, 4, 8, 0, 32, 32, 1, 2),
-    ]
-
-    b_block_descriptions = []
-    for t in tile_descriptions:
-        b_block_transfer = -1
-        if t.block_size == 256:
-            b_block_transfer = [4, 64, 1]
-        if t.block_size == 128 and t.m_per_block != 16:
-            b_block_transfer = [4, 32, 1]
-
-        assert b_block_transfer != -1, f"Cannot determine block_transfer_size with block_size {str(t.block_size)}"
-        b_block_descriptions.append(
-            gemm.BlockTransferDesc(
-                b_block_transfer, [1, 0, 2], [1, 0, 2], 2, 8, 8, 1, True
-            )
+    for dtype, acc_dtype in dtype_acc_types:
+        a_element_desc = library.TensorDesc(
+            dtype, library.LayoutType.ColumnMajor
         )
-    a_block_descriptions = [
-        gemm.BlockTransferDesc([4, 64, 1], [0, 2, 1], [0, 2, 1], 1, 4, 8, 1, True),
-        gemm.BlockTransferDesc([4, 64, 1], [0, 2, 1], [0, 2, 1], 1, 2, 8, 1, True),
-        gemm.BlockTransferDesc([4, 32, 1], [0, 2, 1], [0, 2, 1], 1, 4, 8, 1, True),
-        gemm.BlockTransferDesc([4, 64, 1], [0, 2, 1], [0, 2, 1], 1, 2, 8, 1, True),
-        gemm.BlockTransferDesc([4, 32, 1], [0, 2, 1], [0, 2, 1], 1, 4, 8, 1, True),
-        gemm.BlockTransferDesc([4, 32, 1], [0, 2, 1], [0, 2, 1], 1, 2, 8, 1, True),
-        gemm.BlockTransferDesc([4, 64, 1], [0, 2, 1], [0, 2, 1], 1, 2, 8, 1, True),
-        gemm.BlockTransferDesc([4, 64, 1], [0, 2, 1], [0, 2, 1], 1, 1, 8, 1, True),
-    ]
-    gemm_specialization = [
-        gemm.GemmSpecialization.GemmDefault,
-        gemm.GemmSpecialization.MNKPadding,
-    ]
-    operations = []
-    for gemm_spec in gemm_specialization:
-        for tile_desc, a_block_desc, b_block_desc in zip(
-            tile_descriptions, a_block_descriptions, b_block_descriptions
-        ):
-            new_operation = gemm.GemmOperation(
-                operation_kind=operation_kind,
-                extra_kind=element_op,
-                xdl_op_type=gemm.XdlOpType.DeviceBatchedGemmXdl,
-                A=a_element_desc,
-                B=b_element_desc,
-                C=c_element_desc,
-                a_elem_op=element_op,
-                b_elem_op=element_op,
-                epilogue_functor=element_op,
-                gemm_specialization=gemm_spec,
-                tile_desc=tile_desc,
-                a_block_transfer=a_block_desc,
-                b_block_transfer=b_block_desc,
+        b_element_desc = library.TensorDesc(
+            dtype, library.LayoutType.ColumnMajor
+        )
+        c_element_desc = library.TensorDesc(
+            dtype, library.LayoutType.RowMajor
+        )
+        element_op = library.TensorOperation.PassThrough
+        # 0 indicates not print
+        tile_descriptions = [
+            gemm.TileDesc(256, 256, 128, 4, 8, 0, 32, 32, 4, 2),
+            gemm.TileDesc(256, 128, 256, 4, 8, 0, 32, 32, 2, 4),
+            gemm.TileDesc(128, 128, 128, 4, 8, 0, 32, 32, 4, 2),
+            gemm.TileDesc(256, 128, 128, 4, 8, 0, 32, 32, 2, 2),
+            gemm.TileDesc(128, 128, 64, 4, 8, 0, 32, 32, 2, 2),
+            gemm.TileDesc(128, 64, 128, 4, 8, 0, 32, 32, 2, 2),
+            gemm.TileDesc(256, 128, 64, 4, 8, 0, 32, 32, 2, 1),
+            gemm.TileDesc(256, 64, 128, 4, 8, 0, 32, 32, 1, 2),
+        ]
+
+        b_block_descriptions = []
+        for t in tile_descriptions:
+            b_block_transfer = -1
+            if t.block_size == 256:
+                b_block_transfer = [4, 64, 1]
+            if t.block_size == 128 and t.m_per_block != 16:
+                b_block_transfer = [4, 32, 1]
+
+            assert b_block_transfer != -1, f"Cannot determine block_transfer_size with block_size {str(t.block_size)}"
+            b_block_descriptions.append(
+                gemm.BlockTransferDesc(
+                    b_block_transfer, [1, 0, 2], [1, 0, 2], 2, 8, 8, 1, True
+                )
             )
-            manifest.append(new_operation)
-            operations.append(new_operation)
+        a_block_descriptions = [
+            gemm.BlockTransferDesc([4, 64, 1], [0, 2, 1], [0, 2, 1], 1, 4, 8, 1, True),
+            gemm.BlockTransferDesc([4, 64, 1], [0, 2, 1], [0, 2, 1], 1, 2, 8, 1, True),
+            gemm.BlockTransferDesc([4, 32, 1], [0, 2, 1], [0, 2, 1], 1, 4, 8, 1, True),
+            gemm.BlockTransferDesc([4, 64, 1], [0, 2, 1], [0, 2, 1], 1, 2, 8, 1, True),
+            gemm.BlockTransferDesc([4, 32, 1], [0, 2, 1], [0, 2, 1], 1, 4, 8, 1, True),
+            gemm.BlockTransferDesc([4, 32, 1], [0, 2, 1], [0, 2, 1], 1, 2, 8, 1, True),
+            gemm.BlockTransferDesc([4, 64, 1], [0, 2, 1], [0, 2, 1], 1, 2, 8, 1, True),
+            gemm.BlockTransferDesc([4, 64, 1], [0, 2, 1], [0, 2, 1], 1, 1, 8, 1, True),
+        ]
+        gemm_specialization = [
+            gemm.GemmSpecialization.GemmDefault,
+            gemm.GemmSpecialization.MNKPadding,
+        ]
+        operations = []
+        for gemm_spec in gemm_specialization:
+            for tile_desc, a_block_desc, b_block_desc in zip(
+                tile_descriptions, a_block_descriptions, b_block_descriptions
+            ):
+                new_operation = gemm.GemmOperation(
+                    operation_kind=operation_kind,
+                    extra_kind=element_op,
+                    xdl_op_type=gemm.XdlOpType.DeviceBatchedGemmXdl,
+                    A=a_element_desc,
+                    B=b_element_desc,
+                    C=c_element_desc,
+                    a_elem_op=element_op,
+                    b_elem_op=element_op,
+                    epilogue_functor=element_op,
+                    gemm_specialization=gemm_spec,
+                    tile_desc=tile_desc,
+                    a_block_transfer=a_block_desc,
+                    b_block_transfer=b_block_desc,
+                    acc_dtype=acc_dtype,
+                )
+                manifest.append(new_operation)
+                operations.append(new_operation)
     return operations
 
 
 def CreateBmmCRROperator(manifest):
     operation_kind = library.GemmKind.BatchGemm
-    a_element_desc = library.TensorDesc(
-        library.DataType.f16, library.LayoutType.ColumnMajor
-    )
-    b_element_desc = library.TensorDesc(
-        library.DataType.f16, library.LayoutType.RowMajor
-    )
-    c_element_desc = library.TensorDesc(
-        library.DataType.f16, library.LayoutType.RowMajor
-    )
-    element_op = library.TensorOperation.PassThrough
-    # 0 indicates not print
-    tile_descriptions = [
-        gemm.TileDesc(256, 256, 128, 4, 8, 0, 32, 32, 4, 2),
-        gemm.TileDesc(256, 128, 256, 4, 8, 0, 32, 32, 2, 4),
-        gemm.TileDesc(128, 128, 128, 4, 8, 0, 32, 32, 4, 2),
-        gemm.TileDesc(256, 128, 128, 4, 8, 0, 32, 32, 2, 2),
-        gemm.TileDesc(128, 128, 64, 4, 8, 0, 32, 32, 2, 2),
-        gemm.TileDesc(128, 64, 128, 4, 8, 0, 32, 32, 2, 2),
-        gemm.TileDesc(256, 128, 64, 4, 8, 0, 32, 32, 2, 1),
-        gemm.TileDesc(256, 64, 128, 4, 8, 0, 32, 32, 1, 2),
-    ]
+    for dtype, acc_dtype in dtype_acc_types:
+        a_element_desc = library.TensorDesc(
+            dtype, library.LayoutType.ColumnMajor
+        )
+        b_element_desc = library.TensorDesc(
+            dtype, library.LayoutType.RowMajor
+        )
+        c_element_desc = library.TensorDesc(
+            dtype, library.LayoutType.RowMajor
+        )
+        element_op = library.TensorOperation.PassThrough
+        # 0 indicates not print
+        tile_descriptions = [
+            gemm.TileDesc(256, 256, 128, 4, 8, 0, 32, 32, 4, 2),
+            gemm.TileDesc(256, 128, 256, 4, 8, 0, 32, 32, 2, 4),
+            gemm.TileDesc(128, 128, 128, 4, 8, 0, 32, 32, 4, 2),
+            gemm.TileDesc(256, 128, 128, 4, 8, 0, 32, 32, 2, 2),
+            gemm.TileDesc(128, 128, 64, 4, 8, 0, 32, 32, 2, 2),
+            gemm.TileDesc(128, 64, 128, 4, 8, 0, 32, 32, 2, 2),
+            gemm.TileDesc(256, 128, 64, 4, 8, 0, 32, 32, 2, 1),
+            gemm.TileDesc(256, 64, 128, 4, 8, 0, 32, 32, 1, 2),
+        ]
 
-    a_block_descriptions = [
-        gemm.BlockTransferDesc([4, 64, 1], [0, 2, 1], [0, 2, 1], 1, 4, 8, 1, True),
-        gemm.BlockTransferDesc([4, 64, 1], [0, 2, 1], [0, 2, 1], 1, 2, 8, 1, True),
-        gemm.BlockTransferDesc([4, 32, 1], [0, 2, 1], [0, 2, 1], 1, 4, 8, 1, True),
-        gemm.BlockTransferDesc([4, 64, 1], [0, 2, 1], [0, 2, 1], 1, 2, 8, 1, True),
-        gemm.BlockTransferDesc([4, 32, 1], [0, 2, 1], [0, 2, 1], 1, 4, 8, 1, True),
-        gemm.BlockTransferDesc([4, 32, 1], [0, 2, 1], [0, 2, 1], 1, 2, 8, 1, True),
-        gemm.BlockTransferDesc([4, 64, 1], [0, 2, 1], [0, 2, 1], 1, 2, 8, 1, True),
-        gemm.BlockTransferDesc([4, 64, 1], [0, 2, 1], [0, 2, 1], 1, 1, 8, 1, True),
-    ]
-    b_block_descriptions = [
-        gemm.BlockTransferDesc([4, 64, 1], [0, 2, 1], [0, 2, 1], 1, 2, 8, 1, True),
-        gemm.BlockTransferDesc([4, 64, 1], [0, 2, 1], [0, 2, 1], 1, 4, 8, 1, True),
-        gemm.BlockTransferDesc([4, 32, 1], [0, 2, 1], [0, 2, 1], 1, 4, 8, 1, True),
-        gemm.BlockTransferDesc([4, 64, 1], [0, 2, 1], [0, 2, 1], 1, 2, 8, 1, True),
-        gemm.BlockTransferDesc([4, 32, 1], [0, 2, 1], [0, 2, 1], 1, 2, 8, 1, True),
-        gemm.BlockTransferDesc([4, 32, 1], [0, 2, 1], [0, 2, 1], 1, 4, 8, 1, True),
-        gemm.BlockTransferDesc([4, 64, 1], [0, 2, 1], [0, 2, 1], 1, 1, 8, 1, True),
-        gemm.BlockTransferDesc([4, 64, 1], [0, 2, 1], [0, 2, 1], 1, 2, 8, 1, True),
-    ]
-    gemm_specialization = [
-        gemm.GemmSpecialization.GemmDefault,
-        gemm.GemmSpecialization.MNKPadding,
-    ]
-    operations = []
-    for gemm_spec in gemm_specialization:
-        for tile_desc, a_block_desc, b_block_desc in zip(
-            tile_descriptions, a_block_descriptions, b_block_descriptions
-        ):
-            new_operation = gemm.GemmOperation(
+        a_block_descriptions = [
+            gemm.BlockTransferDesc([4, 64, 1], [0, 2, 1], [0, 2, 1], 1, 4, 8, 1, True),
+            gemm.BlockTransferDesc([4, 64, 1], [0, 2, 1], [0, 2, 1], 1, 2, 8, 1, True),
+            gemm.BlockTransferDesc([4, 32, 1], [0, 2, 1], [0, 2, 1], 1, 4, 8, 1, True),
+            gemm.BlockTransferDesc([4, 64, 1], [0, 2, 1], [0, 2, 1], 1, 2, 8, 1, True),
+            gemm.BlockTransferDesc([4, 32, 1], [0, 2, 1], [0, 2, 1], 1, 4, 8, 1, True),
+            gemm.BlockTransferDesc([4, 32, 1], [0, 2, 1], [0, 2, 1], 1, 2, 8, 1, True),
+            gemm.BlockTransferDesc([4, 64, 1], [0, 2, 1], [0, 2, 1], 1, 2, 8, 1, True),
+            gemm.BlockTransferDesc([4, 64, 1], [0, 2, 1], [0, 2, 1], 1, 1, 8, 1, True),
+        ]
+        b_block_descriptions = [
+            gemm.BlockTransferDesc([4, 64, 1], [0, 2, 1], [0, 2, 1], 1, 2, 8, 1, True),
+            gemm.BlockTransferDesc([4, 64, 1], [0, 2, 1], [0, 2, 1], 1, 4, 8, 1, True),
+            gemm.BlockTransferDesc([4, 32, 1], [0, 2, 1], [0, 2, 1], 1, 4, 8, 1, True),
+            gemm.BlockTransferDesc([4, 64, 1], [0, 2, 1], [0, 2, 1], 1, 2, 8, 1, True),
+            gemm.BlockTransferDesc([4, 32, 1], [0, 2, 1], [0, 2, 1], 1, 2, 8, 1, True),
+            gemm.BlockTransferDesc([4, 32, 1], [0, 2, 1], [0, 2, 1], 1, 4, 8, 1, True),
+            gemm.BlockTransferDesc([4, 64, 1], [0, 2, 1], [0, 2, 1], 1, 1, 8, 1, True),
+            gemm.BlockTransferDesc([4, 64, 1], [0, 2, 1], [0, 2, 1], 1, 2, 8, 1, True),
+        ]
+        gemm_specialization = [
+            gemm.GemmSpecialization.GemmDefault,
+            gemm.GemmSpecialization.MNKPadding,
+        ]
+        operations = []
+        for gemm_spec in gemm_specialization:
+            for tile_desc, a_block_desc, b_block_desc in zip(
+                tile_descriptions, a_block_descriptions, b_block_descriptions
+            ):
+                new_operation = gemm.GemmOperation(
+                    operation_kind=operation_kind,
+                    extra_kind=element_op,
+                    xdl_op_type=gemm.XdlOpType.DeviceBatchedGemmXdl,
+                    A=a_element_desc,
+                    B=b_element_desc,
+                    C=c_element_desc,
+                    a_elem_op=element_op,
+                    b_elem_op=element_op,
+                    epilogue_functor=element_op,
+                    gemm_specialization=gemm_spec,
+                    tile_desc=tile_desc,
+                    a_block_transfer=a_block_desc,
+                    b_block_transfer=b_block_desc,
+                    acc_dtype=acc_dtype,
+                )
+                manifest.append(new_operation)
+                operations.append(new_operation)
+    return operations
+
+
+def CreateSoftmaxOperator(manifest, rank=3):
+    operation_kind = library.OperationKind.Softmax
+    for dtype, acc_dtype in dtype_acc_types:
+        in_dtype = dtype
+        out_dtype = dtype
+        # 0 indicates not print
+        tile_descriptions = [
+            softmax.TileDesc(256, 8, 32, 1, 8, 1, 1, 1),
+            softmax.TileDesc(256, 8, 32, 1, 8, 1, 8, 8),
+            softmax.TileDesc(256, 4, 64, 1, 8, 1, 8, 8),
+            softmax.TileDesc(256, 2, 128, 1, 8, 1, 8, 8),
+            softmax.TileDesc(256, 2, 128, 1, 16, 1, 8, 8),
+            softmax.TileDesc(256, 2, 128, 1, 32, 1, 8, 8),
+            softmax.TileDesc(256, 1, 256, 1, 8, 1, 8, 8),
+            softmax.TileDesc(256, 1, 256, 1, 16, 1, 8, 8),
+            softmax.TileDesc(256, 1, 256, 1, 32, 1, 8, 8),
+        ]
+
+        operations = []
+        for tile_desc in tile_descriptions:
+            new_operation = softmax.SoftmaxOperation(
                 operation_kind=operation_kind,
-                extra_kind=element_op,
-                xdl_op_type=gemm.XdlOpType.DeviceBatchedGemmXdl,
-                A=a_element_desc,
-                B=b_element_desc,
-                C=c_element_desc,
-                a_elem_op=element_op,
-                b_elem_op=element_op,
-                epilogue_functor=element_op,
-                gemm_specialization=gemm_spec,
+                extra_kind=rank,
+                In=in_dtype,
+                Out=out_dtype,
+                Rank=rank,
+                NumReduceDim=1,
                 tile_desc=tile_desc,
-                a_block_transfer=a_block_desc,
-                b_block_transfer=b_block_desc,
+                acc_dtype=acc_dtype,
             )
             manifest.append(new_operation)
             operations.append(new_operation)
     return operations
 
 
-def CreateSoftmaxOperator(manifest, rank=3):
-    operation_kind = library.OperationKind.Softmax
-    in_dtype = library.DataType.f16
-    out_dtype = library.DataType.f16
-    # 0 indicates not print
-    tile_descriptions = [
-        softmax.TileDesc(256, 8, 32, 1, 8, 1, 1, 1),
-        softmax.TileDesc(256, 8, 32, 1, 8, 1, 8, 8),
-        softmax.TileDesc(256, 4, 64, 1, 8, 1, 8, 8),
-        softmax.TileDesc(256, 2, 128, 1, 8, 1, 8, 8),
-        softmax.TileDesc(256, 2, 128, 1, 16, 1, 8, 8),
-        softmax.TileDesc(256, 2, 128, 1, 32, 1, 8, 8),
-        softmax.TileDesc(256, 1, 256, 1, 8, 1, 8, 8),
-        softmax.TileDesc(256, 1, 256, 1, 16, 1, 8, 8),
-        softmax.TileDesc(256, 1, 256, 1, 32, 1, 8, 8),
-    ]
-
-    operations = []
-    for tile_desc in tile_descriptions:
-        new_operation = softmax.SoftmaxOperation(
-            operation_kind=operation_kind,
-            extra_kind=rank,
-            In=in_dtype,
-            Out=out_dtype,
-            Rank=rank,
-            NumReduceDim=1,
-            tile_desc=tile_desc,
-        )
-        manifest.append(new_operation)
-        operations.append(new_operation)
-    return operations
-
-
 def CreateLayerNormOperator(manifest, rank=2):
     operation_kind = library.OperationKind.LayerNorm
-    in_dtype = library.DataType.f16
-    out_dtype = library.DataType.f16
-    # 0 indicates not print
-    tile_descriptions = [
-        layernorm.TileDesc(256, 8, 32, 1, 8, 1, 1, 1, 1, 1, 1, 1),
-        layernorm.TileDesc(256, 8, 32, 1, 8, 1, 2, 1, 2, 1, 2, 2),
-        layernorm.TileDesc(256, 8, 32, 1, 8, 1, 4, 1, 4, 1, 4, 4),
-        layernorm.TileDesc(256, 8, 32, 1, 8, 1, 8, 1, 8, 1, 8, 8),
-        layernorm.TileDesc(256, 4, 64, 1, 8, 1, 8, 1, 8, 1, 8, 8),
-        layernorm.TileDesc(256, 2, 128, 1, 8, 1, 8, 1, 8, 1, 8, 8),
-        layernorm.TileDesc(256, 2, 128, 1, 16, 1, 8, 1, 8, 1, 8, 8),
-        layernorm.TileDesc(256, 2, 128, 1, 32, 1, 8, 1, 8, 1, 8, 8),
-        layernorm.TileDesc(256, 1, 256, 1, 8, 1, 8, 1, 8, 1, 8, 8),
-        layernorm.TileDesc(256, 1, 256, 1, 16, 1, 8, 1, 8, 1, 8, 8),
-        layernorm.TileDesc(256, 1, 256, 1, 32, 1, 8, 1, 8, 1, 8, 8),
-        layernorm.TileDesc(1024, 1, 1024, 1, 32, 1, 8, 1, 8, 1, 8, 8),
-        layernorm.TileDesc(1024, 1, 1024, 1, 8, 1, 2, 1, 2, 1, 2, 2),
-    ]
+    for dtype, acc_dtype in dtype_acc_types:
+        in_dtype = dtype
+        out_dtype = dtype
+        # 0 indicates not print
+        tile_descriptions = [
+            layernorm.TileDesc(256, 8, 32, 1, 8, 1, 1, 1, 1, 1, 1, 1, 1),
+            layernorm.TileDesc(256, 8, 32, 1, 8, 1, 2, 1, 2, 1, 2, 2, 1),
+            layernorm.TileDesc(256, 8, 32, 1, 8, 1, 4, 1, 4, 1, 4, 4, 1),
+            layernorm.TileDesc(256, 8, 32, 1, 8, 1, 8, 1, 8, 1, 8, 8, 1),
+            layernorm.TileDesc(256, 4, 64, 1, 8, 1, 8, 1, 8, 1, 8, 8, 1),
+            layernorm.TileDesc(256, 2, 128, 1, 8, 1, 8, 1, 8, 1, 8, 8, 1),
+            layernorm.TileDesc(256, 2, 128, 1, 16, 1, 8, 1, 8, 1, 8, 8, 1),
+            layernorm.TileDesc(256, 2, 128, 1, 32, 1, 8, 1, 8, 1, 8, 8, 1),
+            layernorm.TileDesc(256, 1, 256, 1, 8, 1, 8, 1, 8, 1, 8, 8, 1),
+            layernorm.TileDesc(256, 1, 256, 1, 16, 1, 8, 1, 8, 1, 8, 8, 1),
+            layernorm.TileDesc(256, 1, 256, 1, 32, 1, 8, 1, 8, 1, 8, 8, 1),
+            layernorm.TileDesc(1024, 1, 1024, 1, 32, 1, 8, 1, 8, 1, 8, 8, 1),
+            layernorm.TileDesc(1024, 1, 1024, 1, 8, 1, 2, 1, 2, 1, 2, 2, 1),
+        ]
 
-    operations = []
-    for tile_desc in tile_descriptions:
-        new_operation = layernorm.LayerNormOperation(
-            operation_kind=operation_kind,
-            extra_kind=rank,
-            In=in_dtype,
-            Out=out_dtype,
-            Rank=rank,
-            NumReduceDim=1,
-            tile_desc=tile_desc,
-        )
-        manifest.append(new_operation)
-        operations.append(new_operation)
+        operations = []
+        for tile_desc in tile_descriptions:
+            new_operation = layernorm.LayerNormOperation(
+                operation_kind=operation_kind,
+                extra_kind=rank,
+                In=in_dtype,
+                Out=out_dtype,
+                Rank=rank,
+                NumReduceDim=1,
+                tile_desc=tile_desc,
+                acc_dtype=acc_dtype,
+            )
+            manifest.append(new_operation)
+            operations.append(new_operation)
     return operations
 
 
 def CreateGroupNormOperator(manifest, rank=5):
     operation_kind = library.OperationKind.GroupNorm
-    in_dtype = library.DataType.f16
-    out_dtype = library.DataType.f16
-    # 0 indicates not print
-    tile_descriptions = [
-        groupnorm.TileDesc(256, 8, 32, 1, 8, 1, 1, 1, 1, 1, 1, 1),
-        groupnorm.TileDesc(256, 8, 32, 1, 8, 1, 2, 1, 2, 1, 2, 2),
-        groupnorm.TileDesc(256, 8, 32, 1, 8, 1, 4, 1, 4, 1, 4, 4),
-        groupnorm.TileDesc(256, 8, 32, 1, 8, 1, 8, 1, 8, 1, 8, 8),
-        groupnorm.TileDesc(256, 4, 64, 1, 8, 1, 8, 1, 8, 1, 8, 8),
-        groupnorm.TileDesc(256, 2, 128, 1, 8, 1, 8, 1, 8, 1, 8, 8),
-        groupnorm.TileDesc(256, 2, 128, 1, 16, 1, 8, 1, 8, 1, 8, 8),
-        groupnorm.TileDesc(256, 2, 128, 1, 32, 1, 8, 1, 8, 1, 8, 8),
-        groupnorm.TileDesc(256, 1, 256, 1, 8, 1, 8, 1, 8, 1, 8, 8),
-        groupnorm.TileDesc(256, 1, 256, 1, 16, 1, 8, 1, 8, 1, 8, 8),
-        groupnorm.TileDesc(256, 1, 256, 1, 32, 1, 8, 1, 8, 1, 8, 8),
-        groupnorm.TileDesc(1024, 1, 1024, 1, 32, 1, 8, 1, 8, 1, 8, 8),
-        groupnorm.TileDesc(1024, 1, 1024, 1, 8, 1, 2, 1, 2, 1, 2, 2),
-    ]
+    for dtype, acc_dtype in dtype_acc_types:
+        in_dtype = dtype
+        out_dtype = dtype
+        # 0 indicates not print
+        tile_descriptions = [
+            groupnorm.TileDesc(256, 8, 32, 1, 8, 1, 1, 1, 1, 1, 1, 1, 1),
+            groupnorm.TileDesc(256, 8, 32, 1, 8, 1, 2, 1, 2, 1, 2, 2, 1),
+            groupnorm.TileDesc(256, 8, 32, 1, 8, 1, 4, 1, 4, 1, 4, 4, 1),
+            groupnorm.TileDesc(256, 8, 32, 1, 8, 1, 8, 1, 8, 1, 8, 8, 1),
+            groupnorm.TileDesc(256, 4, 64, 1, 8, 1, 8, 1, 8, 1, 8, 8, 1),
+            groupnorm.TileDesc(256, 2, 128, 1, 8, 1, 8, 1, 8, 1, 8, 8, 1),
+            groupnorm.TileDesc(256, 2, 128, 1, 16, 1, 8, 1, 8, 1, 8, 8, 1),
+            groupnorm.TileDesc(256, 2, 128, 1, 32, 1, 8, 1, 8, 1, 8, 8, 1),
+            groupnorm.TileDesc(256, 1, 256, 1, 8, 1, 8, 1, 8, 1, 8, 8, 1),
+            groupnorm.TileDesc(256, 1, 256, 1, 16, 1, 8, 1, 8, 1, 8, 8, 1),
+            groupnorm.TileDesc(256, 1, 256, 1, 32, 1, 8, 1, 8, 1, 8, 8, 1),
+            groupnorm.TileDesc(1024, 1, 1024, 1, 32, 1, 8, 1, 8, 1, 8, 8, 1),
+            groupnorm.TileDesc(1024, 1, 1024, 1, 8, 1, 2, 1, 2, 1, 2, 2, 1),
+        ]
 
-    operations = []
-    for tile_desc in tile_descriptions:
-        new_operation = groupnorm.GroupNormOperation(
-            operation_kind=operation_kind,
-            extra_kind=rank,
-            In=in_dtype,
-            Out=out_dtype,
-            Rank=rank,
-            NumReduceDim=3,
-            tile_desc=tile_desc,
-        )
-        manifest.append(new_operation)
-        operations.append(new_operation)
+        operations = []
+        for tile_desc in tile_descriptions:
+            new_operation = groupnorm.GroupNormOperation(
+                operation_kind=operation_kind,
+                extra_kind=rank,
+                In=in_dtype,
+                Out=out_dtype,
+                Rank=rank,
+                NumReduceDim=3,
+                tile_desc=tile_desc,
+                acc_dtype=acc_dtype,
+            )
+            manifest.append(new_operation)
+            operations.append(new_operation)
     return operations
 
 

--- a/src/dinoml/utils/ck_lib/groupnorm_operation.py
+++ b/src/dinoml/utils/ck_lib/groupnorm_operation.py
@@ -34,6 +34,7 @@ class TileDesc:
     beta_src_dim: int
     beta_src_size: int
     out_dst_size: int
+    save_size: int
 
     def __str__(self) -> str:
         values = list(self.__dict__.values())
@@ -62,26 +63,31 @@ class GroupNormOperation:
     Rank: int
     NumReduceDim: int
     tile_desc: TileDesc
+    acc_dtype: library.DataType = library.DataType.f32
 
     def __str__(self) -> str:
-        return "{op_kind}_rank{rank}_{tile_name}".format(
+        return "{op_kind}_{a_dtype}{b_dtype}_{acc_dtype}_rank{rank}_{tile_name}".format(
             op_kind=library.OperationKindNames[self.operation_kind],
             rank=self.Rank,
             tile_name=str(self.tile_desc),
+            a_dtype=library.ShortDataTypeNames[self.In],
+            b_dtype=library.ShortDataTypeNames[self.Out],
+            acc_dtype=library.ShortDataTypeNames[self.acc_dtype],
         )
 
     def accumulator_type(self):
-        return library.DataType.f32
+        return self.acc_dtype
 
     def emit(self) -> str:
         template = jinja2.Template(
             """
-using {{name}} = ck::tensor_operation::device::DeviceNormalizationImpl<
+using {{name}} = ck::tensor_operation::device::DeviceNormalizationFwdImpl<
     {{InDType}},
     {{InDType}},
     {{InDType}},
     {{AccDType}},
     {{OutDType}},
+    {{InDType}},
     YElementOp,
     {{Rank}},
     {{NumReduceDim}},
@@ -92,7 +98,7 @@ using {{name}} = ck::tensor_operation::device::DeviceNormalizationImpl<
         return template.render(
             name=self.__str__(),
             InDType=library.DataTypeTag[self.In],
-            AccDType=library.DataTypeTag[library.DataType.f32],
+            AccDType=library.DataTypeTag[self.acc_dtype],
             OutDType=library.DataTypeTag[self.Out],
             Rank=self.Rank,
             NumReduceDim=self.NumReduceDim,

--- a/src/dinoml/utils/ck_lib/layernorm_operation.py
+++ b/src/dinoml/utils/ck_lib/layernorm_operation.py
@@ -34,6 +34,7 @@ class TileDesc:
     beta_src_dim: int
     beta_src_size: int
     out_dst_size: int
+    save_size: int
 
     def __str__(self) -> str:
         values = list(self.__dict__.values())
@@ -62,26 +63,31 @@ class LayerNormOperation:
     Rank: int
     NumReduceDim: int
     tile_desc: TileDesc
+    acc_dtype: library.DataType = library.DataType.f32
 
     def __str__(self) -> str:
-        return "{op_kind}_rank{rank}_{tile_name}".format(
+        return "{op_kind}_{a_dtype}{b_dtype}_{acc_dtype}_rank{rank}_{tile_name}".format(
             op_kind=library.OperationKindNames[self.operation_kind],
             rank=self.Rank,
             tile_name=str(self.tile_desc),
+            a_dtype=library.ShortDataTypeNames[self.In],
+            b_dtype=library.ShortDataTypeNames[self.Out],
+            acc_dtype=library.ShortDataTypeNames[self.acc_dtype],
         )
 
     def accumulator_type(self):
-        return library.DataType.f32
+        return self.acc_dtype
 
     def emit(self) -> str:
         template = jinja2.Template(
             """
-using {{name}} = ck::tensor_operation::device::DeviceNormalizationImpl<
+using {{name}} = ck::tensor_operation::device::DeviceNormalizationFwdImpl<
     {{InDType}},
     {{InDType}},
     {{InDType}},
     {{AccDType}},
     {{OutDType}},
+    {{InDType}},
     ck::tensor_operation::element_wise::PassThrough,
     {{Rank}},
     {{NumReduceDim}},
@@ -92,7 +98,7 @@ using {{name}} = ck::tensor_operation::device::DeviceNormalizationImpl<
         return template.render(
             name=self.__str__(),
             InDType=library.DataTypeTag[self.In],
-            AccDType=library.DataTypeTag[self.accumulator_type()],
+            AccDType=library.DataTypeTag[self.acc_dtype],
             OutDType=library.DataTypeTag[self.Out],
             Rank=self.Rank,
             NumReduceDim=self.NumReduceDim,  # we only need softmax(dim=-1) at this moment

--- a/src/dinoml/utils/ck_lib/library.py
+++ b/src/dinoml/utils/ck_lib/library.py
@@ -39,6 +39,7 @@ class DataType(enum.Enum):
 ShortDataTypeNames = {
     DataType.s32: "i",
     DataType.f16: "h",
+    DataType.bf16: "bf",
     DataType.f32: "s",
     DataType.f64: "d",
 }
@@ -305,7 +306,7 @@ class TensorOperation(enum.Enum):
 TensorOperationTag = {
     TensorOperation.PassThrough: "ck::tensor_operation::element_wise::PassThrough",
     TensorOperation.Add: "ck::tensor_operation::element_wise::Add",
-    TensorOperation.AddAdd: "ck::tensor_operation::element_wise::AddAdd",
+    TensorOperation.AddAdd: "ck::tensor_operation::element_wise::AddAdd_",
     TensorOperation.AddMul: "ck::tensor_operation::element_wise::AddMul",
     TensorOperation.AddMulTanh: "ck::tensor_operation::element_wise::AddMulTanh",
     TensorOperation.AlphaBetaAdd: "ck::tensor_operation::element_wise::AlphaBetaAdd",

--- a/src/dinoml/utils/ck_lib/softmax_operation.py
+++ b/src/dinoml/utils/ck_lib/softmax_operation.py
@@ -58,16 +58,20 @@ class SoftmaxOperation:
     Rank: int
     NumReduceDim: int
     tile_desc: TileDesc
+    acc_dtype: library.DataType = library.DataType.f32
 
     def __str__(self) -> str:
-        return "{op_kind}_rank{rank}_{tile_name}".format(
+        return "{op_kind}_{a_dtype}{b_dtype}_{acc_dtype}_rank{rank}_{tile_name}".format(
             op_kind=library.OperationKindNames[self.operation_kind],
             rank=self.Rank,
             tile_name=str(self.tile_desc),
+            a_dtype=library.ShortDataTypeNames[self.In],
+            b_dtype=library.ShortDataTypeNames[self.Out],
+            acc_dtype=library.ShortDataTypeNames[self.acc_dtype],
         )
 
     def accumulator_type(self):
-        return library.DataType.f32
+        return self.acc_dtype
 
     def emit(self) -> str:
         template = jinja2.Template(
@@ -87,7 +91,7 @@ using {{name}} = ck::tensor_operation::device::DeviceSoftmaxImpl<
         return template.render(
             name=self.__str__(),
             InDType=library.DataTypeTag[self.In],
-            AccDType=library.DataTypeTag[library.DataType.f32],
+            AccDType=library.DataTypeTag[self.acc_dtype],
             OutDType=library.DataTypeTag[self.Out],
             Rank=self.Rank,
             NumReduceDim=self.NumReduceDim,  # we only need softmax(dim=-1) at this moment

--- a/tests/unittest/ops/test_randn.py
+++ b/tests/unittest/ops/test_randn.py
@@ -16,7 +16,7 @@ device_name = get_device_name()
 
 sm = get_sm()
 
-model_name = f"randn_test.{device_name}.sm{sm}"
+model_name = f"randn_test.{device_name}.{sm}"
 
 dinoml_module = ops.randn([1, 4, 64, 64], dtype="float16", seed=69)
 pt_output = torch.randn(
@@ -51,7 +51,7 @@ torch.testing.assert_close(pt_output, output)
 benchmark_module(module=module, count=50, repeat=3)
 
 
-model_name = f"randn_test_seed_repeat.{device_name}.sm{sm}"
+model_name = f"randn_test_seed_repeat.{device_name}.{sm}"
 
 dinoml_module = ops.randn([1, 4, 64, 64], dtype="float16", seed=69)
 pt_output = torch.randn(
@@ -84,7 +84,7 @@ for _ in range(5):
 
     torch.testing.assert_close(pt_output, output)
 
-model_name = f"randn_test_multi.{device_name}.sm{sm}"
+model_name = f"randn_test_multi.{device_name}.{sm}"
 dinoml_module = ops.randn([1, 4, 64, 64], dtype="float16")
 
 Y = dinoml_module()
@@ -106,7 +106,7 @@ for _ in range(5):
     print(f"{output=}")
 
 
-model_name = f"randn_test_dynamic.{device_name}.sm{sm}"
+model_name = f"randn_test_dynamic.{device_name}.{sm}"
 
 height, width = IntVar([8, 64]), IntVar([8, 64])
 


### PR DESCRIPTION
Various updates for AMD

Introduces Flash Attention for CUDA and AMD

Introduces bf16 support for AMD

`UNet2DConditionModel` `runwayml/stable-diffusion-v1-5` @ `512x512` with `batch 2` on `RX 9070 XT`: `29.297` ms, `34.13` it/s

`UNet2DConditionModel` `runwayml/stable-diffusion-v1-5` @ `512x512` with `batch 2` on `3090` (with Flash Attention): `22.8` ms, `43.86` it/s

# TODO

- [x] Move Flash Attention to separate repos/submodules
- [x] Add build instructions for Flash Attention
- [x] Finalize builder changes for Flash Attention
    - We need to check whether Flash Attention is used, and only link when needed