### PR TITLE
Optional inputs, optional elementwise, UNet2DCondtional residuals

### DIFF
--- a/csrc/include/debug_utility.h
+++ b/csrc/include/debug_utility.h
@@ -44,7 +44,11 @@ void InvokeOutputsChecker(
     int64_t elem_cnt,
     dinoml::StreamType stream) {
   printf("Tensor (%s) output:\n", tensor_name);
-  outputs_checker<<<1, 1, 0, stream>>>(tensor, elem_cnt);
+  if (tensor == nullptr) {
+    printf("nullptr\n");
+  } else {
+    outputs_checker<<<1, 1, 0, stream>>>(tensor, elem_cnt);
+  }
   dinoml::StreamSynchronize(stream);
 }
 } // namespace dinoml

--- a/csrc/include/model.h
+++ b/csrc/include/model.h
@@ -224,6 +224,9 @@ class ModelBase {
  private:
   void SetInputShape(const DinoMLParamShape& shape, size_t idx) {
     auto& param = params_[idx];
+    if (shape.size == 0) {
+      return;
+    }
     if (shape.size != param.shape_ptrs.size()) {
       throw std::runtime_error(
           "[SetInputShape] Got wrong param shape for input " +

--- a/csrc/include/model_container.h
+++ b/csrc/include/model_container.h
@@ -94,6 +94,7 @@ class ModelContainerBase {
   // These entries correspond to inputs/outputs/unbound constants in order;
   // inputs first, then outputs, then constants.
   std::vector<const char*> param_names_;
+  std::vector<bool> param_optional_;
   std::vector<std::vector<int64_t>> max_param_shapes_;
   std::vector<DinoMLDtype> param_dtypes_;
 
@@ -228,6 +229,8 @@ class ModelContainer : ModelContainerBase {
 
   const char* InputName(size_t input_idx) const;
   const char* OutputName(size_t output_idx) const;
+
+  bool InputOptional(size_t input_idx) const;
 
   DinoMLParamShape MaxInputShape(size_t input_idx) const;
   DinoMLParamShape MaxOutputShape(size_t output_idx) const;

--- a/csrc/include/model_interface.h
+++ b/csrc/include/model_interface.h
@@ -277,6 +277,11 @@ DINOML_EXPORT DinoMLError DinoMLModelContainerGetInputName(
     size_t input_idx,
     const char** input_name_out);
 
+DINOML_EXPORT DinoMLError DinoMLModelContainerGetInputOptional(
+    DinoMLModelHandle handle,
+    size_t input_idx,
+    bool* input_optional_out);
+
 DINOML_EXPORT DinoMLError DinoMLModelContainerGetMaximumInputShape(
     DinoMLModelHandle handle,
     size_t input_idx,

--- a/csrc/model_container.cpp
+++ b/csrc/model_container.cpp
@@ -545,6 +545,12 @@ const char* ModelContainer::InputName(size_t input_idx) const {
   return param_names_[input_idx];
 }
 
+bool ModelContainer::InputOptional(size_t input_idx) const {
+  CHECK(input_idx < num_inputs_);
+  CHECK_VECTOR_ACCESS(param_optional_, input_idx)
+  return param_optional_[input_idx];
+}
+
 DinoMLParamShape ModelContainer::MaxInputShape(size_t input_idx) const {
   CHECK(input_idx < num_inputs_);
   CHECK_VECTOR_ACCESS(max_param_shapes_, input_idx)
@@ -761,7 +767,21 @@ void ModelContainer::PrepareForRun(
     size_t num_inputs,
     DinoMLData* outputs,
     size_t num_outputs) {
-  if (num_inputs != num_inputs_) {
+  int num_optional_inputs = 0;
+  for (size_t i = 0; i < num_inputs_; ++i) {
+    if (InputOptional(i)) {
+      num_optional_inputs += 1;
+    }
+  }
+  bool invalid_inputs = false;
+  if (num_optional_inputs > 0 &&
+      num_inputs + num_optional_inputs != num_inputs_ &&
+      num_inputs != num_inputs_) {
+    invalid_inputs = true;
+  } else if (num_optional_inputs == 0 && num_inputs != num_inputs_) {
+    invalid_inputs = true;
+  }
+  if (invalid_inputs) {
     auto msg = "Got wrong number of inputs; expected " +
         std::to_string(num_inputs_) + ", got " + std::to_string(num_inputs);
     throw std::runtime_error(std::move(msg));
@@ -777,7 +797,7 @@ void ModelContainer::PrepareForRun(
   if (num_outputs > 0 && outputs == nullptr) {
     throw std::runtime_error("outputs cannot be null");
   }
-  for (size_t i = 0; i < num_inputs_; ++i) {
+  for (size_t i = 0; i < num_inputs; ++i) {
     auto& input = inputs[i];
     if (input.ptr != nullptr) {
       ValidateParamDtype(input.dtype, i);

--- a/csrc/model_container.cpp
+++ b/csrc/model_container.cpp
@@ -779,7 +779,9 @@ void ModelContainer::PrepareForRun(
   }
   for (size_t i = 0; i < num_inputs_; ++i) {
     auto& input = inputs[i];
-    ValidateParamDtype(input.dtype, i);
+    if (input.ptr != nullptr) {
+      ValidateParamDtype(input.dtype, i);
+    }
     model->SetInput(input.ptr, input.shape, i);
   }
 

--- a/csrc/model_interface.cpp
+++ b/csrc/model_interface.cpp
@@ -357,6 +357,17 @@ DinoMLError DinoMLModelContainerGetInputName(
       { *input_name_out = m->InputName(input_idx); })
 }
 
+DinoMLError DinoMLModelContainerGetInputOptional(
+    DinoMLModelHandle handle,
+    size_t input_idx,
+    bool* input_optional_out) {
+  RETURN_ERROR_IF_NULL(handle)
+  RETURN_ERROR_IF_NULL(input_optional_out)
+  auto* m = reinterpret_cast<dinoml::ModelContainer*>(handle);
+  CONVERT_EXCEPTION_TO_ERROR_CODE(
+      { *input_optional_out = m->InputOptional(input_idx); })
+}
+
 DinoMLError DinoMLModelContainerGetMaximumInputShape(
     DinoMLModelHandle handle,
     size_t input_idx,

--- a/src/dinoml/backend/codegen.py
+++ b/src/dinoml/backend/codegen.py
@@ -367,6 +367,7 @@ class ModelContainerGenerator:
         self.function_state = []
         self.set_up_constants = []
         self.set_up_param_names = []
+        self.set_up_param_optional = []
         self.set_up_param_dtypes = []
         self.set_up_bound_constant_dtypes = []
         self.set_up_bound_constant_size = []
@@ -462,6 +463,10 @@ class ModelContainerGenerator:
         )
         name = tensor._attrs["name"]
         self.set_up_param_names.append(set_value(f"param_names_[{idx}]", f'"{name}"'))
+        param_optional = str(tensor._attrs["is_optional"]).lower()
+        self.set_up_param_optional.append(
+            set_value(f"param_optional_[{idx}]", f"{param_optional}")
+        )
         self.set_up_param_dtypes.append(
             set_value(
                 f"param_dtypes_[{idx}]",
@@ -1117,6 +1122,7 @@ class ModelContainerGenerator:
             set_up_bound_constant_size="\n".join(self.set_up_bound_constant_size),
             set_up_output_shapes="\n".join(self.set_up_output_shapes),
             set_up_param_names="\n".join(self.set_up_param_names),
+            set_up_param_optional="\n".join(self.set_up_param_optional),
             num_constants=self.num_constants,
             num_bound_constants=self.bound_constant_idx,
             num_unbound_constants=self.unbound_constant_idx,

--- a/src/dinoml/backend/codegen.py
+++ b/src/dinoml/backend/codegen.py
@@ -225,6 +225,8 @@ def check_not_null(
     for these outputs - only allow them to be null if their lower bound
     is zero, otherwise never allow them to be null.
     """
+    if tensor._attrs["is_optional"]:
+        return ""
     name = tensor._attrs["name"]
     if tensor_idx is None:
         check = name

--- a/src/dinoml/backend/common/elementwise_common.py
+++ b/src/dinoml/backend/common/elementwise_common.py
@@ -230,6 +230,7 @@ FUNC_TEMPLATE = jinja2.Template(
 
 #include "jagged.h"
 #include "kernels/tensor_accessor.cuh"
+#include "device_functions-generated.h"
 
 namespace {
 
@@ -243,6 +244,7 @@ void invoke_{{func_name}}({{output_params}}, {{input_params}}, {{dynamic_dims_de
     if (n_elements == 0) {
       return;
     }
+    {{optional}}
     int block_size = static_cast<int>(std::ceil(static_cast<double>(n_elements) / N_ELEMENTS_PER_THREAD / FUSED_ELE_THREAD_SIZE));
     {{func_name}}<<<block_size, FUSED_ELE_THREAD_SIZE, 0, stream>>>(
         {{kernel_call_output_params}},
@@ -1264,6 +1266,37 @@ def _gen_kernel_function(
     )
     return kernel_func
 
+def gen_optional(inputs: List[Tensor], outputs: List[Tensor], backend_spec: BackendSpec):
+    optional_begin = """
+bool has_optional = false;
+"""
+    optional_end = """
+if (has_optional) {
+  return;
+}
+"""
+    optional = [optional_begin]
+    optional_template = jinja2.Template(
+        """
+if (input{{optional_idx}} == nullptr) {
+  dinoml::DeviceToDeviceCopy(output{{out_idx}}, input{{if_optional_idx}}, n_elements * sizeof({{dtype}}), stream);
+  has_optional = true;
+}
+"""
+    )
+    for out_idx, out_tensor in enumerate(outputs):
+        if out_tensor._attrs["if_optional"] is not None:
+            if_optional_idx = None
+            optional_idx = None
+            for idx, in_tensor in enumerate(inputs):
+                if out_tensor._attrs["if_optional"]._attrs["name"] == in_tensor._attrs["name"]:
+                    if_optional_idx = idx
+                if in_tensor._attrs["is_optional"]:
+                    optional_idx = idx
+            if if_optional_idx is not None and optional_idx is not None:
+                optional.append(optional_template.render(optional_idx=optional_idx, if_optional_idx=if_optional_idx, out_idx=out_idx, dtype=backend_spec.dtype_to_backend_type(out_tensor.dtype())))
+    optional.append(optional_end)
+    return "\n".join(optional)
 
 def fused_elementwise_gen_function(
     func_attrs: Dict[str, Any],
@@ -1342,7 +1375,7 @@ def fused_elementwise_gen_function(
         op_t=fused_elementwise_metadata.op_t,
         data_t=fused_elementwise_metadata.data_t,
     )
-
+    optional = gen_optional(fused_elementwise_metadata.inputs, fused_elementwise_metadata.outputs, backend_spec)
     function = FUNC_TEMPLATE.render(
         prefix=backend_spec.prefix,
         index_type=backend_spec.index_type,
@@ -1378,6 +1411,7 @@ def fused_elementwise_gen_function(
         ),
         kernel_call_output_params=kernel_call_output_params,
         kernel_call_input_params=kernel_call_input_params,
+        optional=optional,
     )
     return function
 

--- a/src/dinoml/backend/common/elementwise_common.py
+++ b/src/dinoml/backend/common/elementwise_common.py
@@ -1266,7 +1266,10 @@ def _gen_kernel_function(
     )
     return kernel_func
 
-def gen_optional(inputs: List[Tensor], outputs: List[Tensor], backend_spec: BackendSpec):
+
+def gen_optional(
+    inputs: List[Tensor], outputs: List[Tensor], backend_spec: BackendSpec
+):
     optional_begin = """
 bool has_optional = false;
 """
@@ -1289,14 +1292,25 @@ if (input{{optional_idx}} == nullptr) {
             if_optional_idx = None
             optional_idx = None
             for idx, in_tensor in enumerate(inputs):
-                if out_tensor._attrs["if_optional"]._attrs["name"] == in_tensor._attrs["name"]:
+                if (
+                    out_tensor._attrs["if_optional"]._attrs["name"]
+                    == in_tensor._attrs["name"]
+                ):
                     if_optional_idx = idx
                 if in_tensor._attrs["is_optional"]:
                     optional_idx = idx
             if if_optional_idx is not None and optional_idx is not None:
-                optional.append(optional_template.render(optional_idx=optional_idx, if_optional_idx=if_optional_idx, out_idx=out_idx, dtype=backend_spec.dtype_to_backend_type(out_tensor.dtype())))
+                optional.append(
+                    optional_template.render(
+                        optional_idx=optional_idx,
+                        if_optional_idx=if_optional_idx,
+                        out_idx=out_idx,
+                        dtype=backend_spec.dtype_to_backend_type(out_tensor.dtype()),
+                    )
+                )
     optional.append(optional_end)
     return "\n".join(optional)
+
 
 def fused_elementwise_gen_function(
     func_attrs: Dict[str, Any],
@@ -1375,7 +1389,11 @@ def fused_elementwise_gen_function(
         op_t=fused_elementwise_metadata.op_t,
         data_t=fused_elementwise_metadata.data_t,
     )
-    optional = gen_optional(fused_elementwise_metadata.inputs, fused_elementwise_metadata.outputs, backend_spec)
+    optional = gen_optional(
+        fused_elementwise_metadata.inputs,
+        fused_elementwise_metadata.outputs,
+        backend_spec,
+    )
     function = FUNC_TEMPLATE.render(
         prefix=backend_spec.prefix,
         index_type=backend_spec.index_type,

--- a/src/dinoml/backend/main_templates.py
+++ b/src/dinoml/backend/main_templates.py
@@ -371,6 +371,7 @@ ModelContainerBase::ModelContainerBase(
       bound_constant_dtypes_(num_bound_constants),
       num_params_(num_inputs + num_outputs + num_unbound_constants),
       param_names_(num_params_),
+      param_optional_(num_params_),
       param_dtypes_(num_params_),
       max_param_shapes_(num_params_),
       max_param_numel_(num_params_),
@@ -378,6 +379,7 @@ ModelContainerBase::ModelContainerBase(
 {{ set_up_constant_names }}
 {{ set_up_constant_original_names }}
 {{ set_up_param_names }}
+{{ set_up_param_optional }}
 {{ set_up_param_dtypes }}
 {{ set_up_bound_constant_dtypes }}
 {{ set_up_bound_constant_size }}

--- a/src/dinoml/builder/unet2d_condition.py
+++ b/src/dinoml/builder/unet2d_condition.py
@@ -1,5 +1,8 @@
 from dinoml.builder.base import Build, _model_name_with_resolution
+from dinoml.frontend import Tensor
 from dinoml.mapping.unet2d_condition import map_unet2d_condition
+from dinoml.utils.build_utils import build_tensors_from_annotations
+from dinoml.utils.shape_utils import get_shape
 
 
 class UNet2DConditionBuilder(Build):
@@ -30,3 +33,51 @@ class UNet2DConditionBuilder(Build):
     model_output_names = ["Y"]
 
     _model_name = _model_name_with_resolution
+    
+    def create_input_tensors(self):
+        self.input_tensors = build_tensors_from_annotations(
+            getattr(self.dinoml_module, self.model_forward),
+            symbolic_values=self.build_kwargs,
+            config=self.config,
+        )
+        sample_shape = self.input_tensors["sample"]._attrs["shape"]
+        down_block_additional_residuals = []
+        shape = [sample_shape[0], sample_shape[1], sample_shape[2], self.config["block_out_channels"][0]]
+        name = f"down_block_additional_residual_0"
+        down_block_additional_residual = Tensor(shape, name=name, is_input=True, is_optional=True, dtype=self.config["dtype"])
+        down_block_additional_residuals.append(down_block_additional_residual)
+        down_block_additional_residual_idx = 1
+        for idx, block_out_channel in enumerate(self.config["block_out_channels"]):
+            if idx < len(self.config["block_out_channels"]) - 1:
+                # with downsample
+                num_samples = self.config["layers_per_block"] + 1
+            else:
+                # no downsample                
+                num_samples = self.config["layers_per_block"]
+            for sample_idx in range(num_samples):
+                is_downsample = sample_idx == self.config["layers_per_block"]
+                shape = [sample_shape[0], sample_shape[1] / pow(2, idx), sample_shape[2] / pow(2, idx), block_out_channel]
+                if is_downsample:
+                    shape[1] = shape[1] / 2
+                    shape[2] = shape[2] / 2
+                name = f"down_block_additional_residual_{down_block_additional_residual_idx}"
+                down_block_additional_residual = Tensor(shape, name=name, is_input=True, is_optional=True, dtype=self.config["dtype"])
+                down_block_additional_residuals.append(down_block_additional_residual)
+                down_block_additional_residual_idx += 1
+        shape = [sample_shape[0], sample_shape[1] / (len(self.config["block_out_channels"])*2), sample_shape[2] / (len(self.config["block_out_channels"])*2), self.config["block_out_channels"][-1]]
+        mid_block_additional_residual = Tensor(shape, name="mid_block_additional_residual", is_input=True, is_optional=True, dtype=self.config["dtype"])
+        self.input_tensors["down_block_additional_residuals"] = down_block_additional_residuals
+        self.input_tensors["mid_block_additional_residual"] = mid_block_additional_residual
+        batch = list(self.input_tensors.values())[0]._attrs["shape"][0]
+        for name, tensor in self.input_tensors.items():
+            if isinstance(tensor, dict):
+                for sub_name, sub_tensor in tensor.items():
+                    sub_tensor._attrs["shape"][0] = batch
+                    print(f"{sub_name=}: {get_shape(sub_tensor)} {sub_tensor.dtype()}")
+            elif isinstance(tensor, list):
+                for idx, sub_tensor in enumerate(tensor):
+                    sub_tensor._attrs["shape"][0] = batch
+                    print(f"{name=}[{idx}] ({sub_tensor._attrs["name"]}): {get_shape(sub_tensor)} {sub_tensor.dtype()}")
+            else:
+                print(f"{name=}: {get_shape(tensor)} {tensor.dtype()}")
+                tensor._attrs["shape"][0] = batch

--- a/src/dinoml/builder/unet2d_condition.py
+++ b/src/dinoml/builder/unet2d_condition.py
@@ -33,7 +33,7 @@ class UNet2DConditionBuilder(Build):
     model_output_names = ["Y"]
 
     _model_name = _model_name_with_resolution
-    
+
     def create_input_tensors(self):
         self.input_tensors = build_tensors_from_annotations(
             getattr(self.dinoml_module, self.model_forward),
@@ -42,9 +42,20 @@ class UNet2DConditionBuilder(Build):
         )
         sample_shape = self.input_tensors["sample"]._attrs["shape"]
         down_block_additional_residuals = []
-        shape = [sample_shape[0], sample_shape[1], sample_shape[2], self.config["block_out_channels"][0]]
-        name = f"down_block_additional_residual_0"
-        down_block_additional_residual = Tensor(shape, name=name, is_input=True, is_optional=True, dtype=self.config["dtype"])
+        shape = [
+            sample_shape[0],
+            sample_shape[1],
+            sample_shape[2],
+            self.config["block_out_channels"][0],
+        ]
+        name = "down_block_additional_residual_0"
+        down_block_additional_residual = Tensor(
+            shape,
+            name=name,
+            is_input=True,
+            is_optional=True,
+            dtype=self.config["dtype"],
+        )
         down_block_additional_residuals.append(down_block_additional_residual)
         down_block_additional_residual_idx = 1
         for idx, block_out_channel in enumerate(self.config["block_out_channels"]):
@@ -52,22 +63,48 @@ class UNet2DConditionBuilder(Build):
                 # with downsample
                 num_samples = self.config["layers_per_block"] + 1
             else:
-                # no downsample                
+                # no downsample
                 num_samples = self.config["layers_per_block"]
             for sample_idx in range(num_samples):
                 is_downsample = sample_idx == self.config["layers_per_block"]
-                shape = [sample_shape[0], sample_shape[1] / pow(2, idx), sample_shape[2] / pow(2, idx), block_out_channel]
+                shape = [
+                    sample_shape[0],
+                    sample_shape[1] / pow(2, idx),
+                    sample_shape[2] / pow(2, idx),
+                    block_out_channel,
+                ]
                 if is_downsample:
                     shape[1] = shape[1] / 2
                     shape[2] = shape[2] / 2
                 name = f"down_block_additional_residual_{down_block_additional_residual_idx}"
-                down_block_additional_residual = Tensor(shape, name=name, is_input=True, is_optional=True, dtype=self.config["dtype"])
+                down_block_additional_residual = Tensor(
+                    shape,
+                    name=name,
+                    is_input=True,
+                    is_optional=True,
+                    dtype=self.config["dtype"],
+                )
                 down_block_additional_residuals.append(down_block_additional_residual)
                 down_block_additional_residual_idx += 1
-        shape = [sample_shape[0], sample_shape[1] / (len(self.config["block_out_channels"])*2), sample_shape[2] / (len(self.config["block_out_channels"])*2), self.config["block_out_channels"][-1]]
-        mid_block_additional_residual = Tensor(shape, name="mid_block_additional_residual", is_input=True, is_optional=True, dtype=self.config["dtype"])
-        self.input_tensors["down_block_additional_residuals"] = down_block_additional_residuals
-        self.input_tensors["mid_block_additional_residual"] = mid_block_additional_residual
+        shape = [
+            sample_shape[0],
+            sample_shape[1] / (len(self.config["block_out_channels"]) * 2),
+            sample_shape[2] / (len(self.config["block_out_channels"]) * 2),
+            self.config["block_out_channels"][-1],
+        ]
+        mid_block_additional_residual = Tensor(
+            shape,
+            name="mid_block_additional_residual",
+            is_input=True,
+            is_optional=True,
+            dtype=self.config["dtype"],
+        )
+        self.input_tensors["down_block_additional_residuals"] = (
+            down_block_additional_residuals
+        )
+        self.input_tensors["mid_block_additional_residual"] = (
+            mid_block_additional_residual
+        )
         batch = list(self.input_tensors.values())[0]._attrs["shape"][0]
         for name, tensor in self.input_tensors.items():
             if isinstance(tensor, dict):
@@ -77,7 +114,9 @@ class UNet2DConditionBuilder(Build):
             elif isinstance(tensor, list):
                 for idx, sub_tensor in enumerate(tensor):
                     sub_tensor._attrs["shape"][0] = batch
-                    print(f"{name=}[{idx}] ({sub_tensor._attrs["name"]}): {get_shape(sub_tensor)} {sub_tensor.dtype()}")
+                    print(
+                        f"{name=}[{idx}] ({sub_tensor._attrs['name']}): {get_shape(sub_tensor)} {sub_tensor.dtype()}"
+                    )
             else:
                 print(f"{name=}: {get_shape(tensor)} {tensor.dtype()}")
                 tensor._attrs["shape"][0] = batch

--- a/src/dinoml/compiler/base.py
+++ b/src/dinoml/compiler/base.py
@@ -799,6 +799,8 @@ class Tensor(Node):
         dtype: str = "float16",
         is_input: bool = False,
         is_output: bool = False,
+        is_optional: bool = False,
+        if_optional: Tensor = None,
         value: Any = None,
         is_view_of: Any = None,
         is_internal_constant: bool = False,
@@ -853,9 +855,12 @@ class Tensor(Node):
         self._attrs["dtype"] = normalize_dtype(dtype)
         self._attrs["is_output"] = is_output
         self._attrs["is_input"] = is_input
+        self._attrs["is_optional"] = is_optional
         self._attrs["is_param"] = False
         self._attrs["is_internal_constant"] = is_internal_constant
         self._attrs["skip_constant_folding"] = skip_constant_folding
+
+        self._attrs["if_optional"] = if_optional
 
         # True if this is an internal tensor that aliases an output through
         # a view. Set up in mark_param_tensor

--- a/src/dinoml/compiler/model.py
+++ b/src/dinoml/compiler/model.py
@@ -267,7 +267,9 @@ class Model:
         self.debug_sorted_graph = None
 
         self._output_name_to_index = self._construct_output_name_to_index_map()
-        self._input_name_to_index = self._construct_input_name_to_index_map()
+        self._input_name_to_index, self._input_name_to_optional = (
+            self._construct_input_name_to_index_map()
+        )
         self._output_ndims = [
             len(self.get_output_maximum_shape(i))
             for i in range(len(self._output_name_to_index))
@@ -321,8 +323,9 @@ class Model:
         return _CFormatDinoMLData(c_pointer, c_shape, c_dtype)
 
     def _convert_params_to_c_format(self, params: List[DinoMLData]):
-        c_params = (_CFormatDinoMLData * len(params))()
-        for i, param in enumerate(params):
+        params_ = [param for param in params if param is not None]
+        c_params = (_CFormatDinoMLData * len(params_))()
+        for i, param in enumerate(params_):
             c_params[i] = self._convert_single_param_to_c_format(param)
         return c_params
 
@@ -353,22 +356,34 @@ class Model:
             c_output_shapes_out,
         )
 
-    def _dict_to_ordered_list(self, params, is_inputs):
+    def _dict_to_ordered_list(self, params: Dict[str, DinoMLData], is_inputs):
         if is_inputs:
             index_map = self._input_name_to_index
+            optional_map = self._input_name_to_optional
         else:
             index_map = self._output_name_to_index
-        if len(params) != len(index_map):
+            optional_map = {}
+        has_required_keys = True
+        has_optional = any(optional_map.values())
+        required_keys = list(index_map.keys())
+        if has_optional and len(params) != len(index_map):
+            required_keys = [
+                key for key in optional_map.keys() if not optional_map[key]
+            ]
+            has_required_keys = all(key in params for key in required_keys)
+        if len(params) != len(index_map) and not has_required_keys:
             raise ValueError(
                 f"Did not get correct number of {'inputs' if is_inputs else 'outputs'} expected {len(index_map)}, got {len(params)}"
             )
 
-        result = [None] * len(index_map)
+        result = [None] * len(required_keys)
         for name, tensor in params.items():
             if name not in index_map:
                 raise ValueError(
                     f"Got unexpected {'input' if is_inputs else 'output'}: {name}"
                 )
+            if tensor is None:
+                continue
 
             result[index_map[name]] = tensor
 
@@ -765,15 +780,21 @@ class Model:
         )
         return (mean, std, self._interpret_tensors_as_shapes(outputs, dinoml_outputs))
 
-    def _get_map_helper(self, n: int, get_name_func) -> Dict[str, int]:
+    def _get_map_helper(
+        self, n: int, get_name_func, get_optional_func: Callable = None
+    ) -> Tuple[Dict[str, int], Dict[str, bool]]:
         result = {}
+        result_optional = {}
         for i in range(n):
             c_name = ctypes.c_char_p()
             c_idx = ctypes.c_size_t(i)
             get_name_func(c_idx, ctypes.byref(c_name))
             name = c_name.value.decode("utf-8")
+            if get_optional_func is not None:
+                optional = get_optional_func(c_idx)
+                result_optional[name] = optional
             result[name] = i
-        return result
+        return result, result_optional
 
     def get_required_memory(self):
         required_memory = ctypes.c_size_t()
@@ -782,14 +803,25 @@ class Model:
         )
         return required_memory.value
 
-    def _construct_input_name_to_index_map(self) -> Dict[str, int]:
+    def _construct_input_name_to_index_map(
+        self,
+    ) -> Tuple[Dict[str, int], Dict[str, bool]]:
         num_inputs = ctypes.c_size_t()
         self.DLL.DinoMLModelContainerGetNumInputs(self.handle, ctypes.byref(num_inputs))
 
         def get_input_name(idx, name):
             return self.DLL.DinoMLModelContainerGetInputName(self.handle, idx, name)
 
-        return self._get_map_helper(num_inputs.value, get_input_name)
+        def get_input_optional(idx):
+            optional = ctypes.c_bool()
+            self.DLL.DinoMLModelContainerGetInputOptional(
+                self.handle, idx, ctypes.byref(optional)
+            )
+            return optional.value
+
+        return self._get_map_helper(
+            num_inputs.value, get_input_name, get_input_optional
+        )
 
     def get_input_name_to_index_map(self) -> Dict[str, int]:
         """
@@ -810,7 +842,7 @@ class Model:
         def get_output_name(idx, name):
             return self.DLL.DinoMLModelContainerGetOutputName(self.handle, idx, name)
 
-        return self._get_map_helper(num_outputs.value, get_output_name)
+        return self._get_map_helper(num_outputs.value, get_output_name)[0]
 
     def get_output_name_to_index_map(self) -> Dict[str, int]:
         """

--- a/src/dinoml/compiler/model.py
+++ b/src/dinoml/compiler/model.py
@@ -124,6 +124,8 @@ def _check_tensors_contiguous_and_on_gpu(
     tensors: Union[Dict[str, TorchTensor], List[TorchTensor]], name: str
 ):
     def is_bad_tensor(tensor: TorchTensor) -> bool:
+        if tensor is None:
+            return False
         return not tensor.is_contiguous() or not tensor.is_cuda
 
     _check_tensors(tensors, is_bad_tensor, name, "contiguous and on GPU")
@@ -142,6 +144,12 @@ def torch_to_dinoml_data(tensor: TorchTensor) -> DinoMLData:
     """
     Convert a torch Tensor to a DinoMLData.
     """
+    if tensor is None:
+        return DinoMLData(
+            None,
+            [],
+            "float16",
+        )
     return DinoMLData(
         tensor.data_ptr(), list(tensor.size()), torch_dtype_to_string(tensor.dtype)
     )

--- a/src/dinoml/compiler/ops/common/elementwise.py
+++ b/src/dinoml/compiler/ops/common/elementwise.py
@@ -214,6 +214,7 @@ class elementwise(Operator):
         symbolic_args = []
         common_dtype = None
         assert len(args) > 0, "Elementwise ops must take at least one argument."
+        assert len(args) <= 2, "Got more than 2 elementwise arguments"
         for arg in args:
             if isinstance(arg, int) or isinstance(arg, float):
                 converted_args.append(Tensor(shape=[], value=arg))
@@ -269,13 +270,21 @@ class elementwise(Operator):
                 if arg.is_a_const_num():
                     arg._attrs["dtype"] = common_dtype
 
+        if_optional = None
+        if len(converted_args) == 2:
+            if converted_args[0]._attrs["is_optional"]:
+                if_optional = converted_args[1]
+                converted_args[0]._attrs["if_optional"] = if_optional
+            elif converted_args[1]._attrs["is_optional"]:
+                if_optional = converted_args[0]
+                converted_args[1]._attrs["if_optional"] = if_optional
         self._attrs["args"] = list(converted_args)
         self._attrs["inputs"] = [
             arg for arg in converted_args if not arg.is_a_const_num()
         ]
         self._set_depth()
         output_shape = self._infer_shapes(*converted_args)
-        output = Tensor(output_shape, src_ops={self}, dtype=common_dtype)
+        output = Tensor(output_shape, src_ops={self}, dtype=common_dtype, if_optional=if_optional)
         if self._attrs["func"] in INT_ELEMENTWISE_FUNC and None not in symbolic_args:
             output._attrs["symbolic_value"] = functools.reduce(
                 INT_ELEMENTWISE_FUNC[self._attrs["func"]], symbolic_args

--- a/src/dinoml/compiler/ops/common/elementwise.py
+++ b/src/dinoml/compiler/ops/common/elementwise.py
@@ -284,7 +284,9 @@ class elementwise(Operator):
         ]
         self._set_depth()
         output_shape = self._infer_shapes(*converted_args)
-        output = Tensor(output_shape, src_ops={self}, dtype=common_dtype, if_optional=if_optional)
+        output = Tensor(
+            output_shape, src_ops={self}, dtype=common_dtype, if_optional=if_optional
+        )
         if self._attrs["func"] in INT_ELEMENTWISE_FUNC and None not in symbolic_args:
             output._attrs["symbolic_value"] = functools.reduce(
                 INT_ELEMENTWISE_FUNC[self._attrs["func"]], symbolic_args

--- a/src/dinoml/compiler/transform/fuse_ops.py
+++ b/src/dinoml/compiler/transform/fuse_ops.py
@@ -86,6 +86,8 @@ def _find_fusable_elementwise_ops(src_op: Operator) -> Set[Operator]:
     # Get parent ops.
     dependent_ops = set()
     for input_tensor in src_op._attrs["inputs"]:
+        if input_tensor._attrs.get("is_optional", False):
+            return set()
         dependent_ops.update(input_tensor._attrs["src_ops"])
     original_ops = set(dependent_ops)
 
@@ -95,6 +97,9 @@ def _find_fusable_elementwise_ops(src_op: Operator) -> Set[Operator]:
         if op._attrs["op"] != "elementwise":
             to_be_removed_set.add(op)
         else:
+            for t in op._attrs["inputs"]:
+                if t._attrs.get("is_optional", False):
+                    to_be_removed_set.add(op)
             # Assuming there are two elementwise ops, op1 and op2, where op1 is a
             # parent op of op2. If op1's output is an output tensor, or if op1 is
             # consumed by other non-elementwise ops, op1 cannot be fused with op2.


### PR DESCRIPTION
Introduces the concept of Optional input tensors. The use case is supporting something like UNet2DCondtional controlnet residuals without a) compiling distinct modules for "with residuals" and "without residuals" b) passing zeros for residuals when not used.

## Tensor
- Introduce `is_optional`, this is a `bool` set on the input tensor
- Introduce `if_optional`, this is set by the operator, e.g. elementwise, to the other Tensor we should use when the Tensor is optional

## Model (Python interface)
- `is_bad_tensor` (the check for on GPU and contiguous) returns `False` if tensor is `None`
- `torch_to_dinoml_data` returns: `None` for pointer, empty shape, and any dtype
- `_construct_input_name_to_index_map` also retrieves which inputs are optional
- `_dict_to_ordered_list` handles omitted optional inputs and checks required inputs are passed

## ModelContainer
- Introduce `param_optional_` and `InputOptional`
### When optional inputs are omitted
- Number of optional inputs is incorporated into num_inputs check
- Only the passed number of inputs is checked
### When optional inputs are "empty" `DinoMLData`
- In `PrepareForRun` we don't validate dtype if input is nullptr

## Model Interface
- Introduce `DinoMLModelContainerGetInputOptional`

## ModelBase
- In `SetInputShape` we return early when `shape.size == 0`
  - Note: `PrepareForRun` calls `SetInput` which calls both `SetInputShape` and `SetParam`

## Debug utility
- Checks for `nullptr`, this is required as we recently added checking input tensors when `DinoMLDebugSettings(check_all_outputs=True)`

## Codegen
- When input is optional we don't output the nullptr check
- Write `param_optional_` for each index, this includes outputs and constants, so we are prepared to support optional constants  in the future

## ops.elementwise
- When one input is optional we set `if_optional` to the other
- We also set `if_optional` on the output, this helps to link together in codegen

## Elementwise backend
- Introduce codegen for optional tensors, this links together the output to the inputs and we use `DeviceToDeviceCopy` to copy the non-optional tensor to the output

## Elementwise fusion
- We ensure that an elementwise with optional tensors is not fused with another elementwise

## UNet2DConditional
- We override `create_input_tensors` to set the `down_block_additional_residuals` and `mid_block_additional_residual` tensors, this should work with any `UNet2DConditional` config (e.g. SD v1.5, SD XL)
- Note: We will look at how to move this into the `Annotated` `forward` pattern

Tested on Windows AMD 9070 XT with v1.5

```
DinoML mean with residual: 29.492
DinoML mean without residual: 29.360
```

There is minimal difference in inference time with the residuals, and no degradation compared to a module compiled without residuals support when they are not used.

<details><summary>With residuals output</summary>
<p>

```
Y=tensor([[[[-7.5562e-02,  1.1853e-01, -6.8604e-01,  2.2009e-01],
          [-6.8970e-02, -1.2720e-01,  6.0840e-01, -5.4590e-01],
          [ 2.3206e-01,  7.1191e-01,  6.2402e-01, -1.0078e+00],
          ...,
          [-2.6343e-01,  8.5693e-01,  7.2559e-01, -4.1113e-01],
          [ 3.2654e-02, -6.9238e-01,  2.2424e-01,  1.0449e+00],
          [ 4.2261e-01,  8.1421e-02, -2.7563e-01, -1.6809e-01]],

         [[ 6.1963e-01, -2.9932e-01,  5.7037e-02, -1.0410e+00],
          [-6.4160e-01, -1.6040e-01, -5.4297e-01,  8.2178e-01],
          [-1.7859e-01, -3.0249e-01, -3.3203e-02, -1.1395e-01],
          ...,
          [-3.4790e-02,  7.9443e-01,  5.0488e-01, -1.7773e-01],
          [-9.4385e-01, -4.7290e-01, -4.4995e-01,  1.0566e+00],
          [-3.1787e-01,  1.8958e-01,  6.3037e-01, -7.5146e-01]],

         [[-1.0615e+00, -3.5095e-02, -2.2241e-01,  7.2559e-01],
          [ 9.6338e-01, -2.5415e-01,  5.3857e-01, -1.0918e+00],
          [ 2.1643e-01,  4.8389e-01,  1.4141e+00, -1.3867e+00],
          ...,
          [-1.6821e-01,  1.0608e-01, -2.2290e-01, -3.5254e-01],
          [ 5.9521e-01,  6.0010e-01, -7.9639e-01, -4.8706e-01],
          [ 3.8354e-01, -2.4390e-01,  4.3799e-01, -1.4526e-01]],

         ...,

         [[-7.9639e-01, -7.7979e-01, -6.7236e-01,  3.3374e-01],
          [-7.3877e-01, -4.0845e-01, -8.3008e-02,  1.0406e-01],
          [-9.4141e-01,  5.9473e-01,  2.0288e-01,  1.1006e+00],
          ...,
          [-1.1250e+00,  6.3574e-01,  1.2246e+00, -1.6296e-02],
          [ 7.9529e-02,  2.3853e-01,  3.2812e-01, -4.6478e-02],
          [-2.0154e-01, -1.6797e-01,  5.6934e-01, -4.8340e-01]],

         [[ 5.3369e-01,  7.9785e-01,  7.1387e-01, -4.6826e-01],
          [ 2.3254e-01,  3.2617e-01,  1.9702e-01, -2.4744e-01],
          [-1.2903e-01,  4.3115e-01,  5.5371e-01,  1.7322e-01],
          ...,
          [ 3.2593e-02,  7.4463e-02,  2.6318e-01, -1.1346e-01],
          [-5.4395e-01, -1.3306e-01, -4.8364e-01,  4.4531e-01],
          [-7.3433e-03,  3.2251e-01,  4.5996e-01, -6.7993e-02]],

         [[-5.7959e-01,  7.6218e-03,  7.5879e-01, -1.2913e-03],
          [ 3.7500e-01, -4.9268e-01,  5.6055e-01,  1.1553e+00],
          [-5.0568e-02, -1.2964e-01, -4.3994e-01,  7.9422e-03],
          ...,
          [ 6.6895e-01,  5.8807e-02,  5.9473e-01, -9.0918e-01],
          [ 1.0022e-01,  7.2021e-01, -7.9639e-01,  8.1592e-01],
          [ 1.6821e-01, -5.8258e-02, -1.2998e+00,  8.2642e-02]]],


        [[[-3.7329e-01, -4.1479e-01, -1.7031e+00,  1.6494e+00],
          [-1.6870e-01,  4.5239e-01,  2.6660e-01, -4.2236e-01],
          [-4.7485e-02, -4.8828e-01,  2.6318e-01,  1.4771e-01],
          ...,
          [ 2.6318e-01, -4.2578e-01, -2.6978e-01,  3.4790e-01],
          [ 4.1699e-01, -1.6675e-01,  7.3792e-02, -4.5386e-01],
          [-5.9912e-01,  2.5684e-01,  1.0992e-01,  5.4980e-01]],

         [[-1.2520e+00, -7.4097e-02, -6.0242e-02, -2.3389e-01],
          [ 8.3105e-01, -4.9951e-01,  2.2717e-01, -1.9714e-01],
          [-2.8955e-01, -1.6003e-01, -5.5664e-01, -3.0457e-02],
          ...,
          [-6.0791e-02,  5.6201e-01,  1.1475e-02, -2.9175e-01],
          [ 3.6963e-01,  6.2646e-01,  8.8770e-01, -4.6948e-01],
          [ 1.2500e-01, -4.6118e-01, -2.8003e-01, -2.6294e-01]],

         [[ 4.5239e-01,  5.8289e-02, -4.3823e-02, -4.2871e-01],
          [ 8.5840e-01,  6.1719e-01,  2.8687e-01, -5.6299e-01],
          [-9.3506e-02,  2.9190e-02,  1.7944e-02,  7.1094e-01],
          ...,
          [-4.8431e-02, -2.7176e-02, -8.5510e-02,  1.1152e+00],
          [ 1.1267e-01,  2.4500e-01, -3.7817e-01, -7.8174e-01],
          [-5.1904e-01, -6.8359e-02, -4.4617e-02,  1.0391e-02]],

         ...,

         [[ 2.8955e-01,  1.8640e-01,  9.7656e-03, -5.5420e-01],
          [-7.5342e-01,  3.6670e-01,  8.0490e-03,  5.7031e-01],
          [-4.1309e-01, -1.0132e-01, -1.3721e-01,  4.0869e-01],
          ...,
          [ 1.6479e-02, -5.5313e-03, -1.2341e-01,  1.7310e-01],
          [ 7.3828e-01, -2.1887e-01,  5.3516e-01, -7.1875e-01],
          [-1.8823e-01, -3.9444e-03, -1.5247e-01, -4.8096e-01]],

         [[ 2.4438e-01,  1.4697e-01, -4.2389e-02,  2.3914e-01],
          [-9.5605e-01, -3.8306e-01, -9.1699e-01,  6.2061e-01],
          [ 5.8447e-01, -2.2058e-01,  8.6609e-02, -8.4167e-02],
          ...,
          [-6.8896e-01,  3.2568e-01, -4.2456e-01,  5.0684e-01],
          [-2.6685e-01, -8.3252e-02, -1.2494e-01,  4.1919e-01],
          [ 8.4778e-02,  5.8252e-01, -3.0762e-01,  3.3594e-01]],

         [[-1.3440e-01,  3.0176e-01,  6.3525e-01, -6.8750e-01],
          [ 6.3672e-01,  1.0132e-01,  8.8721e-01, -1.3252e+00],
          [-4.8926e-01, -2.0300e-01, -6.3818e-01,  1.0342e+00],
          ...,
          [-2.1106e-01,  1.1025e+00,  8.5254e-01, -1.9031e-01],
          [ 1.7502e-02, -2.7542e-02,  2.7319e-01, -9.3701e-01],
          [ 4.3304e-02,  3.1471e-03,  2.4878e-01, -7.4463e-01]]]],
       device='cuda:0', dtype=torch.float16)
```
</p>
</details> 

<details><summary>Without residuals output</summary>
<p>

```

Y_no_residual=tensor([[[[ 0.3003, -0.2080, -0.8159,  0.4590],
          [-0.0330, -0.1815,  0.2206, -0.3340],
          [ 0.0043,  0.3818,  0.0276, -0.3657],
          ...,
          [ 0.1122,  0.4768,  0.5122, -0.4194],
          [ 0.1003, -0.3115,  0.0089,  0.4409],
          [ 0.6509, -0.5122, -0.3992, -0.2406]],

         [[ 0.6172, -0.0157,  0.4695, -1.1738],
          [-0.6763,  0.0032, -0.4409,  0.7085],
          [-0.0128, -0.1002, -0.0407, -0.1639],
          ...,
          [-0.2698,  0.2460,  0.1046,  0.3340],
          [-1.1270, -0.9380, -0.5527,  1.0635],
          [ 0.0648,  0.2385,  0.4082, -0.4541]],

         [[-0.5996,  0.0708, -0.3474,  0.6621],
          [ 0.5059, -0.1252,  0.8047, -0.9707],
          [ 0.4182, -0.1311,  0.4612, -0.7231],
          ...,
          [-0.2360, -0.0018, -0.0400, -0.1278],
          [ 0.4009,  0.5898, -0.1489, -0.5020],
          [ 0.2927, -0.2283, -0.1172, -0.1586]],

         ...,

         [[-0.6777, -0.4185, -0.5981,  0.5522],
          [-0.4861, -0.0138,  0.2749, -0.2373],
          [-0.2180,  0.1837,  0.0782,  0.2527],
          ...,
          [-0.6284,  0.3032,  0.6821,  0.1010],
          [ 0.1849,  0.0945,  0.2250,  0.0359],
          [ 0.0964, -0.2494,  0.0637, -0.1361]],

         [[-0.1346,  0.3042,  0.5171, -0.0259],
          [-0.0272,  0.2466,  0.2527, -0.2164],
          [-0.0249,  0.1963,  0.1428,  0.0771],
          ...,
          [ 0.0201,  0.0916,  0.2490,  0.0809],
          [-0.5806, -0.1439, -0.1111, -0.1266],
          [ 0.1593,  0.4412,  0.3770, -0.1191]],

         [[ 0.0470,  0.0636,  0.3125, -0.1436],
          [ 0.1543, -0.1100,  0.1310,  0.7363],
          [-0.1487,  0.0441, -0.1659, -0.1997],
          ...,
          [ 0.0609,  0.1652,  0.0768, -0.3064],
          [ 0.0364,  0.0999, -0.5645,  0.4019],
          [ 0.0908,  0.1837, -0.3726,  0.0579]]],


        [[[-0.4263, -0.1421, -0.8535,  0.7134],
          [-0.2615,  0.1854,  0.1454,  0.1418],
          [ 0.2059, -0.4324,  0.0916, -0.0905],
          ...,
          [-0.2842, -0.0144, -0.1835,  0.6089],
          [ 0.2285, -0.0509,  0.0587, -0.5322],
          [-0.0811,  0.1259,  0.0102,  0.3806]],

         [[-0.4849, -0.0946, -0.0915, -0.1083],
          [ 0.3145, -0.0269, -0.0277,  0.2189],
          [-0.1746, -0.0607, -0.2966,  0.0605],
          ...,
          [-0.1212,  0.5811, -0.0352,  0.1122],
          [ 0.2954,  0.3804,  0.3967, -0.5337],
          [-0.0022, -0.1931, -0.2754,  0.0770]],

         [[ 0.4922,  0.1417,  0.1781, -0.4731],
          [ 0.1533,  0.2727, -0.1899, -0.0428],
          [-0.2255,  0.1937, -0.0474,  0.1547],
          ...,
          [ 0.0493, -0.0237,  0.1335,  0.2394],
          [ 0.2036,  0.1062, -0.0725, -0.6211],
          [-0.4705, -0.1743, -0.2175, -0.0357]],

         ...,

         [[-0.0500, -0.0642, -0.0384, -0.2229],
          [-0.0848, -0.0195, -0.0806,  0.1123],
          [ 0.0378, -0.1228, -0.0284, -0.1536],
          ...,
          [-0.2573,  0.1962, -0.1941,  0.3757],
          [ 0.3860, -0.1810,  0.1614, -0.4023],
          [-0.2991,  0.0276, -0.1466, -0.0362]],

         [[ 0.0961,  0.1472,  0.2018,  0.1102],
          [-0.4365, -0.3381, -0.4131,  0.1388],
          [ 0.1418,  0.1030,  0.1749,  0.0553],
          ...,
          [-0.3633, -0.0443,  0.0249,  0.2471],
          [-0.2013,  0.2466,  0.1389,  0.2659],
          [ 0.1262,  0.7280,  0.1918,  0.2815]],

         [[ 0.1096,  0.1219,  0.2759, -0.1343],
          [ 0.2573,  0.0091,  0.3130, -0.3694],
          [-0.4004,  0.0216, -0.2482,  0.6411],
          ...,
          [ 0.0282,  0.5093,  0.1246, -0.1426],
          [-0.0928, -0.0795,  0.0721, -0.1431],
          [ 0.1868, -0.1970,  0.1510, -0.7090]]]], device='cuda:0',
       dtype=torch.float16)
```

</p>
</details> 

## Notes

### Empty or omitted?
We have 2 options for optional tensors

Set them to `None`, this creates "empty" `DinoMLData`
```
inputs, outputs = prepare_inputs_outputs(module)

for key in inputs.keys():
    if "residual" in key:
        inputs[key] = None
```

Omit them
```
inputs = {k: v for k, v in inputs.items() if "residual" not in k}
```

In general, both are supported, but this can be model specific, depending on the generated ordering of input tensors. For reference, the ordering of input tensors is related to the order in which input tensors are used.

In this example, `UNet2DCondition`, `timestep` is used first, so this is index 0, `sample` is used next, this is index 1, `encoder_hidden_states` is index 2, and `down_block_additional_residuals`/`mid_block_additional_residual` follow, so we can safely use either "empty" or omit the optional inputs.

If a model had an optional tensor *before* all the required tensors then omitting the optional tensors will not work as the ordering would be wrong, in that case we must use "empty" `DinoMLData`.

We do not anticipate this being an issue, if we discover a model that has optional tensors before all required tensors we will implement a workaround, we can probably order the `param_names_` based on required/optional.

### Guidelines (tl;dr)
- Both "empty" (`None`) and "omitted" optional inputs are supported
- Omission is only valid when all optional inputs appear after all required inputs in the model’s input ordering.
- Passing `None` is always safe and preserves ordering.
- If a model violates this ordering, users must pass `None` for optional inputs.
  - A structural fix can be implemented if this occurs.