### PR TITLE
Add T2IAdapter builder. Support AvgPool2d ceil_mode. Fix PixelUnshuffle output shape in C++

### DIFF
--- a/csrc/include/ops/avg_pool_2d.h
+++ b/csrc/include/ops/avg_pool_2d.h
@@ -12,34 +12,49 @@ template <
     int KernelSize,
     int Stride,
     int Padding>
-__global__ void avg_pool_1d_kernel(
+__global__ void avg_pool_2d_kernel(
     const ElemType* input_raw,
     ElemType* output_raw,
     const int N,
+    const int H,
     const int W,
     const int C,
+    const int HO,
     const int WO) {
   const VectorType* input = (const VectorType*)input_raw;
   VectorType* output = (VectorType*)output_raw;
 
   const int tid = threadIdx.x;
   const int n_idx = blockIdx.x;
-  const int out_w_idx = blockIdx.y;
+  const int out_h_idx = blockIdx.y;
+  const int out_w_idx = blockIdx.z;
+
+  int h_start_idx = out_h_idx * Stride - Padding;
+  int h_end_idx = h_start_idx + KernelSize;
+  h_start_idx = (h_start_idx < 0) ? 0 : h_start_idx;
+  h_end_idx = (h_end_idx > H) ? H : h_end_idx;
 
   int w_start_idx = out_w_idx * Stride - Padding;
   int w_end_idx = w_start_idx + KernelSize;
   w_start_idx = (w_start_idx < 0) ? 0 : w_start_idx;
-  w_end_idx = w_end_idx > W ? W : w_end_idx;
+  w_end_idx = (w_end_idx > W) ? W : w_end_idx;
 
-  input += n_idx * W * C;
-  output += (n_idx * WO + out_w_idx) * C;
-  const float norm_factor = static_cast<float>(1.0f / KernelSize);
+  input += n_idx * H * W * C;
+  output += ((n_idx * HO + out_h_idx) * WO + out_w_idx) * C;
+
+  const float norm_factor =
+      static_cast<float>(1.0f / (KernelSize * KernelSize));
+
   for (int c_idx = tid; c_idx < C; c_idx += blockDim.x) {
     float2 avg = {0.f, 0.f};
-    for (int w = w_start_idx; w < w_end_idx; w++) {
-      const int idx = w * C;
-      const VectorType tmp = LDG(input + (idx + c_idx));
-      avg = dinoml::helpers::add2(avg, tmp);
+
+    for (int h = h_start_idx; h < h_end_idx; ++h) {
+#pragma unroll
+      for (int w = w_start_idx; w < w_end_idx; ++w) {
+        const int idx = (h * W + w) * C;
+        const VectorType tmp = LDG(input + (idx + c_idx));
+        avg = dinoml::helpers::add2(avg, tmp);
+      }
     }
 
     avg.x *= norm_factor;
@@ -56,12 +71,14 @@ template <
     int KernelSize,
     int Stride,
     int Padding>
-void avg_pool_1d_launcher(
+void avg_pool_2d_launcher(
     const ElemType* input,
     ElemType* output,
     const int N,
+    const int H,
     const int W,
     const int C,
+    const int HO,
     const int WO,
     dinoml::DeviceStream stream) {
   int num_thread = C / 2;
@@ -70,8 +87,10 @@ void avg_pool_1d_launcher(
   } else if (num_thread == 0) {
     num_thread = 1;
   }
-  dim3 grid(N, WO);
+
+  dim3 grid(N, HO, WO);
   dim3 block(num_thread);
-  dinoml::avg_pool_1d_kernel<ElemType, VectorType, KernelSize, Stride, Padding>
-      <<<grid, block, 0, stream>>>(input, output, N, W, C / 2, WO);
+
+  dinoml::avg_pool_2d_kernel<ElemType, VectorType, KernelSize, Stride, Padding>
+      <<<grid, block, 0, stream>>>(input, output, N, H, W, C / 2, HO, WO);
 }

--- a/scripts/t2i_adapter_build.py
+++ b/scripts/t2i_adapter_build.py
@@ -1,0 +1,13 @@
+from dinoml.builder.t2i_adapter import T2IAdapterBuilder
+
+builder = T2IAdapterBuilder(
+    hf_hub="hlky/t2iadapter_canny_sd15v2",
+    label="canny_sd15v2",
+    dtype="float16",
+    device="cuda",
+    build_kwargs={
+        "batch_size": (1, 2),
+        "resolution": (8, 512),
+    },
+)
+builder()

--- a/src/dinoml/backend/common/pixel_unshuffle_common.py
+++ b/src/dinoml/backend/common/pixel_unshuffle_common.py
@@ -55,6 +55,9 @@ void {{function_name}}(
     {{index_type}} total_elements = (*batch) * (*in_h) * (*in_w) * (*in_ch);
     {{index_type}} threads_per_block = 256;
     {{index_type}} num_blocks = (total_elements + threads_per_block - 1) / threads_per_block;
+    *out_h = (*in_h) / r;
+    *out_w = (*in_w) / r;
+    *out_ch = (*in_ch) * (r * r);
 
     pixel_unshuffle_kernel<<<num_blocks, threads_per_block, 0, stream>>>(
         static_cast<const {{elem_input_type}}*>(in_ptr),

--- a/src/dinoml/backend/cuda/pool1d/avg_pool1d.py
+++ b/src/dinoml/backend/cuda/pool1d/avg_pool1d.py
@@ -23,6 +23,7 @@ EXEC_TEMPLATE = jinja2.Template(
 SRC_TEMPLATE = jinja2.Template(
     """
 #include <dinoml/device.h>
+#include <ops/avg_pool_1d.h>
 
 void {{function_name}} (
     const void* in_ptr,

--- a/src/dinoml/backend/cuda/pool2d/avg_pool2d.py
+++ b/src/dinoml/backend/cuda/pool2d/avg_pool2d.py
@@ -19,16 +19,13 @@ Codegen functions for avg_pool2d.
 import jinja2
 
 from dinoml.backend import registry
-
 from dinoml.backend.backend_spec import CUDASpec
 from dinoml.backend.cuda.pool2d import pool2d
-
-# pylint: disable=C0103,C0415,W0613,C0301,W0612
 
 
 EXEC_TEMPLATE = jinja2.Template(
     """
-{{indent}}avg_pool_launcher<{{dtype}}, {{kernel_size}}, {{stride}}, {{padding}}>(
+{{indent}}avg_pool_2d_launcher<{{dtype}}, {{vec_type}}, {{kernel_size}}, {{stride}}, {{padding}}>(
 {{indent}}    static_cast<const {{dtype}}*>(in_ptr),
 {{indent}}    static_cast<{{dtype}}*>(out_ptr),
 {{indent}}    NI,
@@ -45,95 +42,8 @@ EXEC_TEMPLATE = jinja2.Template(
 
 SRC_TEMPLATE = jinja2.Template(
     """
-#include <cuda_fp16.h>
-#include <cuda_runtime.h>
-#include "cutlass/util/host_tensor.h"
-
-namespace {
-
-template <int kernel_size, int stride, int padding>
-__global__ void avg_pool_nhwc_kernel(const {{dtype}}* input_raw,
-                                     {{dtype}}* output_raw,
-                                     const int N,
-                                     const int H,
-                                     const int W,
-                                     const int C,
-                                     const int HO,
-                                     const int WO) {
-{% set vec_dtype = {"half": "half2", "float": "float2"}[dtype] %}
-  const {{vec_dtype}}* input = (const {{vec_dtype}}*)input_raw;
-  {{vec_dtype}}* output = ({{vec_dtype}}*)output_raw;
-
-  const int tid = threadIdx.x;
-  const int n_idx = blockIdx.x;
-  const int out_h_idx = blockIdx.y;
-  const int out_w_idx = blockIdx.z;
-
-  int h_start_idx = out_h_idx * stride - padding;
-  int h_end_idx = h_start_idx + kernel_size;
-  h_start_idx = (h_start_idx < 0) ? 0 : h_start_idx;
-  h_end_idx = h_end_idx > H ? H : h_end_idx;
-
-  int w_start_idx = out_w_idx * stride - padding;
-  int w_end_idx = w_start_idx + kernel_size;
-  w_start_idx = (w_start_idx < 0) ? 0 : w_start_idx;
-  w_end_idx = w_end_idx > W ? W : w_end_idx;
-
-  input += n_idx * H * W * C;
-  output += ((n_idx * HO + out_h_idx) * WO + out_w_idx) * C;
-  const float norm_factor =
-      static_cast<float>(1.0f / (kernel_size * kernel_size));
-  for (int c_idx = tid; c_idx < C; c_idx += blockDim.x) {
-    float2 avg = {0.f, 0.f};
-    for (int h = h_start_idx; h < h_end_idx; h++) {
-      #pragma unroll
-      for (int w = w_start_idx; w < w_end_idx; w++) {
-        const int idx = (h * W + w) * C;
-        const {{vec_dtype}} tmp = __ldg(input + (idx + c_idx));
-{% if dtype == "half" %}
-        avg.x += __half2float(tmp.x);
-        avg.y += __half2float(tmp.y);
-{% else %}
-        avg.x += tmp.x;
-        avg.y += tmp.y;
-{% endif %}
-      }
-    }
-
-    avg.x *= norm_factor;
-    avg.y *= norm_factor;
-{% if dtype == "half" %}
-    output[c_idx] = __float22half2_rn(avg);
-{% else %}
-    output[c_idx] = avg;
-{% endif %}
-  }
-}
-
-template <typename ElemT, int kernel_size, int stride, int padding>
-void avg_pool_launcher(const ElemT* input,
-                       ElemT* output,
-                       const int N,
-                       const int H,
-                       const int W,
-                       const int C,
-                       const int HO,
-                       const int WO,
-                       cudaStream_t stream)
-{
-  int num_thread = C / 2;
-  if (num_thread > 256) {
-      num_thread = 256;
-  } else if (num_thread == 0) {
-      num_thread = 1;
-  }
-  dim3 grid(N, HO, WO);
-  dim3 block(num_thread);
-  avg_pool_nhwc_kernel<kernel_size, stride, padding>
-      <<<grid, block, 0, stream>>>(input, output, N, H,
-                                   W, C / 2, HO, WO);
-}
-} // namespace
+#include <dinoml/device.h>
+#include <ops/avg_pool_2d.h>
 
 void {{function_name}} (
     const void* in_ptr,
@@ -145,7 +55,7 @@ void {{function_name}} (
     int64_t* out_batch,
     int64_t* out_h,
     int64_t* out_w,
-    cudaStream_t stream
+    dinoml::DeviceStream stream
 ) {
   {{shape_function}}
   {{exec_paths}}
@@ -166,8 +76,22 @@ def gen_function(
 ):
     func_name = func_attrs["name"]
     exec_path = func_attrs["exec_path"]
+
     backend_spec = CUDASpec()
     dtype = backend_spec.dtype_to_backend_type(func_attrs["inputs"][0]._attrs["dtype"])
+
+    dtype_vec_type = {
+        "float": "float2",
+        "half": "half2",
+        "bfloat16": "bfloat162",
+    }
+    vec_type = dtype_vec_type[dtype]
+    ceil_mode = func_attrs.get("ceil_mode", False)
+    if ceil_mode:
+        # expands to: (X + SH - 1) / SH
+        div = "+ SH - 1) /"
+    else:
+        div = ") /"
     shape_eval_func = shape_eval_template.render(
         indent="  ",
         dtype="int64_t ",
@@ -179,7 +103,7 @@ def gen_function(
         kernel_w=func_attrs["kernel_size"],
         stride=func_attrs["stride"],
         pad=func_attrs["pad"],
-        div="/",
+        div=div,
     )
     shape_save_func = shape_save_template.render(
         indent="  ",
@@ -196,6 +120,7 @@ def gen_function(
             padding=func_attrs["pad"],
             stride=func_attrs["stride"],
             dtype=dtype,
+            vec_type=vec_type,
         )
         exec_inst = exec_cond_template.render(indent="  ", cond=key, program=program)
         exec_paths += exec_inst
@@ -203,7 +128,6 @@ def gen_function(
         function_name=func_name,
         shape_function=shape_func,
         exec_paths=exec_paths,
-        dtype=dtype,
     )
 
 

--- a/src/dinoml/backend/cuda/pool2d/pool2d.py
+++ b/src/dinoml/backend/cuda/pool2d/pool2d.py
@@ -30,7 +30,7 @@ void {{func_name}}(
   int64_t*,
   int64_t*,
   int64_t*,
-  cudaStream_t
+  dinoml::DeviceStream
 );
 """
 )

--- a/src/dinoml/backend/rocm/pool2d/avg_pool2d.py
+++ b/src/dinoml/backend/rocm/pool2d/avg_pool2d.py
@@ -16,31 +16,184 @@
 ROCM avg_pool2d funcs
 """
 
+import jinja2
+
 from dinoml.backend import registry
-from dinoml.backend.rocm.pool2d import pool2d
+from dinoml.backend.backend_spec import ROCMSpec
+
+FUNC_DECL_TEMPLATE = jinja2.Template(
+    """
+void {{func_name}}(
+  const void*,
+  void*,
+  int64_t*,
+  int64_t*,
+  int64_t*,
+  int64_t*,
+  int64_t*,
+  int64_t*,
+  int64_t*,
+  dinoml::DeviceStream
+);
+"""
+)
+
+FUNC_CALL_TEMPLATE = jinja2.Template(
+    """
+{{indent}}{{func_name}}(
+{{indent}}    {{in_ptr}},
+{{indent}}    {{out_ptr}},
+{{indent}}    {{p_batch}},
+{{indent}}    {{p_in_h}},
+{{indent}}    {{p_in_w}},
+{{indent}}    {{p_in_ch}},
+{{indent}}    {{p_out_batch}},
+{{indent}}    {{p_out_h}},
+{{indent}}    {{p_out_w}},
+{{indent}}    stream
+{{indent}});
+"""
+)
+
+
+EXEC_TEMPLATE = jinja2.Template(
+    """
+{{indent}}avg_pool_2d_launcher<{{dtype}}, {{vec_type}}, {{kernel_size}}, {{stride}}, {{padding}}>(
+{{indent}}    static_cast<const {{dtype}}*>(in_ptr),
+{{indent}}    static_cast<{{dtype}}*>(out_ptr),
+{{indent}}    NI,
+{{indent}}    HI,
+{{indent}}    WI,
+{{indent}}    CI,
+{{indent}}    HO,
+{{indent}}    WO,
+{{indent}}    stream
+{{indent}});
+{{indent}}return;
+"""
+)
+
+SRC_TEMPLATE = jinja2.Template(
+    """
+#include <dinoml/device.h>
+#include <ops/avg_pool_2d.h>
+
+void {{function_name}} (
+    const void* in_ptr,
+    void* out_ptr,
+    int64_t* batch,
+    int64_t* in_h,
+    int64_t* in_w,
+    int64_t* in_ch,
+    int64_t* out_batch,
+    int64_t* out_h,
+    int64_t* out_w,
+    dinoml::DeviceStream stream
+) {
+  {{shape_function}}
+  {{exec_paths}}
+  throw std::runtime_error(
+      "Unsupported workload for this avg pool2d specialization."
+  );
+}
+"""
+)
 
 
 @registry.reg("rocm.avg_pool2d.gen_function")
-def max_pool2d_gen_function(
+def gen_function(
     func_attrs,
     exec_cond_template,
     shape_eval_template,
     shape_save_template,
 ):
-    return pool2d.gen_function(
-        func_attrs,
-        exec_cond_template,
-        shape_eval_template,
-        shape_save_template,
+    func_name = func_attrs["name"]
+    exec_path = func_attrs["exec_path"]
+
+    backend_spec = ROCMSpec()
+    dtype = backend_spec.dtype_to_backend_type(func_attrs["inputs"][0]._attrs["dtype"])
+
+    dtype_vec_type = {
+        "float": "float2",
+        "half": "half2",
+        "bfloat16": "bfloat162",
+    }
+    vec_type = dtype_vec_type[dtype]
+    ceil_mode = func_attrs.get("ceil_mode", False)
+    if ceil_mode:
+        # expands to: (X + SH - 1) / SH
+        div = "+ SH - 1) /"
+    else:
+        div = ") /"
+    shape_eval_func = shape_eval_template.render(
+        indent="  ",
+        dtype="int64_t ",
+        x_dim0="*batch",
+        x_dim1="*in_h",
+        x_dim2="*in_w",
+        x_dim3="*in_ch",
+        kernel_h=func_attrs["kernel_size"],
+        kernel_w=func_attrs["kernel_size"],
+        stride=func_attrs["stride"],
+        pad=func_attrs["pad"],
+        div=div,
+    )
+    shape_save_func = shape_save_template.render(
+        indent="  ",
+        y_dim0="*out_batch",
+        y_dim1="*out_h",
+        y_dim2="*out_w",
+    )
+    shape_func = shape_eval_func + shape_save_func
+    exec_paths = ""
+    for key in exec_path:
+        program = EXEC_TEMPLATE.render(
+            indent=" " * 4,
+            kernel_size=func_attrs["kernel_size"],
+            padding=func_attrs["pad"],
+            stride=func_attrs["stride"],
+            dtype=dtype,
+            vec_type=vec_type,
+        )
+        exec_inst = exec_cond_template.render(indent="  ", cond=key, program=program)
+        exec_paths += exec_inst
+    return SRC_TEMPLATE.render(
+        function_name=func_name,
+        shape_function=shape_func,
+        exec_paths=exec_paths,
+    )
+
+
+def gen_function_decl(func_name):
+    return FUNC_DECL_TEMPLATE.render(func_name=func_name)
+
+
+def gen_function_call(func_attrs, indent="  "):
+    x = func_attrs["inputs"][0]
+    xshape = x._attrs["shape"]
+    y = func_attrs["outputs"][0]
+    yshape = y._attrs["shape"]
+    return FUNC_CALL_TEMPLATE.render(
+        func_name=func_attrs["name"],
+        in_ptr=x._attrs["name"],
+        out_ptr=y._attrs["name"],
+        p_batch="&" + xshape[0]._attrs["name"],
+        p_in_ch="&" + xshape[3]._attrs["name"],
+        p_in_h="&" + xshape[1]._attrs["name"],
+        p_in_w="&" + xshape[2]._attrs["name"],
+        p_out_batch="&" + yshape[0]._attrs["name"],
+        p_out_h="&" + yshape[1]._attrs["name"],
+        p_out_w="&" + yshape[2]._attrs["name"],
+        indent=indent,
     )
 
 
 @registry.reg("rocm.avg_pool2d.func_decl")
 def avg_pool2d_gen_function_decl(func_attrs):
     func_name = func_attrs["name"]
-    return pool2d.gen_function_decl(func_name)
+    return gen_function_decl(func_name)
 
 
 @registry.reg("rocm.avg_pool2d.func_call")
 def avg_pool2d_gen_function_call(func_attrs, indent="  "):
-    return pool2d.gen_function_call(func_attrs, indent)
+    return gen_function_call(func_attrs, indent)

--- a/src/dinoml/builder/base.py
+++ b/src/dinoml/builder/base.py
@@ -26,7 +26,7 @@ class Build:
 
     model_forward: str = "forward"
     model_output: Optional[str] = "sample"
-    model_output_names: List[str] = []
+    model_output_names: Union[List[str], str] = []
 
     map_function: Callable = ()
     map_function_skip_keys: Tuple = ()
@@ -133,9 +133,11 @@ class Build:
         if isinstance(output_tensors, Tensor):
             output_tensors = [output_tensors]
         for idx, output_tensor in enumerate(output_tensors):
-            output_tensors[idx] = mark_output(
-                output_tensor, self.model_output_names[idx]
-            )
+            if isinstance(self.model_output_names, list):
+                model_output_name = self.model_output_names[idx]
+            else:
+                model_output_name = self.model_output_names.format(idx=idx)
+            output_tensors[idx] = mark_output(output_tensor, model_output_name)
         self.output_tensors = output_tensors
 
     def create_constants(self):

--- a/src/dinoml/builder/config.py
+++ b/src/dinoml/builder/config.py
@@ -5,6 +5,7 @@ from typing import Optional
 import diffusers.models.autoencoders
 import diffusers.models.transformers
 import diffusers.models.unets
+import diffusers.models
 import transformers.models
 import requests
 
@@ -120,6 +121,10 @@ _CLASS_MAPPING = {
             dinoml.modeling.transformers.t5.configuration_t5.T5Config,
         ),
         "pt": transformers.models.t5.modeling_t5.T5EncoderModel,
+    },
+    "T2IAdapter": {
+        "dinoml": dinoml.modeling.diffusers.adapter.T2IAdapter,
+        "pt": diffusers.models.adapter.T2IAdapter,
     },
 }
 

--- a/src/dinoml/builder/t2i_adapter.py
+++ b/src/dinoml/builder/t2i_adapter.py
@@ -1,0 +1,29 @@
+from dinoml.builder.base import Build, _model_name_with_resolution
+from dinoml.mapping.t2i_adapter import map_t2i_adapter
+
+
+class T2IAdapterBuilder(Build):
+    """
+
+    Example:
+    ```
+        builder = T2IAdapterBuilder(
+            hf_hub="hlky/t2iadapter_canny_sd15v2",
+            label="canny_sd15v2",
+            dtype="float16",
+            device="cuda",
+            build_kwargs={
+                "batch_size": (1, 2),
+                "resolution": (8, 512),
+            }
+        )
+    ```
+
+    """
+
+    model_name = "t2i_adapter.{label}.{resolution}.{device_name}.{sm}"
+    map_function = map_t2i_adapter
+    model_output_names = "down_intrablock_additional_residuals_{idx}"
+    model_output = None
+
+    _model_name = _model_name_with_resolution

--- a/src/dinoml/compiler/ops/pool/avg_pool2d.py
+++ b/src/dinoml/compiler/ops/pool/avg_pool2d.py
@@ -19,7 +19,6 @@ Avg_pool2d op.
 from dinoml.compiler.ops.pool.pool2d import pool2d_base
 
 
-# pylint: disable=C0103
 class avg_pool2d(pool2d_base):
     r"""Applies a 2D average pooling over an input signal composed of several input
     planes.
@@ -49,6 +48,6 @@ class avg_pool2d(pool2d_base):
         Tensor [N, H_out, W_out, C].
     """
 
-    def __init__(self, kernel_size, stride, pad) -> None:
-        super().__init__(stride, pad, kernel_size, "avg")
+    def __init__(self, kernel_size, stride, pad, ceil_mode) -> None:
+        super().__init__(stride, pad, kernel_size, "avg", ceil_mode=ceil_mode)
         self._attrs["op"] = "avg_pool2d"

--- a/src/dinoml/compiler/ops/pool/pool2d.py
+++ b/src/dinoml/compiler/ops/pool/pool2d.py
@@ -46,8 +46,8 @@ SHAPE_FUNC_TEMPLATE = jinja2.Template(
 {{indent}}{{dtype}}PH = {{pad}};
 {{indent}}{{dtype}}PW = {{pad}};
 {{indent}}{{dtype}}NO = NI;
-{{indent}}{{dtype}}HO = (HI + PH + PH - KH) {{div}} SH + 1;
-{{indent}}{{dtype}}WO = (WI + PW + PW - KW) {{div}} SW + 1;
+{{indent}}{{dtype}}HO = ((HI + PH + PH - KH) {{div}} SH + 1;
+{{indent}}{{dtype}}WO = ((WI + PW + PW - KW) {{div}} SW + 1;
 """
 )
 
@@ -71,7 +71,9 @@ EXEC_COND_TEMPLATE = jinja2.Template(
 class pool2d_base(Operator):
     """Base class of pool2d."""
 
-    def __init__(self, stride, pad, kernel_size, reduce_func) -> None:
+    def __init__(
+        self, stride, pad, kernel_size, reduce_func, ceil_mode: bool = False
+    ) -> None:
         """
         Parameters
         ----------
@@ -88,15 +90,22 @@ class pool2d_base(Operator):
         self._attrs["kernel_size"] = kernel_size
         self._attrs["KH"] = kernel_size
         self._attrs["KW"] = kernel_size
+        self._attrs["ceil_mode"] = ceil_mode
         self.shape_eval_template = SHAPE_FUNC_TEMPLATE
         self.shape_save_template = SHAPE_ASSIGNMENT_TEMPLATE
         self.exec_cond_template = EXEC_COND_TEMPLATE
 
     def _infer_shape(self, x: List[int]):
+        ceil_mode = self._attrs.get("ceil_mode", False)
+        if ceil_mode:
+            # expands to: (X + SH - 1) // SH
+            div = "+ SH - 1) //"
+        else:
+            div = ") //"
         eval_func = self.shape_eval_template.render(
             indent="",
             dtype="",
-            div="//",
+            div=div,
             stride=self._attrs["stride"],
             pad=self._attrs["pad"],
             x_dim0=x[0],

--- a/src/dinoml/frontend/nn/pool2d.py
+++ b/src/dinoml/frontend/nn/pool2d.py
@@ -81,9 +81,9 @@ class AvgPool2d(Module):
         padding: implicit zero padding to be added on both sides
     """
 
-    def __init__(self, kernel_size, stride, padding):
+    def __init__(self, kernel_size, stride, padding: int = 0, ceil_mode: bool = False):
         super().__init__()
-        self.op = avg_pool2d(kernel_size, stride, padding)
+        self.op = avg_pool2d(kernel_size, stride, padding, ceil_mode=ceil_mode)
 
     def forward(self, *args):
         r"""Applies AvgPool2d on the input."""

--- a/src/dinoml/mapping/t2i_adapter.py
+++ b/src/dinoml/mapping/t2i_adapter.py
@@ -1,0 +1,45 @@
+from .mapping_functions import _map
+from typing import Callable, Dict, Iterable, Union
+
+import torch
+
+
+def conv2d_permute(key: str, tensor: torch.Tensor, state_dict: Dict[str, torch.Tensor]):
+    if tensor.ndim == 4:
+        print(f"Permuting {key=}")
+        return torch.permute(tensor, [0, 2, 3, 1]).contiguous()
+    else:
+        return tensor
+
+
+def conv2d_pad(
+    key: str,
+    tensor: torch.Tensor,
+    state_dict: Dict[str, torch.Tensor],
+    pad_to_multiple_of: int = 4,
+):
+    if tensor.ndim == 4 and tensor.shape[-1] % 4 != 0:
+        channels = tensor.shape[-1]
+        pad_by = pad_to_multiple_of - (channels - pad_to_multiple_of)
+        pad = (0, pad_by, 0, 0, 0, 0, 0, 0)
+        print(f"Padding {key=} with {pad=}")
+        return torch.nn.functional.pad(tensor, pad=pad)
+    else:
+        return tensor
+
+
+def map_t2i_adapter(
+    self,
+    pt_module: Union[torch.nn.Module, Dict[str, torch.Tensor]],
+    dtype: Union[str, torch.dtype],
+    device: Union[str, torch.device],
+    skip_keys: Iterable[str],
+    mapping_fn: Iterable[Callable] = (conv2d_permute, conv2d_pad),
+):
+    return _map(
+        pt_module=pt_module,
+        dtype=dtype,
+        device=device,
+        skip_keys=skip_keys,
+        mapping_fn=mapping_fn,
+    )

--- a/src/dinoml/modeling/diffusers/__init__.py
+++ b/src/dinoml/modeling/diffusers/__init__.py
@@ -1,3 +1,4 @@
 from .autoencoders import *
 from .transformers import *
 from .unets import *
+from .adapter import *

--- a/src/dinoml/modeling/diffusers/adapter.py
+++ b/src/dinoml/modeling/diffusers/adapter.py
@@ -1,8 +1,9 @@
-from typing import List
+from typing import Annotated, List
 
 from dinoml.compiler import ops
 
 from dinoml.frontend import nn, Tensor
+from dinoml.utils.build_utils import Shape
 
 
 class T2IAdapter(nn.Module):
@@ -61,7 +62,18 @@ class T2IAdapter(nn.Module):
                 "'full_adapter_xl' or 'light_adapter'."
             )
 
-    def forward(self, x: Tensor) -> List[Tensor]:
+    def forward(
+        self,
+        x: Annotated[
+            Tensor,
+            (
+                Shape(name="batch_size"),
+                Shape(name="height"),
+                Shape(name="width"),
+                Shape(name="channels", config_name="in_channels"),
+            ),
+        ],
+    ) -> List[Tensor]:
         r"""
         This function processes the input tensor `x` through the adapter model and returns a list of feature tensors,
         each representing information extracted at a different scale from the input. The length of the list is
@@ -239,7 +251,6 @@ class AdapterBlock(nn.Module):
 
         self.downsample = None
         if down:
-            # ops TODO: AvgPool2d ceil_mode
             self.downsample = nn.AvgPool2d(kernel_size=2, stride=2, ceil_mode=True)
 
         self.in_conv = None
@@ -391,7 +402,6 @@ class LightAdapterBlock(nn.Module):
 
         self.downsample = None
         if down:
-            # ops TODO: AvgPool2d ceil_mode
             self.downsample = nn.AvgPool2d(kernel_size=2, stride=2, ceil_mode=True)
 
         self.in_conv = nn.Conv2d(in_channels, mid_channels, kernel_size=1, dtype=dtype)


### PR DESCRIPTION
- avg_pool_2d kernel converted from codegen to static
- pixel_unshuffle correctly sets out_h/out_w/out_w from C++ launcher
- avg_pool_2d supports `ceil_mode`
- ROCm uses same `avg_pool_2d` kernel, previously used CK (CK kernel usage needs updating for latest CK)
- Introduce `str` `model_output_names` to `Builder`, this supports `list` outputs and formats `idx` into the `model_output_name`, e.g. `"down_intrablock_additional_residuals_{idx}"` -> outputs are named `down_intrablock_additional_residuals_0`, `down_intrablock_additional_residuals_1` etc.
- `T2IAdapter` `forward` `Annotated`
- Introduce `T2IAdapterBuilder`

Note: Conv2d fusions are currently partly disabled so `T2IAdapter` is not fully optimized, this will be changed in the future