### PR TITLE
T2I-Adapter fusions

### DIFF
--- a/csrc/include/ops/avg_pool_2d.h
+++ b/csrc/include/ops/avg_pool_2d.h
@@ -20,7 +20,8 @@ __global__ void avg_pool_2d_kernel(
     const int W,
     const int C,
     const int HO,
-    const int WO) {
+    const int WO,
+    const float norm_factor) {
   const VectorType* input = (const VectorType*)input_raw;
   VectorType* output = (VectorType*)output_raw;
 
@@ -41,9 +42,6 @@ __global__ void avg_pool_2d_kernel(
 
   input += n_idx * H * W * C;
   output += ((n_idx * HO + out_h_idx) * WO + out_w_idx) * C;
-
-  const float norm_factor =
-      static_cast<float>(1.0f / (KernelSize * KernelSize));
 
   for (int c_idx = tid; c_idx < C; c_idx += blockDim.x) {
     float2 avg = {0.f, 0.f};
@@ -91,6 +89,9 @@ void avg_pool_2d_launcher(
   dim3 grid(N, HO, WO);
   dim3 block(num_thread);
 
+  const float norm_factor =
+      static_cast<float>(1.0f / (KernelSize * KernelSize));
+
   dinoml::avg_pool_2d_kernel<ElemType, VectorType, KernelSize, Stride, Padding>
-      <<<grid, block, 0, stream>>>(input, output, N, H, W, C / 2, HO, WO);
+      <<<grid, block, 0, stream>>>(input, output, N, H, W, C / 2, HO, WO, norm_factor);
 }

--- a/scripts/t2i_adapter_build.py
+++ b/scripts/t2i_adapter_build.py
@@ -6,7 +6,7 @@ builder = T2IAdapterBuilder(
     dtype="float16",
     device="cuda",
     build_kwargs={
-        "batch_size": (1, 2),
+        "batch_size": 1,
         "resolution": (8, 512),
     },
     check_outputs=False,

--- a/scripts/t2i_adapter_build.py
+++ b/scripts/t2i_adapter_build.py
@@ -9,5 +9,6 @@ builder = T2IAdapterBuilder(
         "batch_size": (1, 2),
         "resolution": (8, 512),
     },
+    check_outputs=False,
 )
 builder()

--- a/src/dinoml/backend/common/pixel_unshuffle_common.py
+++ b/src/dinoml/backend/common/pixel_unshuffle_common.py
@@ -53,7 +53,7 @@ void {{function_name}}(
     {{prefix}}Stream_t stream
 ) {
     {{index_type}} total_elements = (*batch) * (*in_h) * (*in_w) * (*in_ch);
-    {{index_type}} threads_per_block = 256;
+    {{index_type}} threads_per_block = 512;
     {{index_type}} num_blocks = (total_elements + threads_per_block - 1) / threads_per_block;
     *out_h = (*in_h) / r;
     *out_w = (*in_w) / r;

--- a/src/dinoml/compiler/model.py
+++ b/src/dinoml/compiler/model.py
@@ -622,7 +622,6 @@ class Model:
         of torch.Tensors ordered according to GetInputNameToIndexMap. Outputs
         can also be a dictionary, or a list ordered according to GetOutputNameToIndexMap.
         """
-        torch.cuda.synchronize()
         if stream_ptr is None:
             stream_ptr = torch.cuda.current_stream().cuda_stream
         _check_tensors_contiguous_and_on_gpu(
@@ -640,7 +639,6 @@ class Model:
             sync=sync,
             graph_mode=graph_mode,
         )
-        torch.cuda.synchronize()
         return self._interpret_tensors_as_shapes(outputs, outputs_dinoml)
 
     def _run_with_outputs_on_host(
@@ -764,7 +762,6 @@ class Model:
             outputs,
             name="outputs",
         )
-        torch.cuda.synchronize()
         if stream_ptr is None:
             stream_ptr = torch.cuda.current_stream().cuda_stream
 

--- a/src/dinoml/modeling/diffusers/adapter.py
+++ b/src/dinoml/modeling/diffusers/adapter.py
@@ -1,7 +1,5 @@
 from typing import Annotated, List
 
-from dinoml.compiler import ops
-
 from dinoml.frontend import nn, Tensor
 from dinoml.utils.build_utils import Shape
 
@@ -295,10 +293,9 @@ class AdapterResnetBlock(nn.Module):
     def __init__(self, channels: int, dtype: str = "float16"):
         super().__init__()
         self.block1 = nn.Conv2d(
-            channels, channels, kernel_size=3, padding=1, dtype=dtype
+            channels, channels, kernel_size=3, padding=1, dtype=dtype, activation="relu",
         )
-        self.act = ops.relu
-        self.block2 = nn.Conv2d(channels, channels, kernel_size=1, dtype=dtype)
+        self.block2 = nn.Conv2d(channels, channels, kernel_size=1, dtype=dtype, add=True)
 
     def forward(self, x: Tensor) -> Tensor:
         r"""
@@ -306,10 +303,10 @@ class AdapterResnetBlock(nn.Module):
         layer on the input tensor. It returns addition with the input tensor.
         """
 
-        h = self.act(self.block1(x))
-        h = self.block2(h)
+        h = self.block1(x)
+        h = self.block2(h, x)
 
-        return h + x
+        return h
 
 
 # light adapter
@@ -443,11 +440,10 @@ class LightAdapterResnetBlock(nn.Module):
     def __init__(self, channels: int, dtype: str = "float16"):
         super().__init__()
         self.block1 = nn.Conv2d(
-            channels, channels, kernel_size=3, padding=1, dtype=dtype
+            channels, channels, kernel_size=3, padding=1, dtype=dtype, activation="relu",
         )
-        self.act = ops.relu
         self.block2 = nn.Conv2d(
-            channels, channels, kernel_size=3, padding=1, dtype=dtype
+            channels, channels, kernel_size=3, padding=1, dtype=dtype, add=True,
         )
 
     def forward(self, x: Tensor) -> Tensor:
@@ -456,7 +452,7 @@ class LightAdapterResnetBlock(nn.Module):
         another convolutional layer and adds it to input tensor.
         """
 
-        h = self.act(self.block1(x))
-        h = self.block2(h)
+        h = self.block1(x)
+        h = self.block2(h, x)
 
-        return h + x
+        return h


### PR DESCRIPTION
- Manually enable conv2d fusions for T2I-Adapter
- Adjust avg_pool_2d kernel
- Tune pixel_unshuffle

On 3090 with `hlky/t2iadapter_canny_sd15v2`:

pt mean: `1.985` ms

DinoML mean: `0.780` ms (down from `0.811` ms on `main`)

